### PR TITLE
Release 0.1.2：CLI help 与运行时行为对齐

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "description": "yoooclaw 独立 CLI：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "bin": {

--- a/skills/yoooclaw-lightrule-create/SKILL.md
+++ b/skills/yoooclaw-lightrule-create/SKILL.md
@@ -57,6 +57,7 @@ yoooclaw lightrule delete <name> --yes         # 删除
 ## 错误处理
 
 - `YOOOCLAW_DAEMON_NOT_RUNNING`：先 `yoooclaw daemon start` 再重试。
-- 创建失败常见为 `VALIDATION_FAILED`（segments 不合法）或 `INVALID_PARAMS`（缺 name/description）：
-  读 `error.message`（含具体校验项）后修正 JSON 重新提交。
+- 创建失败通常表现为 `YOOOCLAW_INVALID_ARGUMENT`，`error.message` 中会带底层
+  `VALIDATION_FAILED`（segments 不合法）或 `INVALID_PARAMS`（缺 name/description）；
+  按具体校验项修正 JSON 后重新提交。
 - 规则名重复：换 `name` 或先 `delete`。

--- a/skills/yoooclaw-tunnel-debug/SKILL.md
+++ b/skills/yoooclaw-tunnel-debug/SKILL.md
@@ -1,52 +1,63 @@
 ---
 name: yoooclaw-tunnel-debug
-description: 用 yoooclaw CLI 排查手机端推送链路是否通。当用户说"手机推送收不到""通知没同步过来""检查一下隧道/连接""daemon 还活着吗""手机连不上"时激活。组合使用 daemon status / tunnel status / tunnel +test / gateway test 自检整条接收链路。多数命令需要 daemon 在运行（🟡）。
+description: 用 yoooclaw CLI 排查手机端推送链路是否通。当用户说“手机推送收不到”“通知没同步过来”“检查一下隧道/连接”“daemon 还活着吗”“手机连不上”时激活。组合使用 auth status / daemon status / tunnel status / tunnel +test / gateway test / daemon logs 定位本地配置、daemon、本地 ingest 鉴权与 Relay WebSocket 状态。多数命令需要 daemon 在运行（🟡）。
 ---
 
-# yoooclaw 隧道 / 接收链路排查
+# yoooclaw Relay / 接收链路排查
 
-独立 daemon 当前以**直连 HTTP** 接收手机推送（`POST /notifications`），
-配合用户自建 `cloudflared` / `tailscale serve` 反代到 daemon 的本地地址即可让手机端推达。
-
-## 何时激活
-
-- "手机推送收不到 / 通知没同步过来"
-- "检查隧道 / 连接 / daemon 状态"
-- "手机连不上 / 一直没新消息"
+独立 daemon 默认用 account api-key 连接托管 Relay WebSocket，手机 App 绑定同一账号后经 Relay 收发。也可以在 Relay 未启用或不可用时，将 `POST /notifications` 通过用户自建 `cloudflared` / `tailscale serve` 暴露为直连 HTTP fallback。
 
 ## 排查顺序
 
 ```bash
-# 1) daemon 是否在跑、监听哪个地址端口
+# 1) 本地凭据是否存在；不调 daemon
+yoooclaw auth status --format json
+
+# 2) daemon 是否在跑、监听哪个地址端口
 yoooclaw daemon status --format json
-#   未运行 → {"ok":false,"error":{"code":"YOOOCLAW_DAEMON_NOT_RUNNING",...}} → yoooclaw daemon start
+# 未运行 → yoooclaw daemon start --format json
 
-# 2) 隧道状态（relay 模式 / 是否连接 / relay URL）
+# 3) Relay 模式、连接状态、URL、多隧道状态
 yoooclaw tunnel status --format json
-#   → {"ok":true,"mode":"standalone-http","connected":false,"relayUrl":"...","note":"..."}
 
-# 3) 端到端回环自检：daemon 通过本地 HTTP 给自己发一条 echo 通知，验证 ingest+鉴权链路
+# 4) daemon 本地回环：验证本地 ingest + 鉴权
 yoooclaw tunnel +test --format json
-#   → {"ok":true,"loopback":{"ok":true,"status":200}}  表示本机接收链路 OK
 
-# 4) 模拟手机端调 /notifications，验证鉴权与连通
+# 5) 模拟手机端直接调本地 /notifications
 yoooclaw gateway test --format json
-#   → {"ok":true,"status":200,"response":{"ok":true,"ingested":1,...}}
-#   要强制走 relay 旁路：yoooclaw gateway test --via-relay
+
+# 6) 看 Relay 连接与重连日志
+yoooclaw daemon logs --lines 200 --format json
+yoooclaw log +errors --format json
 ```
+
+`tunnel +test` 会让 daemon 给本地 `/notifications` 发一条 echo 通知。它可以确认本地 ingest + 鉴权链路，但不会让流量真正绕行远端 Relay。`gateway test --via-relay` 当前也是复用这条本地回环路径，不应单独作为远端 Relay 可达性的证据。
 
 ## 判读
 
-- `daemon status` 报 `YOOOCLAW_DAEMON_NOT_RUNNING` → daemon 没起，先 `yoooclaw daemon start`。
-- `tunnel +test` 的 `loopback.ok=true` 且 `gateway test` `ok=true`：**本机接收链路正常**。
-  手机仍收不到 → 问题在网络可达性：检查防火墙、反代（cloudflared/tailscale）、手机端填的地址是否指向 daemon 的对外地址。
-- `gateway test` 返回 `401 / YOOOCLAW_UNAUTHORIZED`：token 不一致。
-  用 `yoooclaw auth status` 看 token 来源，必要时 `yoooclaw auth token-rotate` 后重启 daemon、并更新手机端 token。
-- 想看 daemon 自身日志定位 ingest 失败：`yoooclaw daemon logs --lines 200`（或 `yoooclaw log +errors`）。
+- `auth status` 中 api-key 不存在：先用 `yoooclaw auth set-api-key -` 从 stdin 设置，再启动或 reload daemon。
+- `daemon status` 报 `YOOOCLAW_DAEMON_NOT_RUNNING`：运行 `yoooclaw daemon start`。
+- `tunnel status` 的 `mode=relay` 且 `connected=true`：daemon 当前已连上 Relay WebSocket。
+- `tunnel status` 的 `mode=relay` 但 `connected=false`：结合 `lastDisconnectReason`、`reconnectAttempt` 和 daemon 日志排查 api-key、网络与 Relay 服务。
+- `tunnel status` 的 `mode=standalone-http`：当前没有 Relay 隧道；按返回的 `note` 检查 `relay.enabled` 和 api-key。只有明确采用直连 fallback 时才检查防火墙、反代和手机端地址。
+- `tunnel +test` 或 `gateway test` 失败：先排查本地 gateway token。运行 `yoooclaw auth status`，必要时 `yoooclaw auth token-rotate`；daemon 已运行时随后执行 `yoooclaw daemon restart`。
 
-## 鉴权前置检查（不调 daemon）
+## 多 clientLabel
+
+多 api-key 模式下，每个 label 对应一条 Relay 隧道。按 label 缩小排查范围：
 
 ```bash
-yoooclaw auth status --format json   # api-key / gateway token 是否存在、来源、daemon 是否可达
-yoooclaw auth check --format json    # 端到端：用本地 token 调 daemon /daemon/status 验证一致性
+yoooclaw auth list-api-keys --format json
+yoooclaw tunnel status --client work --format json
+yoooclaw tunnel +test --client work --format json
+yoooclaw tunnel reconnect --client work --format json
 ```
+
+## 鉴权检查
+
+```bash
+yoooclaw auth status --format json
+yoooclaw auth check --format json
+```
+
+`auth status` 只读本地凭据与 daemon lock。`auth check` 会用本地 gateway token 调 daemon `/daemon/status`，用于确认 CLI 和 daemon 的 token 是否一致。

--- a/src/command-tree.ts
+++ b/src/command-tree.ts
@@ -113,7 +113,7 @@ export const COMMAND_TREE: ServiceSpec[] = [
       { name: "set-default-api-key <label>", summary: "切换 default api-key 🟢" },
       {
         name: "token-rotate",
-        summary: "生成新 gateway token 并热重载 🟡",
+        summary: "生成新 gateway token；daemon 在跑时随后 restart 生效 🟢",
         options: [{ flags: "--length <n>", summary: "token 字节长度", default: "32" }],
       },
       { name: "status", summary: "显示鉴权状态（本地检查，不调 daemon）🟢" },
@@ -216,7 +216,7 @@ export const COMMAND_TREE: ServiceSpec[] = [
   },
   {
     name: "recording",
-    summary: "录音管理 🟢/🟡",
+    summary: "录音查询与 ASR 配置 🟢",
     subcommands: [
       {
         name: "list",
@@ -307,7 +307,7 @@ export const COMMAND_TREE: ServiceSpec[] = [
         name: "create",
         summary: "创建规则（--from-file / --intent ...）",
         options: [
-          { flags: "--from-file <path>", summary: "从 JSON/YAML 读规则（- 为 stdin）" },
+          { flags: "--from-file <path>", summary: "从 JSON 读规则（- 为 stdin）" },
           { flags: "--name <text>", summary: "规则名" },
           { flags: "--intent <text>", summary: "自然语言意图描述" },
           { flags: "--light-action <json>", summary: "命中后的 light 动作 JSON" },
@@ -318,7 +318,7 @@ export const COMMAND_TREE: ServiceSpec[] = [
         name: "update <id>",
         summary: "更新现有规则",
         options: [
-          { flags: "--from-file <path>", summary: "从 JSON/YAML 读规则（- 为 stdin）" },
+          { flags: "--from-file <path>", summary: "从 JSON 读规则（- 为 stdin）" },
           { flags: "--name <text>", summary: "规则名" },
           { flags: "--intent <text>", summary: "自然语言意图描述" },
           { flags: "--light-action <json>", summary: "命中后的 light 动作 JSON" },
@@ -380,7 +380,7 @@ export const COMMAND_TREE: ServiceSpec[] = [
     shortcuts: [
       {
         name: "+test",
-        summary: "端到端联通性自检（echo 回环）",
+        summary: "daemon 本地 ingest + 鉴权自检（echo 回环）",
         options: [{ flags: "--client <label>", summary: "用指定 clientLabel 的 api-key 做回环写入" }],
       },
     ],
@@ -403,10 +403,10 @@ export const COMMAND_TREE: ServiceSpec[] = [
     subcommands: [
       {
         name: "test",
-        summary: "模拟手机端调 daemon /notifications，验证连通/鉴权/relay 🟡",
+        summary: "模拟手机端调 daemon /notifications，验证本地连通与鉴权 🟡",
         options: [
           { flags: "--from-phone-ip <ip>", summary: "模拟来源 IP" },
-          { flags: "--via-relay", summary: "强制走 Relay 隧道" },
+          { flags: "--via-relay", summary: "复用 tunnel +test 本地回环路径" },
         ],
       },
     ],
@@ -468,7 +468,7 @@ export const COMMAND_TREE: ServiceSpec[] = [
   },
   {
     name: "doctor",
-    summary: "环境自检：Node/目录/keychain/daemon/relay 🟢/🟡",
+    summary: "本地环境自检：Node/目录/keychain/config/daemon 🟢",
     options: [
       { flags: "--json", summary: "JSON 输出（给脚本用）" },
       { flags: "--fix", summary: "自动修复可修复的问题" },

--- a/src/program.ts
+++ b/src/program.ts
@@ -36,9 +36,10 @@ function wrapAction(handler: CommandHandler) {
     try {
       ctx = buildContext(globals);
       const result = await handler(ctx, positionals, opts);
-      renderResult(result, { format: ctx.format });
+      // doctor / update self 保留局部 --json 作为全局 --format json 的兼容别名。
+      renderResult(result, { format: opts.json === true ? "json" : ctx.format });
     } catch (err) {
-      const format = ctx?.format ?? "json";
+      const format = opts.json === true ? "json" : ctx?.format ?? "json";
       renderError(err, { format });
       process.exitCode = err instanceof YoooclawError ? err.exitCode : 1;
     }

--- a/test/cli.config.test.ts
+++ b/test/cli.config.test.ts
@@ -184,6 +184,12 @@ describe("doctor", () => {
     const token = res.json.checks.find((c: any) => c.name === "gateway-token");
     expect(token.status).toBe("ok");
   });
+
+  it("--json 作为 --format json 的兼容别名", async () => {
+    const res = await runCli(["doctor", "--format", "pretty", "--json"], { home });
+    expect(res.json.ok).toBe(true);
+    expect(res.stdout.trim().split("\n")).toHaveLength(1);
+  });
 });
 
 describe("migrate from-openclaw", () => {


### PR DESCRIPTION
## 0.1.2

### 改动
- **align cli help with runtime behavior**（`fbc4668`）：command-tree / program 的 help 文案与实际运行时行为对齐；同步更新 `yoooclaw-lightrule-create`、`yoooclaw-tunnel-debug` 两个 Skill 的 SKILL.md，补 `cli.config` 测试。
- 版本 bump 0.1.1 → 0.1.2。

### 验证
- `typecheck` ✅、`bun run test` 112 passed ✅
- 已发布：npm `@yoooclaw/cli@0.1.2`（latest）+ GitHub Release `cli-v0.1.2`（含四平台原生二进制）

🤖 Generated with [Claude Code](https://claude.com/claude-code)