### PR TITLE
release: cli-v0.1.7 — 灯效凭据写死在代码里

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "module",
   "description": "yoooclaw 独立 CLI：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "bin": {

--- a/scripts/build-native.ts
+++ b/scripts/build-native.ts
@@ -33,14 +33,12 @@ const ALL_TARGETS: Target[] = [
 const manifest = pkg as { version?: string };
 const version = manifest.version ?? "unknown";
 
-// 与 build.ts 同源：构建期注入的 Relay host + 灯效凭据，避免 native 二进制
-// 因 env 缺失而在 sendLightEffect 时报 LIGHT_SEND_FAILED。
+// 与 build.ts 同源：构建期注入的 Relay host。
+// （灯效 API 的 appKey / templateId 已写死在 sender.ts，不再走 env 注入。）
 const INJECTED_ENV_KEYS = [
   "OPENCLAW_HOST_PRODUCTION",
   "OPENCLAW_HOST_TEST",
   "OPENCLAW_HOST_DEVELOPMENT",
-  "LIGHT_APP_KEY",
-  "LIGHT_TEMPLATE_ID",
 ] as const;
 
 async function loadPluginBuildEnv(): Promise<Record<string, string>> {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -23,20 +23,17 @@ const version = manifest.version ?? "unknown";
 const externalNames = Object.keys(manifest.dependencies ?? {});
 const external = externalNames.flatMap((name) => [name, `${name}/*`]);
 
-// 复用 phone-notifications 那套 Relay：从插件 .env 读取 host + 灯效凭据，
-// 注入与插件相同的 process.env.*。这样 schema.ts 的 DEFAULT_RELAY_URL 在构建期
-// 就被替换为生产 relay 地址；灯效 API 的 appKey / templateId 也内联进产物，
-// 避免 `yc light` 走 daemon → sendLightEffect 时因 env 缺失而报 LIGHT_SEND_FAILED。
+// 复用 phone-notifications 那套 Relay：从插件 .env 读取 host，注入与插件相同的
+// process.env.*。这样 schema.ts 的 DEFAULT_RELAY_URL 在构建期就被替换为生产 relay
+// 地址。（灯效 API 的 appKey / templateId 已写死在 sender.ts，不再走 env 注入。）
 const INJECTED_ENV_KEYS = [
   "OPENCLAW_HOST_PRODUCTION",
   "OPENCLAW_HOST_TEST",
   "OPENCLAW_HOST_DEVELOPMENT",
-  "LIGHT_APP_KEY",
-  "LIGHT_TEMPLATE_ID",
 ] as const;
 
 async function loadPluginEnv(): Promise<Record<string, string>> {
-  // 独立 CLI 仓自带 .env（本地构建注入 Relay host + 灯效凭据）；CI 中不存在时回退 process.env。
+  // 独立 CLI 仓自带 .env（本地构建注入 Relay host）；CI 中不存在时回退 process.env。
   const envPath = join(import.meta.dir, "..", ".env");
   if (!existsSync(envPath)) return {};
   const raw = await readFile(envPath, "utf-8");

--- a/src/daemon/light-send.ts
+++ b/src/daemon/light-send.ts
@@ -2,8 +2,8 @@
  * daemon /light/send 实际投递路径。
  *
  * 把 { segments | preset | rule } 解析成最终的 segments + repeat_times，再调
- * phone-notifications 的 sendLightEffect 走云 API（需要 LIGHT_APP_KEY /
- * LIGHT_TEMPLATE_ID 进程环境变量 + OPENCLAW_HOST_* 决定的 apiUrl）。
+ * phone-notifications 的 sendLightEffect 走云 API（appKey / templateId 写死在
+ * sender.ts；apiUrl 由 OPENCLAW_HOST_* 决定）。
  *
  * 优先级：rule > preset > segments。用户显式传 --repeat / --repeat-times 时
  * 会覆盖 rule/preset 自带的 repeat_times。

--- a/src/vendor/light/sender.ts
+++ b/src/vendor/light/sender.ts
@@ -21,19 +21,19 @@ export async function sendLightEffect(
   title?: string,
 ): Promise<SendLightResult> {
   const apiUrl = getEnvUrls().lightApiUrl;
-  const appKey = process.env.LIGHT_APP_KEY;
-  const templateId = process.env.LIGHT_TEMPLATE_ID;
+  // 后端要求 appKey / templateId 写死在代码里（不再从 env 注入）
+  const appKey = "phone-notifications";
+  const templateId = "1990771146010017800";
   const resolvedTitle = resolveLightTitle(title, reason, segments);
 
   logger?.info(
     `Light sender: apiUrl=${apiUrl ?? "UNSET"}, appKey=${appKey ? appKey.substring(0, 8) + "…" : "UNSET"}, templateId=${templateId ?? "UNSET"}, apiKey=${apiKey ? apiKey.substring(0, 20) + "…" : "EMPTY"}, title=${resolvedTitle}, reason=${reason ?? ""}, segments=${JSON.stringify(segments)}`,
   );
 
-  if (!apiUrl || !appKey || !templateId) {
+  if (!apiUrl) {
     return {
       ok: false,
-      error:
-        "灯效 API 未配置，请确认构建时已封装 OPENCLAW_HOST_* / LIGHT_APP_KEY / LIGHT_TEMPLATE_ID",
+      error: "灯效 API 未配置，请确认构建时已封装 OPENCLAW_HOST_*",
     };
   }
 


### PR DESCRIPTION
## 改动

后端要求灯效凭据固定写死在代码里，不再依赖构建期 env 注入：

- **appKey** 固定为 `phone-notifications`
- **templateId** 固定为 `1990771146010017800`

具体：

- `src/vendor/light/sender.ts`：`appKey` / `templateId` 改为硬编码常量；发送前校验简化为只检查 `apiUrl`，错误提示同步更新。
- `scripts/build.ts` / `scripts/build-native.ts`：移除已失效的 `LIGHT_APP_KEY` / `LIGHT_TEMPLATE_ID` 构建期注入，仅保留 `OPENCLAW_HOST_*`；注释更新。
- `src/daemon/light-send.ts`：注释更新。

版本号 0.1.6 → 0.1.7（`cli-0.1.7`），tag `cli-v0.1.7` 已推送，release-cli.yml 自动发版中。

## 验证

- `bun run typecheck` ✅
- `bun run test` ✅ 116 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)