### PR TITLE
Release 0.1.1：Windows daemon stop 优雅退出

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ yoooclaw 独立 CLI 工具 —— 自带后台守护进程（daemon），不依�
 
 ## 安装与命令
 
-两种分发渠道，二者**功能一致**，按需选择：
+两种分发渠道，二者**功能一致**，按需选择。
 
-### A. npm（需要 Node ≥ 22.12.0）
+**平台支持**：macOS / Linux 两种渠道都支持；**Windows 走 npm 渠道**（需 Node ≥ 22.12.0），原生二进制暂未提供 Windows 目标。Windows 上凭据以明文落 `~/.yoooclaw/credentials.json`（无系统 keychain 加固，`yoooclaw doctor` 会提示），daemon 停止经 HTTP 优雅退出。
+
+### A. npm（需要 Node ≥ 22.12.0，Windows 用此渠道）
 
 ```bash
 # 免安装（每次拉最新版）
@@ -37,7 +39,7 @@ curl -fsSL https://raw.githubusercontent.com/Yoooclaw/openclaw-plugin/master/pac
   | sh -s -- --version 0.0.5 --dir ~/bin --force
 ```
 
-支持平台：`darwin-arm64` / `darwin-x64` / `linux-x64` / `linux-arm64`。Windows 暂走 npm。
+支持平台：`darwin-arm64` / `darwin-x64` / `linux-x64` / `linux-arm64`。**Windows 暂无原生二进制，请用上面的 npm 渠道。**
 
 二进制也可以从 [GitHub Releases](https://github.com/Yoooclaw/openclaw-plugin/releases?q=cli-v) 手动下载（同 release 内 `checksums.txt` 校验）。
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "yoooclaw 独立 CLI：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "bin": {

--- a/src/commands/daemon.ts
+++ b/src/commands/daemon.ts
@@ -94,17 +94,33 @@ export async function daemonStop(ctx: CliContext): Promise<unknown> {
     removeLock(ctx.paths);
     throw new YoooclawError("YOOOCLAW_DAEMON_NOT_RUNNING", "daemon 未运行");
   }
-  try {
-    process.kill(lock.pid, "SIGTERM");
-  } catch {
-    /* 进程可能刚退出 */
+
+  // Windows 上 Node 没有真正的 POSIX 信号：process.kill(pid, "SIGTERM") 等价于
+  // TerminateProcess，daemon 的 shutdown() 优雅退出钩子（隧道断开、移除 lock）不会跑。
+  // 因此 Windows 优先打 HTTP /daemon/stop 让 daemon 自己走优雅退出，失败再回退到硬杀。
+  const graceful = process.platform === "win32"
+    ? "stop-endpoint"
+    : "SIGTERM";
+  if (graceful === "stop-endpoint") {
+    try {
+      await new DaemonClient(ctx.paths).post("/daemon/stop");
+    } catch {
+      /* daemon 可能拒绝鉴权或刚退出；继续轮询 + 回退硬杀 */
+    }
+  } else {
+    try {
+      process.kill(lock.pid, "SIGTERM");
+    } catch {
+      /* 进程可能刚退出 */
+    }
   }
+
   // 等待优雅退出，最多 10s
   for (let i = 0; i < 100; i += 1) {
     await sleep(100);
     if (!isProcessAlive(lock.pid)) {
       removeLock(ctx.paths);
-      return { ok: true, stopped: lock.pid, signal: "SIGTERM" };
+      return { ok: true, stopped: lock.pid, signal: graceful };
     }
   }
   try {


### PR DESCRIPTION
## 0.1.1

阶段一 Windows 支持（npm 渠道）。

### 改动
- **feat(daemon)**：Windows 上 `daemon stop` 改打 HTTP `POST /daemon/stop` 触发优雅关闭（停 relay → 关存储 → 移 lock），超时 10s 回退硬杀。原因：Windows 上 Node 无真 POSIX 信号，`process.kill(pid,"SIGTERM")` 会直接 TerminateProcess、跳过 `shutdown()`。macOS/Linux 维持 SIGTERM 不变。
- **docs(README)**：补平台支持说明 —— Windows 走 npm 渠道，凭据落明文（无 keychain 加固），stop 经 HTTP。
- 版本 bump 0.1.0 → 0.1.1。

### 验证
- `typecheck` ✅、`bun run test` 111 passed ✅
- 已发布：npm `@yoooclaw/cli@0.1.1`（latest）+ GitHub Release `cli-v0.1.1`（含四平台原生二进制）

> 注：本次未做真机 Windows 验证（开发环境为 macOS）。后续可补 Windows CI job 跑 daemon e2e 闭环。

🤖 Generated with [Claude Code](https://claude.com/claude-code)