### PR TITLE
[codex] Release 0.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "type": "module",
   "description": "yoooclaw 独立 CLI：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "bin": {

--- a/src/daemon/recording-bridge.ts
+++ b/src/daemon/recording-bridge.ts
@@ -8,14 +8,16 @@
  *   - 同时 mode=api 时若用户没填 apiKey，要回退到 account 级 ock- key（resolveApiKey）。
  *
  * 用法：daemon main.ts 先调 registerRecordingInterfaces 装上 list/status/rename/... 一类查询/管理方法，
- * 再调本模块 `overrideRecordingSync` 覆盖 sync 这一项（runtime.gatewayMethods 是 Map，后写覆盖）。
+ * 再调本模块 `overrideRecordingSync` 覆盖 sync / retranscribe（runtime.gatewayMethods 是 Map，后写覆盖）。
  */
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import {
+  canStartTranscription,
   handleRecordingSync,
   RecordingStorage,
+  triggerTranscription,
   validateAsrConfig,
   type AsrConfig,
   type RecordingMetadata,
@@ -39,6 +41,11 @@ export interface RecordingSyncDeps {
 interface SyncParams {
   recordingId?: unknown;
   recording?: RecordingMetadata;
+  asr?: AsrConfig;
+}
+
+interface RetranscribeParams {
+  recordingId?: unknown;
   asr?: AsrConfig;
 }
 
@@ -98,7 +105,7 @@ const TERMINAL_SUCCESS_STATUSES = new Set<string>(["synced", "transcribed"]);
 /** 单条 in-flight 的兜底超时：5 分钟内若没收到终态事件，强制释放（避免句柄泄漏）。 */
 const INFLIGHT_TIMEOUT_MS = 5 * 60 * 1000;
 
-/** 覆盖注册 recordings.sync gateway + POST /recordings HTTP。 */
+/** 覆盖注册 recordings.sync / recordings.retranscribe gateway + POST /recordings HTTP。 */
 export function overrideRecordingSync(deps: RecordingSyncDeps): void {
   const { runtime, storage, logger, fallbackApiKey, asrConfigDir, notifyStatus } = deps;
   const readFallbackApiKey = (): string | undefined =>
@@ -111,6 +118,14 @@ export function overrideRecordingSync(deps: RecordingSyncDeps): void {
    * daemon 层加 in-flight 标记后，第二条直接 short-circuit，仅返回当前 storage 状态。
    */
   const inFlight = new Map<string, NodeJS.Timeout>();
+
+  function resolveConfiguredAsr(callerAsr: AsrConfig | undefined): AsrConfig | undefined {
+    return resolveAsrConfig(
+      callerAsr,
+      loadLocalAsrConfig(asrConfigDir),
+      readFallbackApiKey(),
+    );
+  }
 
   function markInFlight(recordingId: string): void {
     clearTimeout(inFlight.get(recordingId));
@@ -185,8 +200,7 @@ export function overrideRecordingSync(deps: RecordingSyncDeps): void {
       };
     }
 
-    const localAsr = loadLocalAsrConfig(asrConfigDir);
-    const asr = resolveAsrConfig(params.asr, localAsr, readFallbackApiKey());
+    const asr = resolveConfiguredAsr(params.asr);
     if (asr && !params.asr) {
       logger.info(
         `[recording-sync] 使用本地 asr-config.json（mode=${asr.mode}${
@@ -207,6 +221,61 @@ export function overrideRecordingSync(deps: RecordingSyncDeps): void {
     return { ok: true, data: result };
   }
 
+  function retranscribe(params: RetranscribeParams): (
+    | { ok: true; data: { ok: true; recordingId: string; message: string } }
+    | { ok: false; code: string; message: string }
+  ) {
+    const recordingId = trimToString(params.recordingId);
+    if (!recordingId) {
+      return { ok: false, code: "INVALID_PARAMS", message: "recordingId is required" };
+    }
+
+    if (params.asr) {
+      const err = validateAsrConfig(params.asr);
+      if (err) return { ok: false, code: "ASR_NOT_CONFIGURED", message: err };
+    }
+
+    const asr = resolveConfiguredAsr(params.asr);
+    const asrError = validateAsrConfig(asr);
+    if (asrError) {
+      return { ok: false, code: "ASR_NOT_CONFIGURED", message: asrError };
+    }
+
+    const entry = storage.findById(recordingId);
+    if (!entry) {
+      return { ok: false, code: "NOT_FOUND", message: `Recording not found: ${recordingId}` };
+    }
+
+    if (!canStartTranscription(entry.status)) {
+      return {
+        ok: false,
+        code: "INVALID_STATE",
+        message: `Recording status does not allow retranscribe: ${entry.status}`,
+      };
+    }
+
+    if (asr && !params.asr) {
+      logger.info(
+        `[recording-retranscribe] 使用本地 asr-config.json（mode=${asr.mode}${
+          asr.mode === "api" && asr.api?.apiKey ? ", key=ock-***" : ""
+        }）`,
+      );
+    }
+
+    triggerTranscription(recordingId, storage, asr!, logger, {
+      notifyStatus: wrappedNotifyStatus,
+    }).catch((err) => {
+      logger.error(
+        `[recording-retranscribe] 重试转写失败: ${recordingId}, ${err?.message ?? err}`,
+      );
+    });
+
+    return {
+      ok: true,
+      data: { ok: true, recordingId, message: "转写已重新触发" },
+    };
+  }
+
   runtime.registerGatewayMethod("recordings.sync", async ({ params, respond }) => {
     const outcome = await doSync((params ?? {}) as SyncParams);
     if (outcome.ok) {
@@ -214,6 +283,15 @@ export function overrideRecordingSync(deps: RecordingSyncDeps): void {
         code: "SYNC_FAILED",
         message: outcome.data.error ?? "Unknown error",
       });
+    } else {
+      respond(false, null, { code: outcome.code, message: outcome.message });
+    }
+  });
+
+  runtime.registerGatewayMethod("recordings.retranscribe", ({ params, respond }) => {
+    const outcome = retranscribe((params ?? {}) as RetranscribeParams);
+    if (outcome.ok) {
+      respond(true, outcome.data);
     } else {
       respond(false, null, { code: outcome.code, message: outcome.message });
     }
@@ -245,7 +323,7 @@ export function overrideRecordingSync(deps: RecordingSyncDeps): void {
     },
   });
 
-  logger.info("daemon 已覆盖 recordings.sync + POST /recordings（注入本地 ASR 配置）");
+  logger.info("daemon 已覆盖 recordings.sync / recordings.retranscribe + POST /recordings（注入本地 ASR 配置）");
 }
 
 async function readJsonBody(req: IncomingMessage): Promise<unknown | undefined> {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -33,8 +33,9 @@ export { NotificationStorage } from "./vendor/notification/storage.js";
 export { registerNotificationInterfaces } from "./vendor/plugin/notifications.js";
 export { RecordingStorage } from "./vendor/recording/storage.js";
 export { registerRecordingInterfaces } from "./vendor/plugin/recordings.js";
-export { handleRecordingSync } from "./vendor/recording/handler.js";
+export { handleRecordingSync, triggerTranscription } from "./vendor/recording/handler.js";
 export type { RecordingStatusEvent } from "./vendor/recording/handler.js";
+export { canStartTranscription } from "./vendor/recording/state-machine.js";
 export { validateAsrConfig } from "./vendor/recording/asr.js";
 export type {
   AsrConfig,

--- a/test/cli.daemon.e2e.test.ts
+++ b/test/cli.daemon.e2e.test.ts
@@ -6,9 +6,9 @@
  * L4：模拟手机端，直接 fetch daemon HTTP（/health 公开、/notifications 经 api-key 鉴权）。
  */
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { cleanHome, makeHome, profileDir, runCli } from "./helpers/cli.js";
+import { cleanHome, makeHome, profileDir, runCli, seedRecordings } from "./helpers/cli.js";
 import { startDaemon, type DaemonHandle } from "./helpers/daemon.js";
 
 const SEGMENT = { mode: "steady", duration_s: 5, brightness: 192, color: { r: 255, g: 0, b: 0 } };
@@ -221,6 +221,61 @@ describe("L4 手机端 ingest（api-key 鉴权）", () => {
     const search = await runCli(["notification", "search", "--client", "phone-a"], { home });
     expect(search.json.length).toBeGreaterThanOrEqual(1);
     expect(search.json.some((n: any) => n.clientLabel === "phone-a")).toBe(true);
+  });
+});
+
+describe("L4 录音重试（CLI ASR fallback）", () => {
+  let home: string;
+  let daemon: DaemonHandle;
+
+  beforeAll(async () => {
+    home = makeHome();
+    const recordingsDir = join(profileDir(home), "recordings");
+    mkdirSync(recordingsDir, { recursive: true });
+    writeFileSync(
+      join(recordingsDir, "asr-config.json"),
+      JSON.stringify({ mode: "api", api: { language: "auto" } }, null, 2),
+      "utf-8",
+    );
+    seedRecordings(home, [
+      {
+        id: "rec_retry",
+        clientLabel: "phone-a",
+        metadata: {
+          name: "失败录音",
+          duration_sec: 1,
+          file_size_bytes: 544 * 1024,
+          created_at: "2026-06-04T17:16:50+08:00",
+          oss_audio_url: "https://example.invalid/rec_retry.ogg",
+          markers: [],
+        },
+        status: "transcribe_failed",
+        audioFile: "audio/rec_retry.ogg",
+        lastError: "上一次转写失败",
+        ingestedAt: "2026-06-04T17:16:50+08:00",
+        updatedAt: "2026-06-04T17:17:00+08:00",
+      },
+    ]);
+    daemon = await startDaemon({ home });
+  });
+  afterAll(async () => {
+    await daemon.stop();
+    cleanHome(home);
+  });
+
+  it("recordings.retranscribe 不带 asr 时读取 CLI 本地配置", async () => {
+    const res = await fetch(`${daemon.baseUrl}/gateway/recordings.retranscribe`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ recordingId: "rec_retry" }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      ok: true,
+      data: { ok: true, recordingId: "rec_retry", message: "转写已重新触发" },
+    });
   });
 });
 


### PR DESCRIPTION
## What changed

- Fixed CLI daemon `recordings.retranscribe` so retry transcription can use local `recordings/asr-config.json` and the account-level `ock-` key fallback, matching the existing CLI-only `recordings.sync` path.
- Exported the shared recording helpers needed by the daemon bridge.
- Added an e2e regression test for retrying transcription without request-level ASR config.
- Bumped `@yoooclaw/cli` from `0.1.7` to `0.1.8` and pushed tag `cli-v0.1.8` to trigger the release workflow.

## Why

When a recording transcription failed and the phone was only bound to the CLI daemon, retry could still go through the plugin-style `recordings.retranscribe` handler. That path required ASR config in the request, so the client could not re-trigger transcription even though the CLI daemon already had local ASR configuration.

## Validation

- `bun run typecheck`
- `bunx vitest run test/cli.daemon.e2e.test.ts`