### PR TITLE
Release 0.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "description": "yoooclaw 独立 CLI：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "bin": {

--- a/skills/yoooclaw-notification-query/SKILL.md
+++ b/skills/yoooclaw-notification-query/SKILL.md
@@ -41,12 +41,13 @@ yoooclaw notification search \
 # 聚合摘要（topApps / topSenders / 最近样例），适合"帮我总结"
 yoooclaw notification summary --top 10 --sample 30 --format json
 
-# 维度统计（date|app|sender|hour|all）
+# 维度统计（date|app|sender|hour|client|all）
 yoooclaw notification stats --from 2026-05-14 --to 2026-05-21 --dim all --format json
+yoooclaw notification stats --from 2026-05-21T00:00:00+08:00 --to 2026-05-21T23:59:59+08:00 --sender 张三 --dim sender --format json
 ```
 
 - `--app` 支持中英文别名：`微信/wechat`、`飞书/feishu/lark`、`钉钉/dingtalk`、`企业微信/wecom` 等。
-- `--from/--to` 用 ISO 8601 含时区（`2026-05-01T09:00:00+08:00`）。`stats` 的 `--from/--to` 用 `YYYY-MM-DD`。
+- `search` / `summary` 的 `--from/--to` 用 ISO 8601 含时区（`2026-05-01T09:00:00+08:00`）。`stats` 的 `--from/--to` 支持 `YYYY-MM-DD` 或 ISO 8601。
 
 ## 流式处理 ndjson 的样板
 

--- a/src/command-tree.ts
+++ b/src/command-tree.ts
@@ -177,9 +177,10 @@ export const COMMAND_TREE: ServiceSpec[] = [
         name: "stats",
         summary: "按维度聚合统计",
         options: [
-          { flags: "--from <date>", summary: "YYYY-MM-DD，默认 7 天前" },
-          { flags: "--to <date>", summary: "YYYY-MM-DD，默认今天" },
+          { flags: "--from <time>", summary: "YYYY-MM-DD 或 ISO 8601，默认 7 天前" },
+          { flags: "--to <time>", summary: "YYYY-MM-DD 或 ISO 8601，默认今天" },
           { flags: "--app <name>", summary: "仅统计指定应用" },
+          { flags: "--sender <name>", summary: "仅统计指定发送人/标题" },
           { flags: "--client <label>", summary: "按 clientLabel 过滤；all 为全部" },
           { flags: "--dim <dim>", summary: "date|app|sender|hour|client|all", default: "all" },
         ],

--- a/src/commands/notification.ts
+++ b/src/commands/notification.ts
@@ -65,6 +65,7 @@ interface StatsOpts {
   from?: string;
   to?: string;
   app?: string;
+  sender?: string;
   client?: string;
   dim?: string;
 }
@@ -72,26 +73,150 @@ interface StatsOpts {
 const HOUR_KEY = (n: StoredNotification): string =>
   String(new Date(n.timestamp).getHours()).padStart(2, "0");
 
+const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
+const ISO_TIME_RE =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(Z|[+-]\d{2}:\d{2})$/;
+
+interface StatsBoundary {
+  raw: string;
+  exactTs: number | null;
+  startTs: number;
+  endTs: number;
+  minDateKey: string;
+  maxDateKey: string;
+}
+
+interface StatsRange {
+  from: string;
+  to: string;
+  fromTs: number | null;
+  toTs: number | null;
+  fromDateKey: string;
+  toDateKey: string;
+}
+
+function parseDateParts(value: string): { year: number; month: number; day: number } | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!m) return null;
+  const year = Number(m[1]);
+  const month = Number(m[2]);
+  const day = Number(m[3]);
+  const d = new Date(year, month - 1, day);
+  if (
+    d.getFullYear() !== year ||
+    d.getMonth() !== month - 1 ||
+    d.getDate() !== day
+  ) {
+    return null;
+  }
+  return { year, month, day };
+}
+
+function localDateTimestamp(
+  parts: { year: number; month: number; day: number },
+  endOfDay: boolean,
+): number {
+  return new Date(
+    parts.year,
+    parts.month - 1,
+    parts.day,
+    endOfDay ? 23 : 0,
+    endOfDay ? 59 : 0,
+    endOfDay ? 59 : 0,
+    endOfDay ? 999 : 0,
+  ).getTime();
+}
+
+function minDateKey(...keys: string[]): string {
+  return keys.sort()[0];
+}
+
+function maxDateKey(...keys: string[]): string {
+  return keys.sort().at(-1)!;
+}
+
+function parseStatsBoundary(value: string, optionName: "--from" | "--to"): StatsBoundary {
+  if (DATE_ONLY_RE.test(value)) {
+    const parts = parseDateParts(value);
+    if (!parts) {
+      throw new YoooclawError(
+        "YOOOCLAW_INVALID_ARGUMENT",
+        `${optionName} 必须是合法日期 YYYY-MM-DD`,
+      );
+    }
+    const startTs = localDateTimestamp(parts, false);
+    const endTs = localDateTimestamp(parts, true);
+    return {
+      raw: value,
+      exactTs: null,
+      startTs,
+      endTs,
+      minDateKey: value,
+      maxDateKey: value,
+    };
+  }
+
+  if (!ISO_TIME_RE.test(value)) {
+    throw new YoooclawError(
+      "YOOOCLAW_INVALID_ARGUMENT",
+      `${optionName} 必须是 YYYY-MM-DD 或 ISO 8601 时间，例如 2026-06-02 或 2026-06-02T09:00:00+08:00`,
+    );
+  }
+  const exactTs = Date.parse(value);
+  if (Number.isNaN(exactTs)) {
+    throw new YoooclawError("YOOOCLAW_INVALID_ARGUMENT", `${optionName} 不是合法时间`);
+  }
+
+  const declaredDateKey = value.slice(0, 10);
+  const localDateKey = formatDate(new Date(exactTs));
+  return {
+    raw: value,
+    exactTs,
+    startTs: exactTs,
+    endTs: exactTs,
+    minDateKey: minDateKey(declaredDateKey, localDateKey),
+    maxDateKey: maxDateKey(declaredDateKey, localDateKey),
+  };
+}
+
+function buildStatsRange(fromRaw: string | undefined, toRaw: string | undefined): StatsRange {
+  const from = parseStatsBoundary(fromRaw ?? daysAgo(7), "--from");
+  const to = parseStatsBoundary(toRaw ?? today(), "--to");
+  if (from.startTs > to.endTs) {
+    throw new YoooclawError("YOOOCLAW_INVALID_ARGUMENT", "--from 不能晚于 --to");
+  }
+  return {
+    from: from.raw,
+    to: to.raw,
+    fromTs: from.exactTs,
+    toTs: to.exactTs,
+    fromDateKey: from.minDateKey,
+    toDateKey: to.maxDateKey,
+  };
+}
+
 export async function notificationStats(
   ctx: CliContext,
   _args: unknown[],
   opts: StatsOpts,
 ): Promise<unknown> {
-  const from = opts.from ?? daysAgo(7);
-  const to = opts.to ?? today();
+  const range = buildStatsRange(opts.from, opts.to);
   const dim = opts.dim ?? "all";
   const allowed = ["date", "app", "sender", "hour", "client", "all"];
   if (!allowed.includes(dim)) {
     throw new YoooclawError("YOOOCLAW_INVALID_ARGUMENT", `--dim 只能是 ${allowed.join("|")}`);
   }
   const options: NotificationQueryOptions = {
+    from: range.from,
+    to: range.to,
     app: opts.app,
+    sender: opts.sender,
     client: opts.client,
     limit: MAX_LIMIT,
-    fromTs: null,
-    toTs: null,
-    fromDateKey: from,
-    toDateKey: to,
+    fromTs: range.fromTs,
+    toTs: range.toTs,
+    fromDateKey: range.fromDateKey,
+    toDateKey: range.toDateKey,
   };
   const items = await queryNotifications(ctx.paths, options);
 
@@ -105,7 +230,7 @@ export async function notificationStats(
   return {
     ok: true,
     total: items.length,
-    range: { from, to },
+    range: { from: range.from, to: range.to },
     dim,
     ...(dim === "all" ? dims : { [dim]: dims[dim as keyof typeof dims] }),
   };

--- a/test/cli.data.test.ts
+++ b/test/cli.data.test.ts
@@ -87,6 +87,40 @@ describe("notification search", () => {
     expect(res.json.app.find((a: any) => a.key === "微信").count).toBe(2);
   });
 
+  it("stats 支持 ISO 8601 时区时间范围", async () => {
+    const fullDay = await runCli([
+      "notification",
+      "stats",
+      "--from",
+      `${DAY}T00:00:00+08:00`,
+      "--to",
+      `${DAY}T23:59:59+08:00`,
+    ], { home });
+    expect(fullDay.exitCode).toBe(0);
+    expect(fullDay.json.ok).toBe(true);
+    expect(fullDay.json.total).toBe(3);
+
+    const precise = await runCli([
+      "notification",
+      "stats",
+      "--from",
+      `${DAY}T11:30:00+08:00`,
+      "--to",
+      `${DAY}T12:30:00+08:00`,
+      "--dim",
+      "sender",
+    ], { home });
+    expect(precise.json.total).toBe(1);
+    expect(precise.json.sender).toEqual([{ key: "Bob", count: 1 }]);
+  });
+
+  it("stats --sender 按发送人/标题过滤", async () => {
+    const res = await runCli(["notification", "stats", "--from", DAY, "--to", DAY, "--sender", "Alice", "--dim", "sender"], { home });
+    expect(res.exitCode).toBe(0);
+    expect(res.json.total).toBe(1);
+    expect(res.json.sender).toEqual([{ key: "Alice", count: 1 }]);
+  });
+
   it("stats 非法 --dim 报 INVALID_ARGUMENT", async () => {
     const res = await runCli(["notification", "stats", "--dim", "bogus"], { home });
     expect(res.exitCode).toBe(1);


### PR DESCRIPTION
## Summary

- Fix `notification stats` so `--from/--to` accept both `YYYY-MM-DD` and ISO 8601 timestamps with timezone offsets.
- Add `notification stats --sender` filtering, matching the existing sender/title behavior used by notification queries.
- Update CLI help, the packaged notification-query skill docs, and regression coverage.
- Bump package version to `0.1.6` and publish `cli-v0.1.6`.

## Root Cause

`stats` previously passed raw `from/to` values directly into date-key filtering without parsing timestamps. ISO 8601 values like `2026-06-02T00:00:00+08:00` were compared as strings against `YYYY-MM-DD` storage keys, so matching day files could be skipped and return `total: 0`.

`--sender` was only registered for `notification search`/`summary`, so Commander rejected it for `stats` before the handler could run.

## Validation

- `bun run typecheck`
- `bun run test`
- `bun run build`
- Manual repro with a `2026-06-02T10:00:00+08:00` fixture confirmed ISO `stats` and `--sender` both return `total: 1`.
- Release workflow for `cli-v0.1.6` completed successfully, including npm publish and GitHub Release.
