### PR TITLE
release/0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "description": "yoooclaw 独立 CLI：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "bin": {

--- a/src/command-tree.ts
+++ b/src/command-tree.ts
@@ -60,11 +60,12 @@ export const COMMAND_TREE: ServiceSpec[] = [
     subcommands: [
       {
         name: "init",
-        summary: "交互式首次向导，生成 config + gateway token",
+        summary: "交互式首次向导，生成 config + gateway token 并启动 daemon",
         options: [
           { flags: "--non-interactive", summary: "跳过向导（配合 --from-file）" },
           { flags: "--from-file <path>", summary: "从 JSON 文件导入配置（- 为 stdin）" },
           { flags: "--force", summary: "已存在 config 时覆盖" },
+          { flags: "--no-start", summary: "只生成配置，不自动启动 daemon" },
         ],
       },
       {

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -18,15 +18,22 @@ import {
 } from "../config/store.js";
 import { defaultConfig, defaultEvaluator, type YoooclawConfig } from "../config/schema.js";
 import { writeGatewayToken, generateToken, resolveApiKey, setApiKey } from "../credentials/store.js";
+import { daemonStart } from "./daemon.js";
 
 interface InitOpts {
   nonInteractive?: boolean;
   fromFile?: string;
   force?: boolean;
+  start?: boolean; // commander：--no-start → false，跳过自动拉起 daemon
 }
 
 /** 手机端配置摘要 + 关键路径，作为 init 的返回结果。 */
-function phoneSummary(ctx: CliContext, config: YoooclawConfig, token: string) {
+function phoneSummary(
+  ctx: CliContext,
+  config: YoooclawConfig,
+  token: string,
+  daemon: DaemonStartSummary,
+) {
   const apiKey = resolveApiKey();
   return {
     ok: true,
@@ -36,6 +43,8 @@ function phoneSummary(ctx: CliContext, config: YoooclawConfig, token: string) {
       bind: config.daemon.bind,
       port: config.daemon.port,
       localUrl: `http://${config.daemon.bind}:${config.daemon.port}`,
+      started: daemon.started,
+      pid: daemon.pid,
     },
     relay: {
       url: config.relay.url,
@@ -44,10 +53,21 @@ function phoneSummary(ctx: CliContext, config: YoooclawConfig, token: string) {
     },
     gatewayToken: token,
     configPath: ctx.paths.config,
-    hint: apiKey.value
-      ? "已就绪：yc daemon start 后，daemon 会用 api-key 连上 Relay；手机 App 绑定同一账号即可收发"
-      : "Relay 尚未设置 api-key：运行 yc auth set-api-key <ock_…> 后再 yc daemon start",
+    hint: initHint(daemon, Boolean(apiKey.value)),
   };
+}
+
+/** 按 daemon 是否拉起、是否已有 api-key 给出下一步提示。 */
+function initHint(daemon: DaemonStartSummary, apiKeyPresent: boolean): string {
+  if (!daemon.started) {
+    const reason = daemon.error ? `（自动启动失败：${daemon.error}）` : "";
+    return apiKeyPresent
+      ? `配置已就绪${reason}：运行 yc daemon start 启动 daemon，连上 Relay 后手机 App 绑定同一账号即可收发`
+      : `配置已就绪${reason}：运行 yc auth set-api-key <ock_…> 设置 Relay api-key，再 yc daemon start 启动 daemon`;
+  }
+  return apiKeyPresent
+    ? "已就绪：daemon 已启动并用 api-key 连上 Relay；手机 App 绑定同一账号即可收发"
+    : "daemon 已启动，但 Relay 尚未设置 api-key：运行 yc auth set-api-key <ock_…> 后 yc daemon restart 即可连上 Relay";
 }
 
 export async function configInit(
@@ -105,7 +125,34 @@ export async function configInit(
   saveConfig(ctx.paths, config);
   writeGatewayToken(config, token);
 
-  return phoneSummary(ctx, config, token);
+  // init 即用：直接把 daemon 拉起来，省去用户再单独跑一次 yc daemon start。
+  // --no-start 可跳过（例如只想生成配置、稍后手动启动）。
+  let daemon: DaemonStartSummary = { started: false };
+  if (opts.start !== false) {
+    daemon = await startDaemonForInit(ctx);
+  }
+
+  return phoneSummary(ctx, config, token, daemon);
+}
+
+interface DaemonStartSummary {
+  started: boolean;
+  pid?: number;
+  alreadyRunning?: boolean;
+  error?: string;
+}
+
+/** init 收尾时拉起 daemon；失败不阻断 init（配置已落盘），把结果带回摘要由用户决定下一步。 */
+async function startDaemonForInit(ctx: CliContext): Promise<DaemonStartSummary> {
+  try {
+    const res = (await daemonStart(ctx, [], {})) as { pid?: number };
+    return { started: true, pid: res.pid };
+  } catch (err) {
+    if (err instanceof YoooclawError && err.code === "YOOOCLAW_DAEMON_ALREADY_RUNNING") {
+      return { started: true, alreadyRunning: true, pid: err.details?.pid as number | undefined };
+    }
+    return { started: false, error: err instanceof Error ? err.message : String(err) };
+  }
 }
 
 interface ShowOpts {

--- a/test/cli.auth.test.ts
+++ b/test/cli.auth.test.ts
@@ -114,7 +114,7 @@ describe("auth gateway token", () => {
   });
 
   it("token-rotate 生成新 token 并写入 credentials", async () => {
-    await runCli(["config", "init", "--from-file", importFile()], { home });
+    await runCli(["config", "init", "--from-file", importFile(), "--no-start"], { home });
     const res = await runCli(["auth", "token-rotate"], { home });
     expect(res.json.ok).toBe(true);
     expect(typeof res.json.token).toBe("string");
@@ -123,7 +123,7 @@ describe("auth gateway token", () => {
   });
 
   it("token-rotate --length 太短报 INVALID_ARGUMENT", async () => {
-    await runCli(["config", "init", "--from-file", importFile()], { home });
+    await runCli(["config", "init", "--from-file", importFile(), "--no-start"], { home });
     const res = await runCli(["auth", "token-rotate", "--length", "8"], { home });
     expect(res.exitCode).toBe(1);
     expect(res.json.error.code).toBe("YOOOCLAW_INVALID_ARGUMENT");

--- a/test/cli.config.test.ts
+++ b/test/cli.config.test.ts
@@ -24,7 +24,7 @@ function importFile(partial: unknown = {}): string {
 
 describe("config", () => {
   it("init 生成 config + gateway token", async () => {
-    const res = await runCli(["config", "init", "--from-file", importFile()], { home });
+    const res = await runCli(["config", "init", "--from-file", importFile(), "--no-start"], { home });
     expect(res.exitCode).toBe(0);
     expect(res.json.ok).toBe(true);
     expect(res.json.profile).toBe("default");
@@ -35,14 +35,14 @@ describe("config", () => {
   });
 
   it("已初始化再 init 报 ALREADY_EXISTS，--force 可覆盖", async () => {
-    await runCli(["config", "init", "--from-file", importFile()], { home });
-    const blocked = await runCli(["config", "init", "--from-file", importFile()], { home });
+    await runCli(["config", "init", "--from-file", importFile(), "--no-start"], { home });
+    const blocked = await runCli(["config", "init", "--from-file", importFile(), "--no-start"], { home });
     expect(blocked.exitCode).toBe(1);
     expect(blocked.json.ok).toBe(false);
     expect(blocked.json.error.code).toBe("YOOOCLAW_ALREADY_EXISTS");
 
     const forced = await runCli(
-      ["config", "init", "--from-file", importFile(), "--force"],
+      ["config", "init", "--from-file", importFile(), "--force", "--no-start"],
       { home },
     );
     expect(forced.exitCode).toBe(0);
@@ -62,7 +62,7 @@ describe("config", () => {
   });
 
   it("show 返回结构化 config（默认不含明文 secret 值）", async () => {
-    await runCli(["config", "init", "--from-file", importFile()], { home });
+    await runCli(["config", "init", "--from-file", importFile(), "--no-start"], { home });
     const res = await runCli(["config", "show"], { home });
     expect(res.exitCode).toBe(0);
     expect(res.json.version).toBe(1);
@@ -72,7 +72,7 @@ describe("config", () => {
   });
 
   it("set/unset 按点号路径生效并落盘", async () => {
-    await runCli(["config", "init", "--from-file", importFile()], { home });
+    await runCli(["config", "init", "--from-file", importFile(), "--no-start"], { home });
     const set = await runCli(["config", "set", "daemon.port", "28123"], { home });
     expect(set.json).toMatchObject({ ok: true, key: "daemon.port", value: 28123 });
 
@@ -84,7 +84,7 @@ describe("config", () => {
   });
 
   it("set 非法数字 / version 字段报 INVALID_ARGUMENT", async () => {
-    await runCli(["config", "init", "--from-file", importFile()], { home });
+    await runCli(["config", "init", "--from-file", importFile(), "--no-start"], { home });
     const bad = await runCli(["config", "set", "daemon.port", "abc"], { home });
     expect(bad.exitCode).toBe(1);
     expect(bad.json.error.code).toBe("YOOOCLAW_INVALID_ARGUMENT");
@@ -105,7 +105,7 @@ describe("profile", () => {
 
   it("（用 config init --profile 建出 work）→ use → list 反映切换", async () => {
     const created = await runCli(
-      ["config", "init", "--profile", "work", "--from-file", importFile()],
+      ["config", "init", "--profile", "work", "--from-file", importFile(), "--no-start"],
       { home },
     );
     expect(created.exitCode).toBe(0);
@@ -139,7 +139,7 @@ describe("profile", () => {
   });
 
   it("delete --yes 删除非 active profile", async () => {
-    await runCli(["config", "init", "--profile", "tmp", "--from-file", importFile()], { home });
+    await runCli(["config", "init", "--profile", "tmp", "--from-file", importFile(), "--no-start"], { home });
     const del = await runCli(["profile", "delete", "tmp", "--yes"], { home });
     expect(del.json).toMatchObject({ ok: true, deleted: "tmp" });
     expect(existsSync(profileDir(home, "tmp"))).toBe(false);
@@ -160,7 +160,7 @@ describe("全局 flags", () => {
   });
 
   it("--profile 路由到对应 profile，互不影响", async () => {
-    await runCli(["config", "init", "--profile", "work", "--from-file", importFile()], { home });
+    await runCli(["config", "init", "--profile", "work", "--from-file", importFile(), "--no-start"], { home });
     expect(existsSync(join(profileDir(home, "work"), "config.json"))).toBe(true);
     // default 仍未初始化
     const def = await runCli(["config", "show"], { home });
@@ -179,7 +179,7 @@ describe("doctor", () => {
   });
 
   it("init 后 gateway-token 检查转 ok", async () => {
-    await runCli(["config", "init", "--from-file", importFile()], { home });
+    await runCli(["config", "init", "--from-file", importFile(), "--no-start"], { home });
     const res = await runCli(["doctor"], { home });
     const token = res.json.checks.find((c: any) => c.name === "gateway-token");
     expect(token.status).toBe("ok");

--- a/test/cli.lifecycle.e2e.test.ts
+++ b/test/cli.lifecycle.e2e.test.ts
@@ -104,4 +104,48 @@ describe("daemon 生命周期", () => {
     expect(start.json.ok).toBe(true);
     expect(start.json.pid).not.toBe(999999);
   });
+
+  it("config init 默认自动拉起 daemon", async () => {
+    // 用一个未初始化的新 profile，避免命中 beforeEach 写好的 default config。
+    const port = await freePort();
+    const importPath = join(home, "init-import.json");
+    writeFileSync(
+      importPath,
+      JSON.stringify({
+        daemon: { bind: "127.0.0.1", port },
+        relay: { enabled: false },
+      }),
+      "utf-8",
+    );
+
+    const init = runCliSubprocess(
+      ["config", "init", "--profile", "fresh", "--from-file", importPath],
+      { home },
+    );
+    try {
+      expect(init.exitCode).toBe(0);
+      expect(init.json.daemon).toMatchObject({ started: true });
+      expect(typeof init.json.daemon.pid).toBe("number");
+      expect(existsSync(join(profileDir(home, "fresh"), "daemon.lock"))).toBe(true);
+
+      const status = runCliSubprocess(["daemon", "status", "--profile", "fresh"], { home });
+      expect(status.json).toMatchObject({ ok: true, server: "yoooclaw" });
+      expect(status.json.pid).toBe(init.json.daemon.pid);
+    } finally {
+      runCliSubprocess(["daemon", "stop", "--profile", "fresh"], { home });
+    }
+  });
+
+  it("config init --no-start 只生成配置不启动 daemon", () => {
+    const importPath = join(home, "init-import-nostart.json");
+    writeFileSync(importPath, JSON.stringify({ relay: { enabled: false } }), "utf-8");
+
+    const init = runCliSubprocess(
+      ["config", "init", "--profile", "fresh", "--from-file", importPath, "--no-start"],
+      { home },
+    );
+    expect(init.exitCode).toBe(0);
+    expect(init.json.daemon.started).toBe(false);
+    expect(existsSync(join(profileDir(home, "fresh"), "daemon.lock"))).toBe(false);
+  });
 });


### PR DESCRIPTION
## 0.1.3

- `config init` 收尾自动拉起 daemon，开箱即用（新增 `--no-start` 跳过）
- 返回摘要带 `daemon.started`/`pid`，提示语按 daemon 是否已起 + 是否有 api-key 调整

🤖 Generated with [Claude Code](https://claude.com/claude-code)