### PR TITLE
[codex] Add unit test CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,13 @@ jobs:
         run: go vet ./...
 
       - name: Test
-        run: go test ./...
+        run: go test -race -coverprofile=coverage.out ./...
+
+      - name: Coverage summary
+        run: go tool cover -func=coverage.out | tail -1
+
+      - name: Coverage gate
+        run: MIN_COVERAGE=55 scripts/coverage-gate.sh
 
       - name: Build npm distribution (current platform)
         run: scripts/build-go.sh --current

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ dist-npm
 
 # 系统
 .DS_Store
+
+# 测试覆盖率产物
+coverage.out
+coverage.html

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+.PHONY: test test-race cover cover-gate cover-html test-int vet update-golden ci
+
+# 覆盖率门禁阈值（可在命令行覆盖：make cover-gate MIN_COVERAGE=60）
+MIN_COVERAGE ?= 55
+
+# 默认：跑全部单元测试（带竞态检测）
+test:
+	go test -race ./...
+
+# 仅竞态检测，详细输出
+test-race:
+	go test -race -v ./...
+
+# 生成覆盖率 profile 并打印按函数/总计的统计
+cover:
+	go test -race -coverprofile=coverage.out ./...
+	go tool cover -func=coverage.out | tail -1
+
+# 覆盖率门禁（只许涨不许跌）；调高 MIN_COVERAGE 收紧
+cover-gate: cover
+	MIN_COVERAGE=$(MIN_COVERAGE) scripts/coverage-gate.sh
+
+# 在浏览器查看覆盖率（生成 HTML 报告）
+cover-html: cover
+	go tool cover -html=coverage.out -o coverage.html
+	@echo "已生成 coverage.html"
+
+# 跑带 integration tag 的测试（真实钥匙串 / 进程级，本地手动跑）
+test-int:
+	go test -race -tags=integration ./...
+
+# 刷新 golden 期望文件
+update-golden:
+	go test ./... -update
+
+vet:
+	go vet ./...
+
+# 本地复刻 CI：vet + race + 覆盖率门禁
+ci: vet cover-gate

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,66 @@
+# 测试体系
+
+本仓库的单元测试**只用 Go 标准库 `testing`**（零第三方断言/mock 依赖），统一采用
+表驱动 + `t.Parallel()` + 沙箱隔离 + golden 锁契约的风格。
+
+## 快速命令
+
+```bash
+make test          # go test -race ./...
+make cover         # 生成 coverage.out + 打印总覆盖率
+make cover-html    # 生成 coverage.html 报告
+make cover-gate    # 覆盖率门禁（低于 MIN_COVERAGE 失败）
+make test-int      # 跑带 integration tag 的破坏性用例（真实钥匙串等）
+make update-golden # 刷新 golden 期望文件
+make ci            # 本地复刻 CI：vet + race + 覆盖率门禁
+```
+
+CI（`.github/workflows/ci.yml`）跑 `go test -race -coverprofile` + 覆盖率汇总 + 门禁。
+
+## 公共测试设施：`internal/testutil`
+
+仅供 `*_test.go` 使用（依赖 `testing`，不要被生产代码 import）。
+
+- `testutil.Sandbox(t)` —— 把 `YOOOCLAW_HOME` 指向临时目录并预建 default profile，返回 `paths.Paths`。
+  每个测试自带隔离环境，绝不触碰真实 `~/.yoooclaw`。
+- `testutil.Logger{T: t}` —— 把日志转发到 `t.Log` 的假 logger，满足各包 `Info/Warn/Error(string)` 接口。
+- `testutil.Golden(t, name, got)` + 全局 `-update` —— golden 比对/刷新。
+- `testutil.WriteFile(t, path, data)` —— 摆放 fixture。
+
+## 隔离与确定性约定
+
+1. **文件系统**：一律 `t.TempDir()` / `YOOOCLAW_HOME` 沙箱，不写真实数据目录。
+2. **网络**：用 `net/http/httptest` 模拟上游 / Relay / OSS / daemon，不连真实网络。
+3. **系统钥匙串**：`internal/creds` 通过 `keychain_seam.go` 的函数变量
+   （`keychainAvailableFn/GetFn/SetFn`）注入假实现，测试**绝不**读写真实钥匙串；
+   真实钥匙串往返放在 `//go:build keychain_integration` 下，默认不跑。
+4. **并行**：纯函数测试默认 `t.Parallel()`；改写包级变量（creds seam、cli 的
+   `os.Stdout`/`exitCode`）的测试**不可并行**。
+
+## 各层策略
+
+| 层 | 包 | 做法 |
+|---|---|---|
+| 纯函数 | errs, output, config/dotpath, light/validators, paths, fsutil, logread, version, prompt | 表驱动穷尽 + golden |
+| 状态/存储 | config, creds, lightrule, monitor, notif, skills, image | `Sandbox` + 临时目录往返读写 |
+| 集成 | recording, relay, light/sender, daemon/server | `httptest` 模拟上游；构造 `server{}` 直接打 `ServeHTTP` |
+| 命令编排 | cli | 构造 `newRootCmd()`、`SetArgs`、捕获 `os.Stdout`、断言 JSON 输出契约与退出码 |
+
+## 结构性无法覆盖的部分（非缺陷）
+
+以下代码路径依赖进程外部状态，单平台、进程内无法确定性触达，已知并接受：
+
+- **`internal/keychain`**（~29%）：`exec.Command` 调 `security`/`secret-tool` 的写入分支与
+  非当前平台分支。真实往返见 `-tags=keychain_integration`，但 Linux/Windows 分支在 macOS 上仍不可达。
+- **`internal/prompt`**（~82%）：TTY 检测（`isTTY` 的 `os.Stat` 错误分支、交互式真实读写）需真实终端。
+- **`internal/version`**（~86%）：`Dist()` 中 `os.Executable()` 出错分支不可强制触发（纯逻辑已抽到 `distFor` 全覆盖）。
+- **`internal/daemon`**（~21%）：进程 spawn/detach（`proc_unix.go`/`proc_windows.go`/`spawn.go`）、
+  信号处理与主循环 `RunForeground` 的端口监听/优雅退出，属于进程级集成，留待端到端测试；
+  HTTP handler 已用 `httptest` 覆盖核心路由。
+- **`cmd/yc/main.go`**：仅 `cli.Execute()` 入口（含 `os.Exit`），无逻辑。
+- 各包深层 I/O 错误分支（`os.Rename`/`Chmod` 失败等）不易在测试中可靠制造。
+
+## 覆盖率门禁
+
+`scripts/coverage-gate.sh` 校验总覆盖率不低于 `MIN_COVERAGE`（默认 55）。
+**只许涨不许跌**：补完一波测试后把阈值抬到略低于当前实际值，逐步收紧。

--- a/internal/cli/cli_local_test.go
+++ b/internal/cli/cli_local_test.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// assertOKJSON 断言退出码 0 且输出是合法 JSON（数组或对象）。
+func assertOKJSON(t *testing.T, label, out string, code int) {
+	t.Helper()
+	if code != 0 {
+		t.Errorf("%s: expected exit 0, got %d (%s)", label, code, out)
+		return
+	}
+	var v any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &v); err != nil {
+		t.Errorf("%s: output not valid JSON: %q", label, out)
+	}
+}
+
+func TestLocalReadCommandsOnEmptyStore(t *testing.T) {
+	sandbox(t)
+	cases := [][]string{
+		{"recording", "list"},
+		{"recording", "storage-path"},
+		{"image", "list"},
+		{"image", "storage-path"},
+		{"notification", "storage-path"},
+		{"notification", "search"},
+		{"notification", "stats"},
+		{"notification", "summary"},
+		{"notification", "+today"},
+		{"notification", "+recent"},
+		{"sync", "scan"},
+		{"log"},
+		{"log", "+errors"},
+		{"profile", "list"},
+	}
+	for _, args := range cases {
+		out, code := execCLI(t, args...)
+		assertOKJSON(t, strings.Join(args, " "), out, code)
+	}
+}
+
+func TestProfileCreateUseDelete(t *testing.T) {
+	home := sandbox(t)
+	imp := home + "/import.json"
+	if err := os.WriteFile(imp, []byte(`{"daemon":{"port":20003}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if out, code := execCLI(t, "profile", "create", "work", "--non-interactive", "--from-file", imp, "--no-start"); code != 0 {
+		t.Fatalf("profile create: %s", out)
+	}
+	out, code := execCLI(t, "profile", "list")
+	if code != 0 || !strings.Contains(out, "work") {
+		t.Errorf("profile list should include work: %s", out)
+	}
+	// 再建一个待删除的 profile
+	if out, code := execCLI(t, "profile", "create", "spare", "--non-interactive", "--from-file", imp, "--no-start"); code != 0 {
+		t.Fatalf("profile create spare: %s", out)
+	}
+	if out, code := execCLI(t, "profile", "use", "work"); code != 0 {
+		t.Errorf("profile use failed: %s", out)
+	}
+	// 删除非 active profile（active=work，删 spare）
+	if out, code := execCLI(t, "profile", "delete", "spare", "--yes"); code != 0 {
+		t.Errorf("profile delete spare: %s", out)
+	}
+	// use 不存在的 profile -> PROFILE_NOT_FOUND
+	if _, code := execCLI(t, "profile", "use", "ghost"); code == 0 {
+		t.Error("use missing profile should fail")
+	}
+}
+
+func TestNotificationSearchInvalidArg(t *testing.T) {
+	sandbox(t)
+	// 非法 --conversation-type
+	out, code := execCLI(t, "notification", "search", "--conversation-type", "channel")
+	if code == 0 {
+		t.Error("invalid conversation-type should fail")
+	}
+	if !strings.Contains(out, "YOOOCLAW_INVALID_ARGUMENT") {
+		t.Errorf("expected INVALID_ARGUMENT: %s", out)
+	}
+}
+
+func TestRecordingStatusNotFound(t *testing.T) {
+	sandbox(t)
+	out, code := execCLI(t, "recording", "status", "ghost-id")
+	if code == 0 {
+		t.Error("status of missing recording should fail")
+	}
+	if !strings.Contains(out, "error") {
+		t.Errorf("expected error payload: %s", out)
+	}
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,0 +1,198 @@
+package cli
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// execCLI 在隔离沙箱里执行一次 CLI（捕获 os.Stdout 与退出码）。
+// 因为 run() 直接写 os.Stdout 且 exitCode 是包级变量，这些测试不可并行。
+func execCLI(t *testing.T, args ...string) (stdout string, code int) {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	exitCode = 0
+
+	root := newRootCmd()
+	root.SetArgs(args)
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	_ = root.Execute()
+
+	_ = w.Close()
+	os.Stdout = old
+	data, _ := io.ReadAll(r)
+	return string(data), exitCode
+}
+
+// sandbox 设置隔离的 YOOOCLAW_HOME。
+func sandbox(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("YOOOCLAW_HOME", home)
+	t.Setenv("YOOOCLAW_PROFILE", "")
+	return home
+}
+
+func decode(t *testing.T, out string) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &m); err != nil {
+		t.Fatalf("output not JSON object: %q (%v)", out, err)
+	}
+	return m
+}
+
+func TestRootHelpAndVersion(t *testing.T) {
+	sandbox(t)
+	if out, _ := execCLI(t, "--version"); strings.TrimSpace(out) == "" {
+		// --version writes via cobra to SetOut(io.Discard); just ensure no crash.
+	}
+	// help sweep: 构造命令树 + help 不应崩溃
+	if _, code := execCLI(t, "--help"); code != 0 {
+		t.Errorf("--help exit code = %d", code)
+	}
+}
+
+func TestHelpSweepAllCommands(t *testing.T) {
+	sandbox(t)
+	root := newRootCmd()
+	// 遍历一层子命令跑 --help，覆盖各命令构造与 usage。
+	for _, cmd := range root.Commands() {
+		name := strings.Fields(cmd.Use)[0]
+		if _, code := execCLI(t, name, "--help"); code != 0 {
+			t.Errorf("%s --help exit code = %d", name, code)
+		}
+	}
+}
+
+func TestConfigInitShowSetUnset(t *testing.T) {
+	sandbox(t)
+	// 准备 from-file 导入
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "import.json")
+	os.WriteFile(cfgFile, []byte(`{"daemon":{"port":20001}}`), 0o600)
+
+	out, code := execCLI(t, "config", "init", "--non-interactive", "--from-file", cfgFile, "--no-start")
+	if code != 0 {
+		t.Fatalf("config init failed (code %d): %s", code, out)
+	}
+	m := decode(t, out)
+	if m["ok"] != true {
+		t.Errorf("init not ok: %+v", m)
+	}
+
+	// 再次 init 无 force -> ALREADY_EXISTS
+	out, code = execCLI(t, "config", "init", "--non-interactive", "--from-file", cfgFile, "--no-start")
+	if code == 0 {
+		t.Error("second init without --force should fail")
+	}
+	if errObj := decode(t, out)["error"].(map[string]any); errObj["code"] != "YOOOCLAW_ALREADY_EXISTS" {
+		t.Errorf("expected ALREADY_EXISTS, got %v", errObj["code"])
+	}
+
+	// show -> masked config
+	out, code = execCLI(t, "config", "show")
+	if code != 0 {
+		t.Fatalf("config show failed: %s", out)
+	}
+	shown := decode(t, out)
+	if _, ok := shown["daemon"]; !ok {
+		t.Errorf("config show missing daemon: %+v", shown)
+	}
+
+	// set
+	out, code = execCLI(t, "config", "set", "daemon.port", "20002")
+	if code != 0 {
+		t.Fatalf("config set failed: %s", out)
+	}
+	if decode(t, out)["value"] != float64(20002) {
+		t.Errorf("set value wrong: %s", out)
+	}
+
+	// set version -> rejected
+	if _, code := execCLI(t, "config", "set", "version", "9"); code == 0 {
+		t.Error("setting version should fail")
+	}
+
+	// unset
+	out, code = execCLI(t, "config", "unset", "daemon.port")
+	if code != 0 || decode(t, out)["removed"] != true {
+		t.Errorf("unset failed: %s", out)
+	}
+}
+
+func TestConfigShowBeforeInit(t *testing.T) {
+	sandbox(t)
+	out, code := execCLI(t, "config", "show")
+	if code == 0 {
+		t.Error("config show before init should fail")
+	}
+	if decode(t, out)["error"].(map[string]any)["code"] != "YOOOCLAW_CONFIG_INVALID" {
+		t.Errorf("expected CONFIG_INVALID: %s", out)
+	}
+}
+
+func TestInvalidFormatFlag(t *testing.T) {
+	sandbox(t)
+	out, code := execCLI(t, "config", "show", "--format", "yaml")
+	if code == 0 {
+		t.Error("invalid --format should fail")
+	}
+	if !strings.Contains(out, "YOOOCLAW_INVALID_ARGUMENT") {
+		t.Errorf("expected INVALID_ARGUMENT: %s", out)
+	}
+}
+
+func TestLightSendValidation(t *testing.T) {
+	sandbox(t)
+	// 无 --segments/--preset/--rule -> INVALID_ARGUMENT（不触达 daemon）
+	out, code := execCLI(t, "light", "send")
+	if code == 0 {
+		t.Error("light send without source should fail")
+	}
+	if decode(t, out)["error"].(map[string]any)["code"] != "YOOOCLAW_INVALID_ARGUMENT" {
+		t.Errorf("expected INVALID_ARGUMENT: %s", out)
+	}
+}
+
+func TestDaemonDependentCommandsWithoutDaemon(t *testing.T) {
+	sandbox(t)
+	// 这些 🟡 命令在 daemon 未运行时应统一报 DAEMON_NOT_RUNNING
+	cases := [][]string{
+		{"light", "send", "--preset", "red-steady"},
+		{"lightrule", "list"},
+		{"tunnel", "status"},
+	}
+	for _, args := range cases {
+		out, code := execCLI(t, args...)
+		if code == 0 {
+			t.Errorf("%v should fail without daemon", args)
+			continue
+		}
+		errObj := decode(t, out)["error"].(map[string]any)
+		if errObj["code"] != "YOOOCLAW_DAEMON_NOT_RUNNING" {
+			t.Errorf("%v expected DAEMON_NOT_RUNNING, got %v", args, errObj["code"])
+		}
+	}
+}
+
+func TestSkillsListCLI(t *testing.T) {
+	sandbox(t)
+	out, code := execCLI(t, "skills", "list")
+	if code != 0 {
+		t.Fatalf("skills list failed: %s", out)
+	}
+	// 输出应是 JSON（数组或对象），至少不为空
+	if strings.TrimSpace(out) == "" {
+		t.Error("skills list produced no output")
+	}
+}

--- a/internal/clictx/clictx_test.go
+++ b/internal/clictx/clictx_test.go
@@ -1,0 +1,73 @@
+package clictx
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/YoooClaw/cli/internal/paths"
+)
+
+func TestResolveActiveProfileFlagWins(t *testing.T) {
+	t.Setenv("YOOOCLAW_PROFILE", "envp")
+	if got := ResolveActiveProfile("  flagp  "); got != "flagp" {
+		t.Errorf("flag should win: %q", got)
+	}
+}
+
+func TestResolveActiveProfileEnv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YOOOCLAW_HOME", home)
+	t.Setenv("YOOOCLAW_PROFILE", "envp")
+	if got := ResolveActiveProfile(""); got != "envp" {
+		t.Errorf("env should win over file/default: %q", got)
+	}
+}
+
+func TestResolveActiveProfileFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YOOOCLAW_HOME", home)
+	t.Setenv("YOOOCLAW_PROFILE", "")
+	if err := os.WriteFile(paths.ActiveProfilePath(), []byte("filep\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := ResolveActiveProfile(""); got != "filep" {
+		t.Errorf("file profile should be used: %q", got)
+	}
+}
+
+func TestResolveActiveProfileDefault(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YOOOCLAW_HOME", home)
+	t.Setenv("YOOOCLAW_PROFILE", "")
+	if got := ResolveActiveProfile(""); got != paths.DefaultProfile {
+		t.Errorf("should fall back to default: %q", got)
+	}
+}
+
+func TestBuild(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YOOOCLAW_HOME", home)
+	t.Setenv("YOOOCLAW_PROFILE", "")
+	ctx, err := Build("work", "json", true, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ctx.Profile != "work" {
+		t.Errorf("profile = %q", ctx.Profile)
+	}
+	if ctx.Paths.Dir != paths.ProfileDir("work") {
+		t.Errorf("paths not wired: %q", ctx.Paths.Dir)
+	}
+	if string(ctx.Format) != "json" || !ctx.Quiet || ctx.Color {
+		t.Errorf("flags not materialized: %+v", ctx)
+	}
+	_ = filepath.Separator
+}
+
+func TestBuildInvalidFormat(t *testing.T) {
+	t.Setenv("YOOOCLAW_HOME", t.TempDir())
+	if _, err := Build("", "yaml", false, false); err == nil {
+		t.Error("invalid format should error")
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,183 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/YoooClaw/cli/internal/errs"
+	"github.com/YoooClaw/cli/internal/testutil"
+)
+
+func TestDefaultRelayURL(t *testing.T) {
+	old := RelayHost
+	t.Cleanup(func() { RelayHost = old })
+	RelayHost = "example.test"
+	if got := DefaultRelayURL(); got != "wss://example.test/message/messages/ws/plugin" {
+		t.Errorf("DefaultRelayURL = %q", got)
+	}
+}
+
+func TestDefaultShape(t *testing.T) {
+	t.Parallel()
+	cfg := Default("/creds.json")
+	if cfg.Version != ConfigVersion {
+		t.Errorf("version = %d", cfg.Version)
+	}
+	if cfg.Daemon.Port != DefaultPort || cfg.Daemon.Bind != DefaultBind {
+		t.Errorf("daemon defaults wrong: %+v", cfg.Daemon)
+	}
+	if cfg.Auth.TokenRef != "file:/creds.json#gatewayToken" {
+		t.Errorf("tokenRef = %q", cfg.Auth.TokenRef)
+	}
+	if cfg.Image.MaxBytes != DefaultImageMaxByte {
+		t.Errorf("image maxBytes = %d", cfg.Image.MaxBytes)
+	}
+	if !cfg.Relay.Enabled || !cfg.LightRules.Enabled || !cfg.AutoUpdate.Enabled {
+		t.Error("expected enabled defaults")
+	}
+}
+
+func TestDefaultEvaluator(t *testing.T) {
+	t.Parallel()
+	ev := DefaultEvaluator("/c.json")
+	if ev.Mode != "webhook" || ev.TimeoutMs != 5000 || ev.Retries != 1 {
+		t.Errorf("evaluator defaults wrong: %+v", ev)
+	}
+	if !strings.HasSuffix(ev.WebhookSecretRef, "#evaluatorSecret") {
+		t.Errorf("secretRef = %q", ev.WebhookSecretRef)
+	}
+}
+
+func TestExistsSaveLoadRoundTrip(t *testing.T) {
+	p := testutil.Sandbox(t)
+	if Exists(p) {
+		t.Fatal("config should not exist initially")
+	}
+	// Load 在缺文件时返回纯默认
+	loaded, err := Load(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Daemon.Port != DefaultPort {
+		t.Errorf("default load port = %d", loaded.Daemon.Port)
+	}
+
+	cfg := Default(p.Credentials)
+	cfg.Daemon.Port = 19999
+	cfg.Daemon.LogLevel = "debug"
+	if err := Save(p, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if !Exists(p) {
+		t.Fatal("config should exist after save")
+	}
+	loaded, err = Load(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Daemon.Port != 19999 || loaded.Daemon.LogLevel != "debug" {
+		t.Errorf("round trip mismatch: %+v", loaded.Daemon)
+	}
+}
+
+func TestLoadMergesDefaults(t *testing.T) {
+	p := testutil.Sandbox(t)
+	// 只写部分字段，其余应由默认补齐（deepMerge 语义）。
+	testutil.WriteFile(t, p.Config, []byte(`{"daemon":{"port":12345}}`))
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Daemon.Port != 12345 {
+		t.Errorf("port not loaded: %d", cfg.Daemon.Port)
+	}
+	if cfg.Relay.URL == "" || cfg.Image.MaxBytes != DefaultImageMaxByte {
+		t.Errorf("missing fields not defaulted: %+v", cfg)
+	}
+}
+
+func TestLoadInvalidJSON(t *testing.T) {
+	p := testutil.Sandbox(t)
+	testutil.WriteFile(t, p.Config, []byte("{bad"))
+	if _, err := Load(p); err == nil {
+		t.Error("invalid config should error")
+	}
+}
+
+func TestRequire(t *testing.T) {
+	p := testutil.Sandbox(t)
+	_, err := Require(p)
+	var ye *errs.Error
+	if e, ok := err.(*errs.Error); ok {
+		ye = e
+	}
+	if ye == nil || ye.Code != errs.CodeConfigInvalid {
+		t.Fatalf("Require on missing config should be CONFIG_INVALID, got %v", err)
+	}
+	if err := Save(p, Default(p.Credentials)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Require(p); err != nil {
+		t.Errorf("Require after save should succeed: %v", err)
+	}
+}
+
+func TestToMapAndLoadMergedMap(t *testing.T) {
+	p := testutil.Sandbox(t)
+	if err := Save(p, Default(p.Credentials)); err != nil {
+		t.Fatal(err)
+	}
+	m, err := LoadMergedMap(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := GetByPath(m, "daemon.port"); !ok {
+		t.Error("merged map should contain daemon.port")
+	}
+	direct := ToMap(Default(p.Credentials))
+	if _, ok := direct["relay"]; !ok {
+		t.Error("ToMap should contain relay section")
+	}
+}
+
+func TestLoadRawAndSaveRaw(t *testing.T) {
+	p := testutil.Sandbox(t)
+	// 缺文件时 LoadRaw 返回默认 map
+	m, err := LoadRaw(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	SetByPath(m, "daemon.port", float64(20002))
+	if err := SaveRaw(p, m); err != nil {
+		t.Fatal(err)
+	}
+	reloaded, err := LoadRaw(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v, _ := GetByPath(reloaded, "daemon.port"); v != float64(20002) {
+		t.Errorf("SaveRaw/LoadRaw round trip failed: %v", v)
+	}
+}
+
+func TestMask(t *testing.T) {
+	t.Parallel()
+	m := map[string]any{
+		"auth": map[string]any{"tokenRef": "inline:supersecret"},
+		"lightRules": map[string]any{
+			"evaluator": map[string]any{"webhookSecretRef": "file:/c.json#x"},
+		},
+	}
+	masked := Mask(m)
+	if v, _ := GetByPath(masked, "auth.tokenRef"); v != "inline:****" {
+		t.Errorf("inline secret should be masked: %v", v)
+	}
+	// file: 引用不遮罩
+	if v, _ := GetByPath(masked, "lightRules.evaluator.webhookSecretRef"); v != "file:/c.json#x" {
+		t.Errorf("file ref should not be masked: %v", v)
+	}
+	// 原 map 不被改动
+	if v, _ := GetByPath(m, "auth.tokenRef"); v != "inline:supersecret" {
+		t.Error("Mask must not mutate input")
+	}
+}

--- a/internal/config/dotpath_test.go
+++ b/internal/config/dotpath_test.go
@@ -1,0 +1,117 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetByPath(t *testing.T) {
+	t.Parallel()
+	obj := map[string]any{
+		"daemon": map[string]any{"port": 8080.0},
+		"top":    "v",
+	}
+	tests := []struct {
+		path   string
+		want   any
+		wantOK bool
+	}{
+		{"top", "v", true},
+		{"daemon.port", 8080.0, true},
+		{"daemon.missing", nil, false},
+		{"nope.deep", nil, false},
+		{"top.deeper", nil, false}, // top 是字符串，不能继续下钻
+	}
+	for _, tt := range tests {
+		got, ok := GetByPath(obj, tt.path)
+		if ok != tt.wantOK || (ok && !reflect.DeepEqual(got, tt.want)) {
+			t.Errorf("GetByPath(%q) = (%v,%v), want (%v,%v)", tt.path, got, ok, tt.want, tt.wantOK)
+		}
+	}
+}
+
+func TestSetByPathCreatesIntermediate(t *testing.T) {
+	t.Parallel()
+	obj := map[string]any{}
+	SetByPath(obj, "a.b.c", 42)
+	got, ok := GetByPath(obj, "a.b.c")
+	if !ok || got != 42 {
+		t.Fatalf("SetByPath did not create nested value: %+v", obj)
+	}
+}
+
+func TestSetByPathOverwrites(t *testing.T) {
+	t.Parallel()
+	obj := map[string]any{"a": map[string]any{"b": "old"}}
+	SetByPath(obj, "a.b", "new")
+	got, _ := GetByPath(obj, "a.b")
+	if got != "new" {
+		t.Errorf("overwrite failed: %v", got)
+	}
+}
+
+func TestUnsetByPath(t *testing.T) {
+	t.Parallel()
+	obj := map[string]any{"a": map[string]any{"b": 1, "c": 2}}
+	if !UnsetByPath(obj, "a.b") {
+		t.Error("UnsetByPath should report removal")
+	}
+	if _, ok := GetByPath(obj, "a.b"); ok {
+		t.Error("a.b should be gone")
+	}
+	if _, ok := GetByPath(obj, "a.c"); !ok {
+		t.Error("a.c should remain")
+	}
+	if UnsetByPath(obj, "a.missing") {
+		t.Error("removing nonexistent key should report false")
+	}
+	if UnsetByPath(obj, "x.y") {
+		t.Error("removing through nonexistent parent should report false")
+	}
+}
+
+func TestCoerceValue(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		path    string
+		raw     string
+		want    any
+		wantErr bool
+	}{
+		{"daemon.port", "8080", 8080.0, false},
+		{"daemon.port", "abc", nil, true},
+		{"daemon.detach", "true", true, false},
+		{"daemon.detach", "false", false, false},
+		{"daemon.detach", "yes", nil, true},
+		{"notification.ignoredApps", "a, b ,,c", []any{"a", "b", "c"}, false},
+		{"notification.retentionDays", "", nil, false},
+		{"notification.retentionDays", "null", nil, false},
+		{"some.unknown.path", "raw-string", "raw-string", false},
+	}
+	for _, tt := range tests {
+		got, err := CoerceValue(tt.path, tt.raw)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("CoerceValue(%q,%q) expected error", tt.path, tt.raw)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("CoerceValue(%q,%q) unexpected error: %v", tt.path, tt.raw, err)
+			continue
+		}
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("CoerceValue(%q,%q) = %#v, want %#v", tt.path, tt.raw, got, tt.want)
+		}
+	}
+}
+
+func TestDeepCloneMapIsolation(t *testing.T) {
+	t.Parallel()
+	src := map[string]any{"a": map[string]any{"b": 1}}
+	clone := deepCloneMap(src)
+	SetByPath(clone, "a.b", 999)
+	if got, _ := GetByPath(src, "a.b"); got != 1 {
+		t.Errorf("clone mutation leaked into source: %v", got)
+	}
+}

--- a/internal/creds/keychain_seam.go
+++ b/internal/creds/keychain_seam.go
@@ -1,0 +1,12 @@
+package creds
+
+import "github.com/YoooClaw/cli/internal/keychain"
+
+// keychain seam —— 生产指向真实 keychain 包；测试通过替换这些函数变量来注入
+// 假后端，从而在任意平台（含无钥匙串的 CI）确定性地覆盖 keychain 分支，
+// 且绝不触碰真实系统钥匙串。见 *_test.go 中的 withFakeKeychain。
+var (
+	keychainAvailableFn = keychain.Available
+	keychainGetFn       = keychain.Get
+	keychainSetFn       = keychain.Set
+)

--- a/internal/creds/refs.go
+++ b/internal/creds/refs.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/YoooClaw/cli/internal/errs"
 	"github.com/YoooClaw/cli/internal/fsutil"
-	"github.com/YoooClaw/cli/internal/keychain"
 )
 
 // ResolvedRef 是 ref 解析结果。
@@ -83,7 +82,7 @@ func ResolveRef(ref string) (ResolvedRef, error) {
 		if err != nil {
 			return ResolvedRef{}, err
 		}
-		r := keychain.Get(service, account)
+		r := keychainGetFn(service, account)
 		return ResolvedRef{Source: "keychain", Value: r.Value, Location: service + "/" + account}, nil
 	case "inline":
 		decoded, _ := base64.StdEncoding.DecodeString(rest)
@@ -125,7 +124,7 @@ func WriteRef(ref, value string) (ResolvedRef, error) {
 		if err != nil {
 			return ResolvedRef{}, err
 		}
-		if !keychain.Set(service, account, value) {
+		if !keychainSetFn(service, account, value) {
 			return ResolvedRef{}, errs.New(errs.CodeKeychainUnavailable, "keychain 写入失败："+service+"/"+account).
 				WithHint("当前平台可能没有可用的 keychain 工具，请改用 file: 引用")
 		}

--- a/internal/creds/refs_test.go
+++ b/internal/creds/refs_test.go
@@ -1,0 +1,140 @@
+package creds
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/YoooClaw/cli/internal/config"
+)
+
+func TestResolveRefEnv(t *testing.T) {
+	t.Setenv("MY_TOKEN", "  secret-val  ")
+	got, err := ResolveRef("env:MY_TOKEN")
+	if err != nil || got.Source != "env" || got.Value != "secret-val" {
+		t.Errorf("env ref: %+v err=%v", got, err)
+	}
+}
+
+func TestResolveRefInline(t *testing.T) {
+	t.Parallel()
+	enc := base64.StdEncoding.EncodeToString([]byte("hello"))
+	got, err := ResolveRef("inline:" + enc)
+	if err != nil || got.Value != "hello" || got.Source != "inline" {
+		t.Errorf("inline ref: %+v err=%v", got, err)
+	}
+}
+
+func TestResolveRefFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "creds.json")
+	if err := os.WriteFile(path, []byte(`{"gatewayToken":"tok-123"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ResolveRef("file:" + path + "#gatewayToken")
+	if err != nil || got.Value != "tok-123" || got.Source != "file" {
+		t.Errorf("file ref: %+v err=%v", got, err)
+	}
+	// 缺字段 -> 空值，不报错
+	empty, err := ResolveRef("file:" + path + "#missing")
+	if err != nil || empty.Value != "" {
+		t.Errorf("missing field should be empty: %+v err=%v", empty, err)
+	}
+}
+
+func TestResolveRefErrors(t *testing.T) {
+	t.Parallel()
+	bad := []string{
+		"no-colon",
+		"file:/path/without/hash",
+		"keychain:no-slash",
+		"weird:rest",
+	}
+	for _, ref := range bad {
+		if _, err := ResolveRef(ref); err == nil {
+			t.Errorf("ResolveRef(%q) should error", ref)
+		}
+	}
+}
+
+func TestResolveRefKeychain(t *testing.T) {
+	fk := setup(t)
+	fk.store[key("svc", "acct")] = "kc-secret"
+	got, err := ResolveRef("keychain:svc/acct")
+	if err != nil || got.Value != "kc-secret" || got.Source != "keychain" {
+		t.Errorf("keychain ref: %+v err=%v", got, err)
+	}
+}
+
+func TestWriteRefFileRoundTrip(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	ref := "file:" + filepath.Join(dir, "c.json") + "#token"
+	if _, err := WriteRef(ref, "written-value"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ResolveRef(ref)
+	if err != nil || got.Value != "written-value" {
+		t.Errorf("write/resolve round trip: %+v err=%v", got, err)
+	}
+}
+
+func TestWriteRefKeychain(t *testing.T) {
+	fk := setup(t)
+	if _, err := WriteRef("keychain:svc/acct", "v1"); err != nil {
+		t.Fatal(err)
+	}
+	if fk.store[key("svc", "acct")] != "v1" {
+		t.Error("keychain write not stored")
+	}
+	// 不可用时报错
+	fk.available = false
+	if _, err := WriteRef("keychain:svc/acct", "v2"); err == nil {
+		t.Error("unavailable keychain write should error")
+	}
+}
+
+func TestWriteRefRejectsEnvInline(t *testing.T) {
+	t.Parallel()
+	if _, err := WriteRef("env:X", "v"); err == nil {
+		t.Error("env writes should be rejected")
+	}
+	if _, err := WriteRef("inline:abc", "v"); err == nil {
+		t.Error("inline writes should be rejected")
+	}
+	if _, err := WriteRef("no-colon", "v"); err == nil {
+		t.Error("malformed ref should error")
+	}
+	if _, err := WriteRef("bogus:rest", "v"); err == nil {
+		t.Error("unknown scheme should error")
+	}
+}
+
+func TestExpandHome(t *testing.T) {
+	t.Parallel()
+	home, _ := os.UserHomeDir()
+	if got := expandHome("~"); got != home {
+		t.Errorf("~ = %q, want %q", got, home)
+	}
+	if got := expandHome("~/sub"); got != filepath.Join(home, "sub") {
+		t.Errorf("~/sub = %q", got)
+	}
+	if got := expandHome("/abs"); got != "/abs" {
+		t.Errorf("abs path should be unchanged: %q", got)
+	}
+}
+
+func TestGatewayTokenHelpers(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfg := config.Config{Auth: config.AuthSection{TokenRef: "file:" + filepath.Join(dir, "c.json") + "#gatewayToken"}}
+	if _, err := WriteGatewayToken(cfg, "gw-tok"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ResolveGatewayToken(cfg)
+	if err != nil || got.Value != "gw-tok" {
+		t.Errorf("gateway token round trip: %+v err=%v", got, err)
+	}
+}

--- a/internal/creds/store.go
+++ b/internal/creds/store.go
@@ -11,7 +11,6 @@ import (
 	"github.com/YoooClaw/cli/internal/config"
 	"github.com/YoooClaw/cli/internal/errs"
 	"github.com/YoooClaw/cli/internal/fsutil"
-	"github.com/YoooClaw/cli/internal/keychain"
 	"github.com/YoooClaw/cli/internal/paths"
 )
 
@@ -172,10 +171,10 @@ func pickDefault(entries []ApiKeyEntry) *ApiKeyEntry {
 }
 
 func keychainValue() string {
-	if !keychain.Available() {
+	if !keychainAvailableFn() {
 		return ""
 	}
-	return keychain.Get(KeychainService, KeychainAPIKeyAccount).Value
+	return keychainGetFn(KeychainService, KeychainAPIKeyAccount).Value
 }
 
 func storedEntriesFromFile(data map[string]any) []storedEntry {
@@ -281,7 +280,7 @@ func SetAPIKey(key string, useKeychain bool) (ApiKeyResolution, error) {
 			return ApiKeyResolution{}, errs.New(errs.CodeKeychainMultiUnsupport,
 				"multi-key 模式不支持 --keychain；请使用文件 apiKeys[] 管理多 key")
 		}
-		if !keychain.Set(KeychainService, KeychainAPIKeyAccount, trimmed) {
+		if !keychainSetFn(KeychainService, KeychainAPIKeyAccount, trimmed) {
 			return ApiKeyResolution{}, errs.New(errs.CodeKeychainUnavailable,
 				"当前平台无法写入 keychain，请去掉 --keychain 改写共享文件")
 		}

--- a/internal/creds/store_test.go
+++ b/internal/creds/store_test.go
@@ -1,0 +1,251 @@
+package creds
+
+import (
+	"testing"
+
+	"github.com/YoooClaw/cli/internal/keychain"
+	"github.com/YoooClaw/cli/internal/paths"
+	"github.com/YoooClaw/cli/internal/testutil"
+)
+
+// fakeKeychain 是内存假钥匙串，避免测试触碰真实系统钥匙串。
+type fakeKeychain struct {
+	available bool
+	store     map[string]string
+}
+
+func key(service, account string) string { return service + "/" + account }
+
+// setup 隔离 YOOOCLAW_HOME 并安装一个默认空、可用的假钥匙串，返回它以便断言/预置。
+// 因为改写包级 seam 变量，使用 setup 的测试不可 t.Parallel()。
+func setup(t *testing.T) *fakeKeychain {
+	t.Helper()
+	testutil.Sandbox(t)
+	fk := &fakeKeychain{available: true, store: map[string]string{}}
+	oldA, oldG, oldS := keychainAvailableFn, keychainGetFn, keychainSetFn
+	keychainAvailableFn = func() bool { return fk.available }
+	keychainGetFn = func(service, account string) keychain.Result {
+		return keychain.Result{Available: fk.available, Value: fk.store[key(service, account)]}
+	}
+	keychainSetFn = func(service, account, value string) bool {
+		if !fk.available {
+			return false
+		}
+		fk.store[key(service, account)] = value
+		return true
+	}
+	t.Cleanup(func() {
+		keychainAvailableFn, keychainGetFn, keychainSetFn = oldA, oldG, oldS
+	})
+	return fk
+}
+
+func TestIsValidAPIKeyLabel(t *testing.T) {
+	t.Parallel()
+	valid := []string{"work", "key-1", "a", "x123"}
+	for _, l := range valid {
+		if !IsValidAPIKeyLabel(l) {
+			t.Errorf("%q should be valid", l)
+		}
+	}
+	invalid := []string{"", "ALL", "all", "legacy", "env", "keychain", "local", "Has Space", "tooooooooooooooooooooooooooooooong-label"}
+	for _, l := range invalid {
+		if IsValidAPIKeyLabel(l) {
+			t.Errorf("%q should be invalid", l)
+		}
+	}
+	if AssertValidAPIKeyLabel("all") == nil {
+		t.Error("AssertValidAPIKeyLabel(all) should error")
+	}
+	if AssertValidAPIKeyLabel("ok") != nil {
+		t.Error("AssertValidAPIKeyLabel(ok) should pass")
+	}
+}
+
+func TestMaskSecret(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"":                 "",
+		"short":            "***",
+		"12345678":         "***",
+		"sk-1234567890abcd": "sk-1***abcd",
+	}
+	for in, want := range cases {
+		if got := MaskSecret(in); got != want {
+			t.Errorf("MaskSecret(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestGenerateToken(t *testing.T) {
+	t.Parallel()
+	a := GenerateToken(16)
+	if len(a) != 32 { // 16 bytes -> 32 hex chars
+		t.Errorf("token len = %d", len(a))
+	}
+	if GenerateToken(0) == a {
+		t.Error("tokens should differ / default length applies")
+	}
+	if len(GenerateToken(0)) != 64 {
+		t.Error("default token should be 32 bytes (64 hex)")
+	}
+}
+
+func TestSetAndResolveAPIKeyFile(t *testing.T) {
+	setup(t)
+	res, err := SetAPIKey("sk-file-key-123456", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Source != "file" || res.Label != "default" {
+		t.Errorf("set result: %+v", res)
+	}
+	got := ResolveAPIKey()
+	if got.Value != "sk-file-key-123456" || got.Source != "file" {
+		t.Errorf("resolve: %+v", got)
+	}
+}
+
+func TestSetAPIKeyEmpty(t *testing.T) {
+	setup(t)
+	if _, err := SetAPIKey("   ", false); err == nil {
+		t.Error("empty key should error")
+	}
+}
+
+func TestSetAPIKeyKeychain(t *testing.T) {
+	fk := setup(t)
+	res, err := SetAPIKey("sk-kc-abcdefgh", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Source != "keychain" {
+		t.Errorf("expected keychain source: %+v", res)
+	}
+	if fk.store[key(KeychainService, KeychainAPIKeyAccount)] != "sk-kc-abcdefgh" {
+		t.Error("key not written to fake keychain")
+	}
+	// 解析应优先 keychain（无 file apiKeys 时）
+	if got := ResolveAPIKey(); got.Source != "keychain" || got.Value != "sk-kc-abcdefgh" {
+		t.Errorf("resolve keychain: %+v", got)
+	}
+}
+
+func TestSetAPIKeyKeychainUnavailable(t *testing.T) {
+	fk := setup(t)
+	fk.available = false
+	if _, err := SetAPIKey("sk-x12345678", true); err == nil {
+		t.Error("unavailable keychain should error")
+	}
+}
+
+func TestResolveAPIKeyEnvWins(t *testing.T) {
+	setup(t)
+	t.Setenv(APIKeyEnv, "sk-env-override")
+	SetAPIKey("sk-file-key-12345678", false)
+	got := ResolveAPIKey()
+	if got.Source != "env" || got.Value != "sk-env-override" {
+		t.Errorf("env should win: %+v", got)
+	}
+}
+
+func TestAddRemoveSetDefaultMultiKey(t *testing.T) {
+	setup(t)
+	if _, err := AddAPIKey("sk-aaaa1111bbbb", "work", false, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := AddAPIKey("sk-cccc2222dddd", "home", false, false); err != nil {
+		t.Fatal(err)
+	}
+	set := ResolveAPIKeyEntries()
+	if set.Mode != "file-multi" || len(set.Entries) != 2 {
+		t.Fatalf("expected 2 file-multi entries: %+v", set)
+	}
+	// 第一条 work 默认
+	if set.DefaultEntry == nil || set.DefaultEntry.Label != "work" {
+		t.Errorf("default should be work: %+v", set.DefaultEntry)
+	}
+	// 切换默认到 home
+	if _, err := SetDefaultAPIKey("home"); err != nil {
+		t.Fatal(err)
+	}
+	if d := ResolveAPIKey(); d.Label != "home" {
+		t.Errorf("default should now be home: %+v", d)
+	}
+	// 重复 label 无 force 报错
+	if _, err := AddAPIKey("sk-eeee", "home", false, false); err == nil {
+		t.Error("duplicate label without force should error")
+	}
+	// force 覆盖
+	if _, err := AddAPIKey("sk-ffff9999gggg", "home", false, true); err != nil {
+		t.Errorf("force overwrite should succeed: %v", err)
+	}
+	// 删除 home（是默认）-> work 接任默认
+	_, removed, newDefault, err := RemoveAPIKey("home")
+	if err != nil || removed != "home" {
+		t.Fatalf("remove home: removed=%q err=%v", removed, err)
+	}
+	if newDefault != "work" {
+		t.Errorf("new default should be work, got %q", newDefault)
+	}
+}
+
+func TestAddAPIKeyInvalidInputs(t *testing.T) {
+	setup(t)
+	if _, err := AddAPIKey("", "work", false, false); err == nil {
+		t.Error("empty key should error")
+	}
+	if _, err := AddAPIKey("sk-x", "BAD LABEL", false, false); err == nil {
+		t.Error("invalid label should error")
+	}
+}
+
+func TestRemoveSetDefaultNotFound(t *testing.T) {
+	setup(t)
+	if _, _, _, err := RemoveAPIKey("ghost"); err == nil {
+		t.Error("removing missing label should error")
+	}
+	if _, err := SetDefaultAPIKey("ghost"); err == nil {
+		t.Error("set-default missing label should error")
+	}
+}
+
+func TestResolveAPIKeyNone(t *testing.T) {
+	setup(t) // 空沙箱、空假钥匙串
+	got := ResolveAPIKey()
+	if got.Source != "none" {
+		t.Errorf("expected none, got %+v", got)
+	}
+	if set := ResolveAPIKeyEntries(); set.Mode != "none" {
+		t.Errorf("expected none mode, got %q", set.Mode)
+	}
+}
+
+func TestResolveLegacyFileSingle(t *testing.T) {
+	setup(t)
+	// 直接写 legacy apiKey 字段（无 apiKeys[]）
+	testutil.WriteFile(t, paths.SharedCredentialsPath(), []byte(`{"apiKey":"sk-legacy-12345678"}`))
+	set := ResolveAPIKeyEntries()
+	if set.Mode != "legacy-file-single" || !set.LegacyAPIKeyPresent {
+		t.Errorf("expected legacy single: %+v", set)
+	}
+}
+
+func TestNormalizeStoredEntriesWarnings(t *testing.T) {
+	setup(t)
+	// 含非法/重复/空 key 条目
+	testutil.WriteFile(t, paths.SharedCredentialsPath(), []byte(`{"apiKeys":[
+		{"label":"work","key":"sk-1111aaaa"},
+		"not-an-object",
+		{"label":"BAD LABEL","key":"x"},
+		{"label":"empty","key":""},
+		{"label":"work","key":"sk-dupe"}
+	]}`))
+	set := ResolveAPIKeyEntries()
+	if len(set.Entries) != 1 || set.Entries[0].Label != "work" {
+		t.Errorf("only valid work entry should survive: %+v", set.Entries)
+	}
+	if len(set.Warnings) == 0 {
+		t.Error("expected warnings for skipped entries")
+	}
+}

--- a/internal/daemon/client_test.go
+++ b/internal/daemon/client_test.go
@@ -1,0 +1,64 @@
+package daemon
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/YoooClaw/cli/internal/errs"
+)
+
+func TestNewClientBuildsURL(t *testing.T) {
+	p := sandboxPaths(t)
+	WriteLock(p, Lock{PID: 1, Bind: "0.0.0.0", Port: 12345})
+	c := NewClient(p)
+	// 0.0.0.0 应改写成 127.0.0.1
+	if !strings.Contains(c.BaseURL, "127.0.0.1:12345") {
+		t.Errorf("base url = %q", c.BaseURL)
+	}
+}
+
+func TestClientRequestDaemonNotRunning(t *testing.T) {
+	c := &Client{BaseURL: "http://127.0.0.1:1", timeout: 1e9}
+	_, _, err := c.Request("GET", "/health", nil)
+	if e, ok := err.(*errs.Error); !ok || e.Code != errs.CodeDaemonNotRunning {
+		t.Errorf("connection refused should map to DAEMON_NOT_RUNNING, got %v", err)
+	}
+}
+
+func TestClientRequestSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer tok" {
+			t.Errorf("missing auth header: %q", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"echo":1}`))
+	}))
+	defer srv.Close()
+	c := &Client{BaseURL: srv.URL, token: "tok", timeout: 5e9}
+	status, body, err := c.Request("POST", "/x", map[string]any{"a": 1})
+	if err != nil || status != 200 {
+		t.Fatalf("request: status=%d err=%v", status, err)
+	}
+	m, ok := body.(map[string]any)
+	if !ok || m["echo"] != float64(1) {
+		t.Errorf("parsed body wrong: %+v", body)
+	}
+}
+
+func TestClientRequestUnauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(401)
+		_, _ = w.Write([]byte(`{"ok":false}`))
+	}))
+	defer srv.Close()
+	c := &Client{BaseURL: srv.URL, timeout: 5e9}
+	status, _, err := c.Request("GET", "/x", nil)
+	if status != 401 {
+		t.Errorf("status = %d", status)
+	}
+	if e, ok := err.(*errs.Error); !ok || e.Code != errs.CodeUnauthorized {
+		t.Errorf("401 should map to Unauthorized, got %v", err)
+	}
+}

--- a/internal/daemon/lock_test.go
+++ b/internal/daemon/lock_test.go
@@ -1,0 +1,77 @@
+package daemon
+
+import (
+	"os"
+	"testing"
+
+	"github.com/YoooClaw/cli/internal/paths"
+)
+
+func sandboxPaths(t *testing.T) paths.Paths {
+	t.Helper()
+	t.Setenv("YOOOCLAW_HOME", t.TempDir())
+	p := paths.For(paths.DefaultProfile)
+	if err := os.MkdirAll(p.Dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestLockRoundTrip(t *testing.T) {
+	p := sandboxPaths(t)
+	if ReadLock(p) != nil {
+		t.Fatal("no lock should exist initially")
+	}
+	if State(p).Running {
+		t.Error("no lock -> not running")
+	}
+	lock := Lock{PID: os.Getpid(), StartedAt: "2026-06-07T10:00:00Z", Bind: "127.0.0.1", Port: 18789}
+	if err := WriteLock(p, lock); err != nil {
+		t.Fatal(err)
+	}
+	got := ReadLock(p)
+	if got == nil || got.PID != os.Getpid() || got.Port != 18789 {
+		t.Fatalf("lock round trip: %+v", got)
+	}
+	// 自己的 pid 必然存活 -> Running
+	st := State(p)
+	if !st.Running || st.Stale {
+		t.Errorf("self pid should be running: %+v", st)
+	}
+	RemoveLock(p)
+	if ReadLock(p) != nil {
+		t.Error("lock should be removed")
+	}
+}
+
+func TestStateStaleLock(t *testing.T) {
+	p := sandboxPaths(t)
+	// 一个几乎不可能存活的 pid
+	if err := WriteLock(p, Lock{PID: 2147483600, Port: 1}); err != nil {
+		t.Fatal(err)
+	}
+	st := State(p)
+	if st.Running || !st.Stale {
+		t.Errorf("dead pid lock should be stale: %+v", st)
+	}
+}
+
+func TestIsProcessAlive(t *testing.T) {
+	if !IsProcessAlive(os.Getpid()) {
+		t.Error("current process should be alive")
+	}
+	if IsProcessAlive(2147483600) {
+		t.Error("absurd pid should not be alive")
+	}
+}
+
+func TestAssertRunning(t *testing.T) {
+	p := sandboxPaths(t)
+	if AssertRunning(p) == nil {
+		t.Error("no daemon -> AssertRunning should error")
+	}
+	WriteLock(p, Lock{PID: os.Getpid(), Port: 1})
+	if err := AssertRunning(p); err != nil {
+		t.Errorf("self-pid lock -> running: %v", err)
+	}
+}

--- a/internal/daemon/logger_test.go
+++ b/internal/daemon/logger_test.go
@@ -1,0 +1,68 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLoggerWritesLevels(t *testing.T) {
+	t.Parallel()
+	logFile := filepath.Join(t.TempDir(), "daemon.log")
+	l := NewLogger(logFile, "info", false)
+	l.Info("hello")
+	l.Warn("careful")
+	l.Error("boom")
+	l.Debug("verbose") // info 级别下 debug 被过滤
+
+	raw, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(raw)
+	if !strings.Contains(content, "[INFO] hello") || !strings.Contains(content, "[ERROR] boom") {
+		t.Errorf("missing expected lines: %s", content)
+	}
+	if strings.Contains(content, "verbose") {
+		t.Error("debug should be filtered at info level")
+	}
+	// 行格式应可被 logread 解析（ISO 时间 + [LEVEL]）
+	if !strings.Contains(content, "[WARN] careful") {
+		t.Errorf("warn line missing: %s", content)
+	}
+}
+
+func TestLoggerLevelDefaults(t *testing.T) {
+	t.Parallel()
+	l := NewLogger(filepath.Join(t.TempDir(), "x.log"), "", false)
+	if l.level != "info" {
+		t.Errorf("empty level should default to info, got %q", l.level)
+	}
+	if !l.enabled("error") || !l.enabled("info") {
+		t.Error("info logger should enable info/error")
+	}
+	if l.enabled("debug") {
+		t.Error("info logger should not enable debug")
+	}
+	// 未知级别按 info 处理
+	if !l.enabled("bogus") {
+		t.Error("unknown level treated as info should be enabled")
+	}
+}
+
+func TestUpperHelper(t *testing.T) {
+	t.Parallel()
+	if upper("info") != "INFO" || upper("Warn") != "WARN" {
+		t.Error("upper")
+	}
+}
+
+func TestDateKey(t *testing.T) {
+	t.Parallel()
+	d := time.Date(2026, 6, 7, 10, 0, 0, 0, time.UTC)
+	if dateKey(d) != "2026-06-07" {
+		t.Errorf("dateKey = %q", dateKey(d))
+	}
+}

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -1,0 +1,154 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/YoooClaw/cli/internal/clictx"
+	"github.com/YoooClaw/cli/internal/config"
+	"github.com/YoooClaw/cli/internal/notif"
+	"github.com/YoooClaw/cli/internal/paths"
+)
+
+// newTestServer 构造一个最小可用的 server（无 relay、token 可配）。
+func newTestServer(t *testing.T, token string) (*server, *httptest.Server) {
+	t.Helper()
+	t.Setenv("YOOOCLAW_HOME", t.TempDir())
+	p := paths.For(paths.DefaultProfile)
+	logger := NewLogger(filepath.Join(t.TempDir(), "d.log"), "info", false)
+	storage := notif.NewStorage(p.Notifications, notif.PluginConfig{}, logger)
+	if err := storage.Init(); err != nil {
+		t.Fatal(err)
+	}
+	srv := &server{
+		ctx:               &clictx.Context{Profile: "default", Paths: p},
+		cfg:               config.Default(p.Credentials),
+		logger:            logger,
+		st:                &runtimeState{startedAt: "2026-06-07T10:00:00Z"},
+		storage:           storage,
+		recordingInFlight: map[string]time.Time{},
+		token:             token,
+		ignored:           map[string]bool{"com.spam.app": true},
+		bind:              "127.0.0.1",
+		port:              18789,
+	}
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+	return srv, ts
+}
+
+func TestServerHealth(t *testing.T) {
+	_, ts := newTestServer(t, "")
+	resp, err := http.Get(ts.URL + "/health")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var body map[string]any
+	json.NewDecoder(resp.Body).Decode(&body)
+	if body["server"] != "yoooclaw" {
+		t.Errorf("health body: %+v", body)
+	}
+}
+
+func TestServerStatusNoToken(t *testing.T) {
+	_, ts := newTestServer(t, "")
+	resp, err := http.Get(ts.URL + "/daemon/status")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var body map[string]any
+	json.NewDecoder(resp.Body).Decode(&body)
+	if body["ok"] != true || body["server"] != "yoooclaw" {
+		t.Errorf("status body: %+v", body)
+	}
+	if body["relay"].(map[string]any)["mode"] != "standalone-http" {
+		t.Errorf("expected standalone-http relay mode: %+v", body["relay"])
+	}
+}
+
+func TestServerAuthRequired(t *testing.T) {
+	_, ts := newTestServer(t, "secret-token")
+	// 无 token -> 401（status 不是 ingest 路径，token 非空）
+	resp, err := http.Get(ts.URL + "/daemon/status")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 401 {
+		t.Errorf("expected 401 without token, got %d", resp.StatusCode)
+	}
+	// 带正确 token -> 200
+	req, _ := http.NewRequest("GET", ts.URL+"/daemon/status", nil)
+	req.Header.Set("Authorization", "Bearer secret-token")
+	resp2, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != 200 {
+		t.Errorf("expected 200 with token, got %d", resp2.StatusCode)
+	}
+}
+
+func TestServerIngestNotifications(t *testing.T) {
+	srv, ts := newTestServer(t, "")
+	payload := `{"notifications":[
+		{"id":"1","app":"wechat","title":"t","body":"b","timestamp":"2026-06-07T10:00:00+08:00"},
+		{"id":"2","app":"com.spam.app","title":"spam","body":"x","timestamp":"2026-06-07T10:00:00+08:00"}
+	]}`
+	resp, err := http.Post(ts.URL+"/notifications", "application/json", strings.NewReader(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var body map[string]any
+	json.NewDecoder(resp.Body).Decode(&body)
+	// 第二条命中 ignoredApps，应被过滤；只 ingest 1 条
+	if body["ingested"] != float64(1) {
+		t.Errorf("expected 1 ingested (spam filtered): %+v", body)
+	}
+	if srv.st.ingestCount != 1 {
+		t.Errorf("runtime ingest count = %d", srv.st.ingestCount)
+	}
+}
+
+func TestServerNotFound(t *testing.T) {
+	_, ts := newTestServer(t, "")
+	resp, err := http.Get(ts.URL + "/no/such/path")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 404 {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestServerHelpers(t *testing.T) {
+	t.Parallel()
+	if firstNonEmptyStr("", "", "x", "y") != "x" {
+		t.Error("firstNonEmptyStr")
+	}
+	if nilIfEmptyStr("") != nil || nilIfEmptyStr("a") != "a" {
+		t.Error("nilIfEmptyStr")
+	}
+	if !isIngestPath("/notifications") || isIngestPath("/daemon/status") {
+		t.Error("isIngestPath")
+	}
+	r, _ := http.NewRequest("GET", "/", nil)
+	r.Header.Set("Authorization", "Bearer abc")
+	if bearerValue(r) != "abc" {
+		t.Error("bearerValue")
+	}
+	r.Header.Set("Authorization", "Basic xyz")
+	if bearerValue(r) != "" {
+		t.Error("non-bearer should be empty")
+	}
+}

--- a/internal/errs/errors_test.go
+++ b/internal/errs/errors_test.go
@@ -1,0 +1,67 @@
+package errs
+
+import "testing"
+
+func TestNewDefaults(t *testing.T) {
+	t.Parallel()
+	e := New(CodeInvalidArgument, "bad arg")
+	if e.Code != CodeInvalidArgument {
+		t.Errorf("code = %q, want %q", e.Code, CodeInvalidArgument)
+	}
+	if e.Error() != "bad arg" {
+		t.Errorf("Error() = %q, want %q", e.Error(), "bad arg")
+	}
+	if e.ExitCode != 1 {
+		t.Errorf("ExitCode = %d, want 1", e.ExitCode)
+	}
+	if e.Details == nil {
+		t.Error("Details should be non-nil empty map")
+	}
+}
+
+func TestNewWithDetails(t *testing.T) {
+	t.Parallel()
+	e := New(CodeNotFound, "missing", map[string]any{"id": "rec_1"})
+	if e.Details["id"] != "rec_1" {
+		t.Errorf("Details[id] = %v, want rec_1", e.Details["id"])
+	}
+}
+
+func TestNewf(t *testing.T) {
+	t.Parallel()
+	e := Newf(CodeInvalidArgument, "want %s got %d", "num", 7)
+	if e.Message != "want num got 7" {
+		t.Errorf("Message = %q", e.Message)
+	}
+}
+
+func TestWithHint(t *testing.T) {
+	t.Parallel()
+	e := New(CodeInvalidArgument, "x").WithHint("try --help")
+	if e.Details["hint"] != "try --help" {
+		t.Errorf("hint = %v, want 'try --help'", e.Details["hint"])
+	}
+}
+
+func TestPayloadFlattensDetails(t *testing.T) {
+	t.Parallel()
+	e := New(CodeNotFound, "missing", map[string]any{"id": "rec_1"}).WithHint("check id")
+	p := e.Payload()
+	if p["code"] != CodeNotFound || p["message"] != "missing" {
+		t.Errorf("payload core mismatch: %+v", p)
+	}
+	if p["id"] != "rec_1" || p["hint"] != "check id" {
+		t.Errorf("payload should flatten details: %+v", p)
+	}
+}
+
+func TestNotImplemented(t *testing.T) {
+	t.Parallel()
+	e := NotImplemented("foo bar")
+	if e.Code != CodeNotImplemented {
+		t.Errorf("code = %q", e.Code)
+	}
+	if e.Details["hint"] == "" {
+		t.Error("NotImplemented should carry a hint")
+	}
+}

--- a/internal/fsutil/fsutil_test.go
+++ b/internal/fsutil/fsutil_test.go
@@ -1,0 +1,204 @@
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/YoooClaw/cli/internal/errs"
+)
+
+func TestEnsureDir(t *testing.T) {
+	t.Parallel()
+	dir := filepath.Join(t.TempDir(), "a", "b")
+	if err := EnsureDir(dir, 0); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		t.Fatalf("dir not created: %v", err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != DirMode {
+		t.Errorf("dir mode = %v, want %v", info.Mode().Perm(), DirMode)
+	}
+	// 幂等
+	if err := EnsureDir(dir, DirMode); err != nil {
+		t.Fatalf("second EnsureDir: %v", err)
+	}
+}
+
+func TestWriteAtomicAndExists(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "sub", "secret")
+	if Exists(path) {
+		t.Fatal("should not exist yet")
+	}
+	if err := WriteAtomic(path, []byte("data"), 0); err != nil {
+		t.Fatal(err)
+	}
+	if !Exists(path) {
+		t.Fatal("should exist after write")
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != "data" {
+		t.Errorf("content = %q", got)
+	}
+	// 确认没有遗留临时文件
+	entries, _ := os.ReadDir(filepath.Dir(path))
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".tmp" {
+			t.Errorf("leftover tmp file: %s", e.Name())
+		}
+	}
+}
+
+func TestWriteJSONReadJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "c.json")
+	in := map[string]any{"name": "x", "n": float64(3)}
+	if err := WriteJSON(path, in, SecretFileMode); err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := os.ReadFile(path)
+	if raw[len(raw)-1] != '\n' {
+		t.Error("WriteJSON should append trailing newline")
+	}
+	var out map[string]any
+	exists, err := ReadJSON(path, &out)
+	if err != nil || !exists {
+		t.Fatalf("ReadJSON existing: exists=%v err=%v", exists, err)
+	}
+	if out["name"] != "x" || out["n"] != float64(3) {
+		t.Errorf("round trip mismatch: %+v", out)
+	}
+}
+
+func TestReadJSONMissing(t *testing.T) {
+	t.Parallel()
+	var out map[string]any
+	exists, err := ReadJSON(filepath.Join(t.TempDir(), "nope.json"), &out)
+	if exists || err != nil {
+		t.Errorf("missing file -> (false,nil), got (%v,%v)", exists, err)
+	}
+}
+
+func TestReadJSONInvalid(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "bad.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]any
+	exists, err := ReadJSON(path, &out)
+	if !exists {
+		t.Error("invalid file should report exists=true")
+	}
+	var ye *errs.Error
+	if e, ok := err.(*errs.Error); ok {
+		ye = e
+	}
+	if ye == nil || ye.Code != errs.CodeConfigInvalid {
+		t.Errorf("want CONFIG_INVALID, got %v", err)
+	}
+}
+
+func TestCopyDir(t *testing.T) {
+	t.Parallel()
+	src := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(src, "nested"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "a.txt"), []byte("A"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "nested", "b.txt"), []byte("B"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(t.TempDir(), "copy")
+	if err := CopyDir(src, dst); err != nil {
+		t.Fatal(err)
+	}
+	a, _ := os.ReadFile(filepath.Join(dst, "a.txt"))
+	b, _ := os.ReadFile(filepath.Join(dst, "nested", "b.txt"))
+	if string(a) != "A" || string(b) != "B" {
+		t.Errorf("copied content mismatch: %q %q", a, b)
+	}
+}
+
+func TestWriteJSONMarshalError(t *testing.T) {
+	t.Parallel()
+	// channel 无法 JSON 序列化，应返回错误且不创建文件。
+	path := filepath.Join(t.TempDir(), "x.json")
+	if err := WriteJSON(path, make(chan int), 0); err == nil {
+		t.Error("expected marshal error")
+	}
+	if Exists(path) {
+		t.Error("file should not be created on marshal error")
+	}
+}
+
+func TestWriteAtomicDirCreateFails(t *testing.T) {
+	t.Parallel()
+	// 在一个普通文件下面建子路径，EnsureDir 会失败。
+	blocker := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteAtomic(filepath.Join(blocker, "child", "f"), []byte("y"), 0); err == nil {
+		t.Error("expected error writing under a file path")
+	}
+}
+
+func TestReadJSONReadError(t *testing.T) {
+	t.Parallel()
+	// 把目录当文件读，os.ReadFile 返回非 NotExist 错误。
+	dir := t.TempDir()
+	var out map[string]any
+	exists, err := ReadJSON(dir, &out)
+	if err == nil {
+		t.Error("reading a directory should error")
+	}
+	_ = exists
+}
+
+func TestCopyDirSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on windows")
+	}
+	t.Parallel()
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "target"), []byte("T"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("target", filepath.Join(src, "link")); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(t.TempDir(), "copy")
+	if err := CopyDir(src, dst); err != nil {
+		t.Fatal(err)
+	}
+	link, err := os.Readlink(filepath.Join(dst, "link"))
+	if err != nil || link != "target" {
+		t.Errorf("symlink not preserved: %q err=%v", link, err)
+	}
+}
+
+func TestCopyDirMissingSource(t *testing.T) {
+	t.Parallel()
+	if err := CopyDir(filepath.Join(t.TempDir(), "nope"), t.TempDir()); err == nil {
+		t.Error("copying missing source should error")
+	}
+}
+
+func TestCountFiles(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	os.MkdirAll(filepath.Join(root, "d1"), 0o700)
+	os.WriteFile(filepath.Join(root, "f1"), []byte("x"), 0o600)
+	os.WriteFile(filepath.Join(root, "d1", "f2"), []byte("y"), 0o600)
+	// 条目：d1, f1, d1/f2 = 3
+	if got := CountFiles(root); got != 3 {
+		t.Errorf("CountFiles = %d, want 3", got)
+	}
+}

--- a/internal/image/extra_test.go
+++ b/internal/image/extra_test.go
@@ -1,0 +1,30 @@
+package image
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveFile(t *testing.T) {
+	t.Parallel()
+	if got := ResolveFile("/imgs", "a/b.png"); got != filepath.Join("/imgs", "a/b.png") {
+		t.Errorf("relative resolve = %q", got)
+	}
+	abs := filepath.Join(t.TempDir(), "x.png")
+	if got := ResolveFile("/imgs", abs); got != abs {
+		t.Errorf("absolute path should be returned as-is: %q", got)
+	}
+}
+
+func TestSortByCreatedDesc(t *testing.T) {
+	t.Parallel()
+	entries := []Entry{
+		{ImageID: "a", Metadata: Metadata{CreatedAt: "2026-06-01T00:00:00Z"}},
+		{ImageID: "b", Metadata: Metadata{CreatedAt: "2026-06-03T00:00:00Z"}},
+		{ImageID: "c", Metadata: Metadata{CreatedAt: "2026-06-02T00:00:00Z"}},
+	}
+	SortByCreatedDesc(entries)
+	if entries[0].ImageID != "b" || entries[1].ImageID != "c" || entries[2].ImageID != "a" {
+		t.Errorf("sort order wrong: %v", []string{entries[0].ImageID, entries[1].ImageID, entries[2].ImageID})
+	}
+}

--- a/internal/keychain/keychain_integration_test.go
+++ b/internal/keychain/keychain_integration_test.go
@@ -1,0 +1,23 @@
+//go:build keychain_integration
+
+// 该文件含会真正写入系统钥匙串的破坏性用例，默认不跑。
+// 本地手动验证：go test -tags=keychain_integration ./internal/keychain/...
+// （macOS 上首次可能弹出钥匙串授权对话框。）
+package keychain
+
+import "testing"
+
+func TestSetGetRoundTrip(t *testing.T) {
+	if !Available() {
+		t.Skip("keychain backend not available on this host")
+	}
+	const service = "yoooclaw-integration-test"
+	const account = "round-trip"
+	if !Set(service, account, "integration-value") {
+		t.Fatal("Set should succeed when keychain is available")
+	}
+	got := Get(service, account)
+	if !got.Available || got.Value != "integration-value" {
+		t.Fatalf("round trip mismatch: %+v", got)
+	}
+}

--- a/internal/keychain/keychain_test.go
+++ b/internal/keychain/keychain_test.go
@@ -1,0 +1,48 @@
+package keychain
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestHasCommand(t *testing.T) {
+	t.Parallel()
+	// "go" 一定存在于运行测试的环境。
+	if !hasCommand("go") {
+		t.Error("hasCommand(go) should be true in a Go test env")
+	}
+	if hasCommand("definitely-not-a-real-command-xyz") {
+		t.Error("nonexistent command should report false")
+	}
+}
+
+func TestAvailable(t *testing.T) {
+	t.Parallel()
+	// 仅断言不 panic 且与平台逻辑一致；具体真假取决于运行环境。
+	got := Available()
+	switch runtime.GOOS {
+	case "darwin":
+		if got != hasCommand("security") {
+			t.Errorf("darwin Available mismatch: %v", got)
+		}
+	case "linux":
+		if got != hasCommand("secret-tool") {
+			t.Errorf("linux Available mismatch: %v", got)
+		}
+	default:
+		if got {
+			t.Errorf("non darwin/linux should be unavailable, got %v", got)
+		}
+	}
+}
+
+func TestGetNonexistentIsSafe(t *testing.T) {
+	t.Parallel()
+	// 读一个极不可能存在的条目：只读、不写，安全。
+	res := Get("yoooclaw-unit-test-service-nope", "no-such-account-xyz")
+	if res.Value != "" {
+		t.Errorf("nonexistent entry should yield empty value, got %q", res.Value)
+	}
+	// Available 字段应与平台 keychain 工具是否存在一致（不强断真假）。
+	_ = res.Available
+}

--- a/internal/light/env_test.go
+++ b/internal/light/env_test.go
@@ -1,0 +1,54 @@
+package light
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeHost(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"":                            "",
+		"  example.com  ":             "example.com",
+		"https://example.com":         "example.com",
+		"wss://example.com/":          "example.com",
+		"http://example.com///":       "example.com",
+	}
+	for in, want := range cases {
+		if got := normalizeHost(in); got != want {
+			t.Errorf("normalizeHost(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestLoadEnvName(t *testing.T) {
+	t.Setenv("PHONE_NOTIFICATIONS_ENV", "test")
+	if loadEnvName() != "test" {
+		t.Error("should read test env")
+	}
+	t.Setenv("PHONE_NOTIFICATIONS_ENV", "bogus")
+	if loadEnvName() != "production" {
+		t.Error("unknown env should fall back to production")
+	}
+}
+
+func TestEnvHostOverrideAndDefault(t *testing.T) {
+	t.Setenv("PHONE_NOTIFICATIONS_ENV", "development")
+	t.Setenv("OPENCLAW_HOST_DEVELOPMENT", "https://dev.override.test/")
+	if got := envHost(); got != "dev.override.test" {
+		t.Errorf("override host = %q", got)
+	}
+	t.Setenv("OPENCLAW_HOST_DEVELOPMENT", "")
+	if got := envHost(); got != defaultEnvHosts["development"] {
+		t.Errorf("default dev host = %q", got)
+	}
+}
+
+func TestLightAPIURL(t *testing.T) {
+	t.Setenv("PHONE_NOTIFICATIONS_ENV", "production")
+	t.Setenv("OPENCLAW_HOST_PRODUCTION", "")
+	url := LightAPIURL()
+	if !strings.HasPrefix(url, "https://") || !strings.HasSuffix(url, "/api/message/tob/sendMessage") {
+		t.Errorf("LightAPIURL = %q", url)
+	}
+}

--- a/internal/light/sender_test.go
+++ b/internal/light/sender_test.go
@@ -1,0 +1,105 @@
+package light
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRepeatInputFromAny(t *testing.T) {
+	t.Parallel()
+	in := RepeatInputFromAny(true, 3.0)
+	if in.Repeat == nil || !*in.Repeat || in.RepeatTimes == nil || *in.RepeatTimes != 3 {
+		t.Errorf("RepeatInputFromAny full: %+v", in)
+	}
+	empty := RepeatInputFromAny("not-bool", "not-num")
+	if empty.Repeat != nil || empty.RepeatTimes != nil {
+		t.Errorf("non-typed values should be nil: %+v", empty)
+	}
+}
+
+func TestLookupPreset(t *testing.T) {
+	t.Parallel()
+	presets := Presets()
+	if len(presets) == 0 {
+		t.Skip("no presets embedded")
+	}
+	first := presets[0].PresetID
+	got, ok := LookupPreset(first)
+	if !ok || got.PresetID != first {
+		t.Errorf("LookupPreset(%q) failed", first)
+	}
+	if _, ok := LookupPreset("no-such-preset"); ok {
+		t.Error("missing preset should return false")
+	}
+}
+
+func TestResolveLightTitle(t *testing.T) {
+	t.Parallel()
+	if got := resolveLightTitle("  My Title ", "reason", nil); got != "My Title" {
+		t.Errorf("explicit title should win: %q", got)
+	}
+	if got := resolveLightTitle("", "  Reason ", nil); got != "Reason" {
+		t.Errorf("reason fallback: %q", got)
+	}
+	segs := []map[string]any{{"mode": "wave"}, {"mode": "steady"}}
+	if got := resolveLightTitle("", "", segs); got != "Effect: wave+steady" {
+		t.Errorf("mode-derived title: %q", got)
+	}
+	if got := resolveLightTitle("", "", []map[string]any{{}}); got != "Effect: custom" {
+		t.Errorf("empty modes title: %q", got)
+	}
+}
+
+func TestTruncateAndMaskKey(t *testing.T) {
+	t.Parallel()
+	if truncate("short", 10) != "short" {
+		t.Error("short string unchanged")
+	}
+	if got := truncate("0123456789", 4); got != "0123…" {
+		t.Errorf("truncate = %q", got)
+	}
+	if maskKey("") != "EMPTY" {
+		t.Error("empty key -> EMPTY")
+	}
+	if maskKey("abcdefghijklmnopqrstuvwxyz") != truncate("abcdefghijklmnopqrstuvwxyz", 20) {
+		t.Error("maskKey should truncate to 20")
+	}
+}
+
+func TestNewUUID(t *testing.T) {
+	t.Parallel()
+	u := newUUID()
+	if len(u) != 36 || strings.Count(u, "-") != 4 {
+		t.Errorf("uuid format wrong: %q", u)
+	}
+	if u[14] != '4' {
+		t.Errorf("uuid version nibble should be 4: %q", u)
+	}
+	if newUUID() == u {
+		t.Error("uuids should be unique")
+	}
+}
+
+func TestSendLightEffectConnectionError(t *testing.T) {
+	// 指向一个会被拒绝的端口，覆盖 SendLightEffect 的请求构建与错误返回路径。
+	t.Setenv("PHONE_NOTIFICATIONS_ENV", "production")
+	t.Setenv("OPENCLAW_HOST_PRODUCTION", "127.0.0.1:1")
+	segs := []map[string]any{{"mode": "steady", "brightness": 100.0, "color": color(255, 0, 0)}}
+	res := SendLightEffect("test-key", segs, RepeatInput{}, "reason", "title", nil)
+	if res.OK {
+		t.Error("connection to refused port should fail")
+	}
+	if res.Error == "" {
+		t.Error("expected an error message")
+	}
+}
+
+func TestSendLightEffectBadBody(t *testing.T) {
+	t.Setenv("PHONE_NOTIFICATIONS_ENV", "production")
+	t.Setenv("OPENCLAW_HOST_PRODUCTION", "127.0.0.1:1")
+	// 空 segments 会让 BuildLightEffectApnsBody 报错（编码前置校验）。
+	res := SendLightEffect("k", nil, RepeatInput{}, "r", "t", nil)
+	if res.OK {
+		t.Error("empty segments should fail body build or send")
+	}
+}

--- a/internal/light/validators_test.go
+++ b/internal/light/validators_test.go
@@ -1,0 +1,187 @@
+package light
+
+import "testing"
+
+func color(r, g, b float64) map[string]any {
+	return map[string]any{"r": r, "g": g, "b": b}
+}
+
+func TestValidateSegmentsTopLevel(t *testing.T) {
+	t.Parallel()
+	if ValidateSegments("not-array").Valid {
+		t.Error("non-array should be invalid")
+	}
+	if ValidateSegments([]any{}).Valid {
+		t.Error("empty should be invalid")
+	}
+	tooMany := make([]any, MaxSegments+1)
+	for i := range tooMany {
+		tooMany[i] = map[string]any{"mode": "steady", "brightness": 100.0, "color": color(1, 1, 1)}
+	}
+	if ValidateSegments(tooMany).Valid {
+		t.Error("over MaxSegments should be invalid")
+	}
+}
+
+func TestValidateSegmentsValidSteady(t *testing.T) {
+	t.Parallel()
+	res := ValidateSegments([]any{
+		map[string]any{"mode": "steady", "brightness": 200.0, "color": color(255, 0, 0), "duration_s": 5.0},
+	})
+	if !res.Valid {
+		t.Fatalf("valid steady should pass: %+v", res.Errors)
+	}
+	if len(res.Segments) != 1 {
+		t.Errorf("expected 1 normalized segment")
+	}
+}
+
+func TestValidateSegmentInvalidMode(t *testing.T) {
+	t.Parallel()
+	res := ValidateSegments([]any{map[string]any{"mode": "disco", "brightness": 1.0, "color": color(1, 1, 1)}})
+	if res.Valid {
+		t.Error("unsupported mode should fail")
+	}
+}
+
+func TestValidateSegmentNotObject(t *testing.T) {
+	t.Parallel()
+	if ValidateSegments([]any{"nope"}).Valid {
+		t.Error("non-object segment should fail")
+	}
+}
+
+func TestValidateForegroundBrightnessZero(t *testing.T) {
+	t.Parallel()
+	// brightness=0 on non-steady should fail
+	res := ValidateSegments([]any{map[string]any{"mode": "wave", "brightness": 0.0, "color": color(10, 10, 10)}})
+	if res.Valid {
+		t.Error("brightness=0 on wave should fail")
+	}
+	// brightness=0 on steady is allowed
+	ok := ValidateSegments([]any{map[string]any{"mode": "steady", "brightness": 0.0, "color": color(10, 10, 10), "duration_s": 0.0}})
+	if !ok.Valid {
+		t.Errorf("brightness=0 on steady should pass: %+v", ok.Errors)
+	}
+}
+
+func TestValidateColorAndRanges(t *testing.T) {
+	t.Parallel()
+	bad := ValidateSegments([]any{map[string]any{"mode": "steady", "brightness": 300.0, "color": color(999, -1, 0)}})
+	if bad.Valid {
+		t.Error("out-of-range brightness/color should fail")
+	}
+	noColor := ValidateSegments([]any{map[string]any{"mode": "steady", "brightness": 100.0, "color": "red"}})
+	if noColor.Valid {
+		t.Error("non-object color should fail")
+	}
+}
+
+func TestValidateWaveOptions(t *testing.T) {
+	t.Parallel()
+	res := ValidateSegments([]any{map[string]any{
+		"mode": "wave", "brightness": 100.0, "color": color(255, 0, 0), "duration_s": 3.0,
+		"interval_ms": 200.0, "direction": "ltr", "window": 2.0,
+		"background": map[string]any{"r": 0.0, "g": 0.0, "b": 10.0, "brightness": 50.0},
+	}})
+	if !res.Valid {
+		t.Fatalf("valid wave should pass: %+v", res.Errors)
+	}
+	// bad direction / window
+	bad := ValidateSegments([]any{map[string]any{
+		"mode": "wave", "brightness": 100.0, "color": color(1, 1, 1),
+		"direction": "up", "window": 9.0,
+	}})
+	if bad.Valid {
+		t.Error("bad direction/window should fail")
+	}
+}
+
+func TestValidateBreathTiming(t *testing.T) {
+	t.Parallel()
+	ok := ValidateSegments([]any{map[string]any{
+		"mode": "breath", "brightness": 100.0, "color": color(1, 1, 1), "duration_s": 0.0,
+		"breath_timing": map[string]any{"rise_ms": 100.0, "hold_ms": 0.0, "fall_ms": 100.0, "off_ms": 0.0},
+	}})
+	if !ok.Valid {
+		t.Fatalf("valid breath should pass: %+v", ok.Errors)
+	}
+	bad := ValidateSegments([]any{map[string]any{
+		"mode": "breath", "brightness": 100.0, "color": color(1, 1, 1),
+		"breath_timing": map[string]any{"rise_ms": 0.0, "fall_ms": -1.0},
+	}})
+	if bad.Valid {
+		t.Error("rise_ms=0 should fail")
+	}
+}
+
+func TestValidatePixelFrame(t *testing.T) {
+	t.Parallel()
+	ok := ValidateSegments([]any{map[string]any{
+		"mode": "pixel_frame", "duration_s": 0.0,
+		"pixels": []any{
+			map[string]any{"index": 0.0, "brightness": 100.0, "color": color(255, 0, 0)},
+			map[string]any{"index": 1.0, "brightness": 100.0, "color": color(0, 255, 0)},
+		},
+	}})
+	if !ok.Valid {
+		t.Fatalf("valid pixel_frame should pass: %+v", ok.Errors)
+	}
+	// duplicate index + bad index + missing pixels
+	dup := ValidateSegments([]any{map[string]any{
+		"mode": "pixel_frame",
+		"pixels": []any{
+			map[string]any{"index": 0.0, "brightness": 100.0, "color": color(1, 1, 1)},
+			map[string]any{"index": 0.0, "brightness": 100.0, "color": color(1, 1, 1)},
+			map[string]any{"index": 9.0, "brightness": 100.0, "color": color(1, 1, 1)},
+		},
+	}})
+	if dup.Valid {
+		t.Error("duplicate/out-of-range pixel index should fail")
+	}
+	noPixels := ValidateSegments([]any{map[string]any{"mode": "pixel_frame", "pixels": "x"}})
+	if noPixels.Valid {
+		t.Error("non-array pixels should fail")
+	}
+}
+
+func TestValidateColorFlow(t *testing.T) {
+	t.Parallel()
+	// 无任何非零颜色锚点 -> 失败
+	bad := ValidateSegments([]any{map[string]any{"mode": "color_flow", "brightness": 100.0, "color": color(0, 0, 0)}})
+	if bad.Valid {
+		t.Error("color_flow without nonzero anchor should fail")
+	}
+	// 单一极端纯色前景，无底色 -> valid 但有 warning
+	warn := ValidateSegments([]any{map[string]any{"mode": "color_flow", "brightness": 100.0, "color": color(255, 0, 0), "duration_s": 0.0}})
+	if !warn.Valid {
+		t.Fatalf("single anchor color_flow should still be valid: %+v", warn.Errors)
+	}
+	if len(warn.Warnings) == 0 || warn.Warnings[0].Code != "COLOR_FLOW_SINGLE_ANCHOR_MISUSE" {
+		t.Errorf("expected single-anchor misuse warning: %+v", warn.Warnings)
+	}
+	// 前景 + 有效底色 -> 无 warning
+	twoAnchor := ValidateSegments([]any{map[string]any{
+		"mode": "color_flow", "brightness": 100.0, "color": color(255, 0, 0), "duration_s": 0.0,
+		"background": map[string]any{"r": 0.0, "g": 0.0, "b": 255.0, "brightness": 100.0},
+	}})
+	if len(twoAnchor.Warnings) != 0 {
+		t.Errorf("two-anchor color_flow should have no warning: %+v", twoAnchor.Warnings)
+	}
+}
+
+func TestHelpers(t *testing.T) {
+	t.Parallel()
+	if stringifyMode(nil) != "undefined" {
+		t.Error("nil mode -> undefined")
+	}
+	if joinSlash([]string{"a", "b", "c"}) != "a/b/c" {
+		t.Error("joinSlash")
+	}
+	if trimNum(3.0) != "3" || trimNum(3.5) != "3.5" {
+		t.Error("trimNum")
+	}
+	if !contains(validModes, "wave") || contains(validModes, "x") {
+		t.Error("contains")
+	}
+}

--- a/internal/lightrule/storage_test.go
+++ b/internal/lightrule/storage_test.go
@@ -1,0 +1,138 @@
+package lightrule
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func segs() []map[string]any {
+	return []map[string]any{{"mode": "static", "color": []any{255.0, 0.0, 0.0}}}
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestCreateGetList(t *testing.T) {
+	base := t.TempDir()
+	m, err := Create(base, CreateParams{Name: "alarm", Title: "Alarm", Description: "red", Segments: segs(), Repeat: boolPtr(true)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Name != "alarm" || m.Type != "light-rule" || !m.Enabled || m.RepeatTimes != 0 {
+		t.Errorf("created meta wrong: %+v", m)
+	}
+	if m.CreatedAt == "" {
+		t.Error("createdAt should be set")
+	}
+	got := Get(base, "alarm")
+	if got == nil || got.Title != "Alarm" {
+		t.Errorf("Get mismatch: %+v", got)
+	}
+	// .json 后缀也能解析
+	if Get(base, "alarm.json") == nil {
+		t.Error("lookup with .json suffix should resolve")
+	}
+	if list := List(base); len(list) != 1 {
+		t.Errorf("list len = %d", len(list))
+	}
+}
+
+func TestCreateDuplicate(t *testing.T) {
+	base := t.TempDir()
+	if _, err := Create(base, CreateParams{Name: "dup", Segments: segs(), Repeat: boolPtr(false)}); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Create(base, CreateParams{Name: "dup", Segments: segs(), Repeat: boolPtr(false)})
+	e, ok := err.(*Error)
+	if !ok || e.Code != "ALREADY_EXISTS" {
+		t.Errorf("want ALREADY_EXISTS, got %v", err)
+	}
+}
+
+func TestCreateInvalidRepeatTimes(t *testing.T) {
+	base := t.TempDir()
+	rt := 2.0 // ANCS 仅支持 0/1
+	if _, err := Create(base, CreateParams{Name: "x", Segments: segs(), RepeatTimes: &rt}); err == nil {
+		t.Error("repeat_times=2 should be rejected on ANCS path")
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	base := t.TempDir()
+	Create(base, CreateParams{Name: "u", Title: "old", Description: "d", Segments: segs(), Repeat: boolPtr(false)})
+	newTitle := "new"
+	m, err := Update(base, UpdateParams{Name: "u", Title: &newTitle, Enabled: boolPtr(false)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Title != "new" || m.Enabled || m.UpdatedAt == "" {
+		t.Errorf("update result wrong: %+v", m)
+	}
+	// segments 仅当 HasSegments 时替换
+	newSegs := []map[string]any{{"mode": "static", "color": []any{0.0, 255.0, 0.0}}}
+	m, err = Update(base, UpdateParams{Name: "u", Segments: newSegs, HasSegments: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Segments) != 1 {
+		t.Errorf("segments not updated: %+v", m.Segments)
+	}
+}
+
+func TestUpdateNotFound(t *testing.T) {
+	base := t.TempDir()
+	_, err := Update(base, UpdateParams{Name: "ghost"})
+	e, ok := err.(*Error)
+	if !ok || e.Code != "NOT_FOUND" {
+		t.Errorf("want NOT_FOUND, got %v", err)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	base := t.TempDir()
+	Create(base, CreateParams{Name: "d", Segments: segs(), Repeat: boolPtr(false)})
+	name, err := Delete(base, "d")
+	if err != nil || name != "d" {
+		t.Fatalf("delete: name=%q err=%v", name, err)
+	}
+	if Get(base, "d") != nil {
+		t.Error("rule should be gone")
+	}
+	_, err = Delete(base, "d")
+	if e, ok := err.(*Error); !ok || e.Code != "NOT_FOUND" {
+		t.Errorf("deleting missing should be NOT_FOUND, got %v", err)
+	}
+}
+
+func TestListEmptyAndMissingDir(t *testing.T) {
+	base := t.TempDir()
+	if got := List(base); len(got) != 0 {
+		t.Errorf("empty -> [], got %+v", got)
+	}
+}
+
+func TestResolveByDirScanWhenNameDiffers(t *testing.T) {
+	base := t.TempDir()
+	// 目录名与 meta.name 不一致：写到目录 dirX，但 name=ruleY
+	taskDir := filepath.Join(tasksDir(base), "dirX")
+	m := &Meta{Name: "ruleY", Title: "Y", Type: "light-rule", Segments: segs(), Enabled: true}
+	if err := writeMeta(taskDir, m); err != nil {
+		t.Fatal(err)
+	}
+	if got := Get(base, "ruleY"); got == nil || got.Name != "ruleY" {
+		t.Errorf("should resolve by scanning dirs: %+v", got)
+	}
+}
+
+func TestReadMetaRejectsWrongType(t *testing.T) {
+	base := t.TempDir()
+	taskDir := filepath.Join(tasksDir(base), "bad")
+	os.MkdirAll(taskDir, 0o700)
+	os.WriteFile(filepath.Join(taskDir, "meta.json"), []byte(`{"type":"not-a-rule","segments":[]}`), 0o600)
+	if Get(base, "bad") != nil {
+		t.Error("non light-rule type should be ignored")
+	}
+	if len(List(base)) != 0 {
+		t.Error("List should skip non light-rule")
+	}
+}

--- a/internal/logread/logread_test.go
+++ b/internal/logread/logread_test.go
@@ -1,0 +1,102 @@
+package logread
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeLog(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParseLine(t *testing.T) {
+	t.Parallel()
+	l := parseLine("2026-06-07T10:00:00+08:00 [INFO] started")
+	if l == nil {
+		t.Fatal("expected parse")
+	}
+	if l.Date != "2026-06-07" || l.Level != "info" || l.Message != "started" {
+		t.Errorf("parsed = %+v", l)
+	}
+	if parseLine("garbage line") != nil {
+		t.Error("non-matching line should return nil")
+	}
+}
+
+func TestSearchNewestFirstAndLimit(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	log := filepath.Join(dir, "daemon.log")
+	writeLog(t, log, "2026-06-07T01:00:00Z [INFO] first\n2026-06-07T02:00:00Z [ERROR] second\n2026-06-07T03:00:00Z [INFO] third\n")
+	got := Search(log, Query{Limit: 10})
+	if len(got) != 3 || got[0].Message != "third" || got[2].Message != "first" {
+		t.Fatalf("expected newest-first order: %+v", got)
+	}
+	limited := Search(log, Query{Limit: 2})
+	if len(limited) != 2 || limited[0].Message != "third" {
+		t.Errorf("limit not applied: %+v", limited)
+	}
+}
+
+func TestSearchLevelAndKeyword(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	log := filepath.Join(dir, "daemon.log")
+	writeLog(t, log, "2026-06-07T01:00:00Z [INFO] hello world\n2026-06-07T02:00:00Z [ERROR] boom failure\n")
+	errOnly := Search(log, Query{Level: "error", Limit: 10})
+	if len(errOnly) != 1 || errOnly[0].Message != "boom failure" {
+		t.Errorf("level filter failed: %+v", errOnly)
+	}
+	kw := Search(log, Query{Keyword: "WORLD", Limit: 10})
+	if len(kw) != 1 || kw[0].Message != "hello world" {
+		t.Errorf("keyword filter failed: %+v", kw)
+	}
+}
+
+func TestSearchDateRange(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	log := filepath.Join(dir, "daemon.log")
+	writeLog(t, log, "2026-06-05T01:00:00Z [INFO] old\n2026-06-07T01:00:00Z [INFO] mid\n2026-06-09T01:00:00Z [INFO] new\n")
+	got := Search(log, Query{From: "2026-06-06", To: "2026-06-08", Limit: 10})
+	if len(got) != 1 || got[0].Message != "mid" {
+		t.Errorf("date range failed: %+v", got)
+	}
+}
+
+func TestSearchRotatedFiles(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	log := filepath.Join(dir, "daemon.log")
+	writeLog(t, log, "2026-06-07T01:00:00Z [INFO] current\n")
+	writeLog(t, filepath.Join(dir, "daemon.log.2026-06-05"), "2026-06-05T01:00:00Z [INFO] rotated-old\n")
+	writeLog(t, filepath.Join(dir, "daemon.log.2026-06-06"), "2026-06-06T01:00:00Z [INFO] rotated-new\n")
+	got := Search(log, Query{Limit: 10})
+	// current 在最前，轮转按日期倒序
+	if len(got) != 3 || got[0].Message != "current" || got[1].Message != "rotated-new" || got[2].Message != "rotated-old" {
+		t.Fatalf("rotated ordering wrong: %+v", got)
+	}
+}
+
+func TestSearchUnparsedLineKept(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	log := filepath.Join(dir, "daemon.log")
+	writeLog(t, log, "panic: raw stack trace\n")
+	got := Search(log, Query{Limit: 10})
+	if len(got) != 1 || got[0].Raw != "panic: raw stack trace" || got[0].Level != "" {
+		t.Errorf("unparsed line should be kept raw: %+v", got)
+	}
+}
+
+func TestSearchMissingDir(t *testing.T) {
+	t.Parallel()
+	got := Search(filepath.Join(t.TempDir(), "nope", "daemon.log"), Query{Limit: 10})
+	if len(got) != 0 {
+		t.Errorf("missing dir -> empty, got %+v", got)
+	}
+}

--- a/internal/monitor/store_test.go
+++ b/internal/monitor/store_test.go
@@ -1,0 +1,114 @@
+package monitor
+
+import (
+	"testing"
+
+	"github.com/YoooClaw/cli/internal/testutil"
+)
+
+func validInput(name string) CreateInput {
+	return CreateInput{
+		Name:        name,
+		Description: "desc",
+		MatchRules:  map[string]any{"app": "wechat"},
+		Schedule:    "0 9 * * *",
+	}
+}
+
+func TestListEmpty(t *testing.T) {
+	p := testutil.Sandbox(t)
+	if got := List(p); len(got) != 0 {
+		t.Errorf("empty store -> [], got %+v", got)
+	}
+}
+
+func TestCreateGetList(t *testing.T) {
+	p := testutil.Sandbox(t)
+	task, err := Create(p, validInput("daily"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !task.Enabled || task.CreatedAt == "" || task.UpdatedAt == "" {
+		t.Errorf("created task fields wrong: %+v", task)
+	}
+	got, ok := Get(p, "daily")
+	if !ok || got.Name != "daily" || got.Schedule != "0 9 * * *" {
+		t.Errorf("Get mismatch: %+v ok=%v", got, ok)
+	}
+	if len(List(p)) != 1 {
+		t.Error("list should have 1 task")
+	}
+	if _, ok := Get(p, "missing"); ok {
+		t.Error("Get missing should be false")
+	}
+}
+
+func TestCreateValidation(t *testing.T) {
+	p := testutil.Sandbox(t)
+	bad := []CreateInput{
+		{Description: "d", MatchRules: 1, Schedule: "s"},          // 无 name
+		{Name: "n", MatchRules: 1, Schedule: "s"},                 // 无 description
+		{Name: "n", Description: "d", Schedule: "s"},              // 无 matchRules
+		{Name: "n", Description: "d", MatchRules: 1},              // 无 schedule
+	}
+	for i, in := range bad {
+		if _, err := Create(p, in); err == nil {
+			t.Errorf("case %d: expected validation error", i)
+		}
+	}
+}
+
+func TestCreateDuplicate(t *testing.T) {
+	p := testutil.Sandbox(t)
+	if _, err := Create(p, validInput("dup")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Create(p, validInput("dup")); err == nil {
+		t.Error("duplicate name should error")
+	}
+}
+
+func TestDelete(t *testing.T) {
+	p := testutil.Sandbox(t)
+	Create(p, validInput("a"))
+	Create(p, validInput("b"))
+	removed, err := Delete(p, "a")
+	if err != nil || !removed {
+		t.Fatalf("delete a: removed=%v err=%v", removed, err)
+	}
+	if _, ok := Get(p, "a"); ok {
+		t.Error("a should be gone")
+	}
+	if _, ok := Get(p, "b"); !ok {
+		t.Error("b should remain")
+	}
+	removed, err = Delete(p, "missing")
+	if err != nil || removed {
+		t.Errorf("delete missing -> (false,nil), got (%v,%v)", removed, err)
+	}
+}
+
+func TestSetEnabled(t *testing.T) {
+	p := testutil.Sandbox(t)
+	Create(p, validInput("x"))
+	ok, err := SetEnabled(p, "x", false)
+	if err != nil || !ok {
+		t.Fatalf("SetEnabled: ok=%v err=%v", ok, err)
+	}
+	got, _ := Get(p, "x")
+	if got.Enabled {
+		t.Error("task should be disabled")
+	}
+	ok, err = SetEnabled(p, "missing", true)
+	if err != nil || ok {
+		t.Errorf("SetEnabled missing -> (false,nil), got (%v,%v)", ok, err)
+	}
+}
+
+func TestListIgnoresInvalidFile(t *testing.T) {
+	p := testutil.Sandbox(t)
+	testutil.WriteFile(t, storePath(p), []byte("{bad json"))
+	if got := List(p); len(got) != 0 {
+		t.Errorf("invalid file -> [], got %+v", got)
+	}
+}

--- a/internal/notif/feishu_test.go
+++ b/internal/notif/feishu_test.go
@@ -1,0 +1,108 @@
+package notif
+
+import "testing"
+
+func TestIsFeishuApp(t *testing.T) {
+	t.Parallel()
+	for _, ok := range []string{"feishu", "Lark", "com.ss.android.lark", "飞书", "my-feishu-clone"} {
+		if !isFeishuApp(ok) {
+			t.Errorf("%q should be feishu", ok)
+		}
+	}
+	for _, no := range []string{"", "wechat", "com.tencent.mm"} {
+		if isFeishuApp(no) {
+			t.Errorf("%q should not be feishu", no)
+		}
+	}
+}
+
+func TestExtractColonSender(t *testing.T) {
+	t.Parallel()
+	tests := map[string]string{
+		"Alice: hi":   "Alice",
+		"Bob：你好":      "Bob",
+		"no colon":    "",
+		"":            "",
+		":leading":    "",
+	}
+	for in, want := range tests {
+		if got := extractColonSender(in); got != want {
+			t.Errorf("extractColonSender(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestNormalizeFeishuNonFeishu(t *testing.T) {
+	t.Parallel()
+	if _, ok := normalizeFeishuFields(RawNotification{App: "wechat", Title: "x", Body: "y"}); ok {
+		t.Error("non-feishu should return false")
+	}
+}
+
+func TestNormalizeFeishuGroupViaMetadata(t *testing.T) {
+	t.Parallel()
+	n := RawNotification{
+		App: "feishu", Title: "Alice", Body: "hello team",
+		Metadata: map[string]any{"subtitle": "研发群"},
+	}
+	got, ok := normalizeFeishuFields(n)
+	if !ok {
+		t.Fatal("expected feishu normalization")
+	}
+	if got.Structured.ConversationType != "group" || got.Structured.ConversationName != "研发群" {
+		t.Errorf("structured wrong: %+v", got.Structured)
+	}
+	if got.Title != "研发群" {
+		t.Errorf("group title should be conversation name, got %q", got.Title)
+	}
+	if got.Content != "Alice: hello team" {
+		t.Errorf("group content should prefix sender, got %q", got.Content)
+	}
+}
+
+func TestNormalizeFeishuPrivateViaMetadata(t *testing.T) {
+	t.Parallel()
+	n := RawNotification{
+		App: "lark", Title: "Bob", Body: "Bob: 私聊内容",
+		Metadata: map[string]any{"subtitle": ""},
+	}
+	got, ok := normalizeFeishuFields(n)
+	if !ok {
+		t.Fatal("expected normalization")
+	}
+	if got.Structured.ConversationType != "private" || got.Structured.SenderName != "Bob" {
+		t.Errorf("private structured wrong: %+v", got.Structured)
+	}
+	if got.Content != "私聊内容" {
+		t.Errorf("private content should strip sender prefix, got %q", got.Content)
+	}
+}
+
+func TestNormalizeFeishuColonFallback(t *testing.T) {
+	t.Parallel()
+	// 无 metadata.subtitle，但 Title 是 feishu 标签且 body 含冒号发送人
+	n := RawNotification{App: "feishu", Title: "飞书", Body: "Carol: 在吗"}
+	got, ok := normalizeFeishuFields(n)
+	if !ok {
+		t.Fatal("expected colon-fallback normalization")
+	}
+	if got.Structured.SenderName != "Carol" || got.Structured.ConversationType != "private" {
+		t.Errorf("colon fallback wrong: %+v", got.Structured)
+	}
+}
+
+func TestFindMetadataTextByKeyNested(t *testing.T) {
+	t.Parallel()
+	meta := map[string]any{
+		"outer": []any{
+			map[string]any{"inner": map[string]any{"Subtitle": "群名X"}},
+		},
+	}
+	found, text := findMetadataTextByKey(meta, "subtitle", 0)
+	if !found || text != "群名X" {
+		t.Errorf("nested lookup failed: found=%v text=%q", found, text)
+	}
+	if f, _ := findMetadataTextByKey(meta, "absent", 0); f {
+		t.Error("absent key should not be found")
+	}
+}

--- a/internal/notif/helpers_test.go
+++ b/internal/notif/helpers_test.go
@@ -1,0 +1,29 @@
+package notif
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// timeNowISO 返回当前本地时间的 RFC3339 串（用于 prune 等"今天"场景）。
+func timeNowISO() string {
+	return time.Now().Format(time.RFC3339)
+}
+
+// writeDateFile 在通知目录写一个 YYYY-MM-DD.json 文件。
+func writeDateFile(t *testing.T, dir, dateKey string, items []StoredNotification) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.MarshalIndent(items, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, dateKey+".json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/notif/query_test.go
+++ b/internal/notif/query_test.go
@@ -1,0 +1,170 @@
+package notif
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/YoooClaw/cli/internal/errs"
+)
+
+func TestParseTime(t *testing.T) {
+	t.Parallel()
+	for _, v := range []string{
+		"2026-06-07T10:00:00+08:00",
+		"2026-06-07T10:00:00Z",
+		"2026-06-07T10:00Z",
+		"2026-06-07T10:00:00.123Z",
+	} {
+		if _, ok := ParseTime(v); !ok {
+			t.Errorf("ParseTime(%q) should succeed", v)
+		}
+	}
+	if _, ok := ParseTime("not-a-time"); ok {
+		t.Error("invalid time should fail")
+	}
+}
+
+func TestBuildQueryOptions(t *testing.T) {
+	t.Parallel()
+	opts, err := BuildQueryOptions(RawQueryOpts{
+		From: "2026-06-01T00:00:00+08:00", To: "2026-06-30T00:00:00+08:00",
+		App: "wechat", Limit: "50", ConversationType: "group",
+	}, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.Limit != 50 || opts.FromDateKey != "2026-06-01" || opts.ToDateKey != "2026-06-30" {
+		t.Errorf("opts = %+v", opts)
+	}
+}
+
+func TestBuildQueryOptionsErrors(t *testing.T) {
+	t.Parallel()
+	cases := []RawQueryOpts{
+		{ConversationType: "channel"},                                            // 非法 type
+		{From: "bad-date"},                                                       // 非法 from
+		{To: "bad-date"},                                                         // 非法 to
+		{From: "2026-06-30T00:00:00Z", To: "2026-06-01T00:00:00Z"},               // from > to
+		{Limit: "0"},                                                             // limit <= 0
+		{Limit: "abc"},                                                           // limit 非数字
+	}
+	for i, c := range cases {
+		if _, err := BuildQueryOptions(c, 20); err == nil {
+			t.Errorf("case %d (%+v) should error", i, c)
+		} else if e, ok := err.(*errs.Error); !ok || e.Code != errs.CodeInvalidArgument {
+			t.Errorf("case %d should be INVALID_ARGUMENT, got %v", i, err)
+		}
+	}
+}
+
+func TestBuildQueryOptionsDefaultLimit(t *testing.T) {
+	t.Parallel()
+	opts, err := BuildQueryOptions(RawQueryOpts{}, 20)
+	if err != nil || opts.Limit != 20 {
+		t.Errorf("default limit should be 20, got %d err=%v", opts.Limit, err)
+	}
+}
+
+func TestMatchesAppFilter(t *testing.T) {
+	t.Parallel()
+	wechat := StoredNotification{AppName: "com.tencent.mm", AppDisplayName: "微信"}
+	if !MatchesAppFilter(wechat, "wechat") {
+		t.Error("alias 'wechat' should match com.tencent.mm")
+	}
+	if !MatchesAppFilter(wechat, "微信") {
+		t.Error("display name should match")
+	}
+	if MatchesAppFilter(wechat, "feishu") {
+		t.Error("feishu should not match wechat")
+	}
+	if !MatchesAppFilter(wechat, "") {
+		t.Error("empty filter matches all")
+	}
+	if MatchesAppFilter(StoredNotification{AppName: "x"}, "totallyunknown") {
+		t.Error("unknown app + unknown filter should not match")
+	}
+}
+
+func TestMatchesQuery(t *testing.T) {
+	t.Parallel()
+	item := StoredNotification{
+		ClientLabel: "phone-a", AppName: "feishu", Title: "群名", Content: "hello world",
+		SenderName: "Alice", ConversationType: "group", ConversationName: "Team",
+		Timestamp: "2026-06-07T10:00:00+08:00",
+	}
+	base := QueryOptions{Limit: 10}
+	if !MatchesQuery(item, base) {
+		t.Error("empty query should match")
+	}
+	if MatchesQuery(item, QueryOptions{Client: "phone-b"}) {
+		t.Error("client mismatch should fail")
+	}
+	if !MatchesQuery(item, QueryOptions{Client: "all"}) {
+		t.Error("client=all should match")
+	}
+	if MatchesQuery(item, QueryOptions{ConversationType: "private"}) {
+		t.Error("conversation type mismatch should fail")
+	}
+	if !MatchesQuery(item, QueryOptions{Sender: "Alice"}) {
+		t.Error("sender substring should match")
+	}
+	if !MatchesQuery(item, QueryOptions{Keyword: "world"}) {
+		t.Error("keyword should match content")
+	}
+	if MatchesQuery(item, QueryOptions{Keyword: "absent"}) {
+		t.Error("absent keyword should fail")
+	}
+	// legacy label
+	legacy := item
+	legacy.ClientLabel = ""
+	if !MatchesQuery(legacy, QueryOptions{Client: "legacy"}) {
+		t.Error("empty label should match client=legacy")
+	}
+	// bad timestamp
+	bad := item
+	bad.Timestamp = "garbage"
+	if MatchesQuery(bad, base) {
+		t.Error("unparsable timestamp should fail match")
+	}
+}
+
+func TestMatchesQueryTimeRange(t *testing.T) {
+	t.Parallel()
+	item := StoredNotification{AppName: "x", Timestamp: "2026-06-07T10:00:00Z"}
+	from := time.Date(2026, 6, 7, 9, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 6, 7, 11, 0, 0, 0, time.UTC)
+	if !MatchesQuery(item, QueryOptions{FromTs: &from, ToTs: &to}) {
+		t.Error("within range should match")
+	}
+	early := time.Date(2026, 6, 7, 10, 30, 0, 0, time.UTC)
+	if MatchesQuery(item, QueryOptions{FromTs: &early}) {
+		t.Error("before from should fail")
+	}
+}
+
+func TestQueryEndToEnd(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// Query on missing dir
+	if got := Query(filepath.Join(dir, "nope"), QueryOptions{Limit: 10}); got != nil {
+		t.Error("missing dir should return nil")
+	}
+	writeDateFile(t, dir, "2026-06-07", []StoredNotification{
+		{AppName: "wechat", Title: "a", Content: "first", Timestamp: "2026-06-07T08:00:00Z"},
+		{AppName: "feishu", Title: "b", Content: "second", Timestamp: "2026-06-07T09:00:00Z"},
+	})
+	got := Query(dir, QueryOptions{Limit: 10})
+	if len(got) != 2 || got[0].Content != "second" {
+		t.Fatalf("expected newest-first 2 results: %+v", got)
+	}
+	// app filter
+	wx := Query(dir, QueryOptions{App: "wechat", Limit: 10})
+	if len(wx) != 1 || wx[0].AppName != "wechat" {
+		t.Errorf("app filter failed: %+v", wx)
+	}
+	// limit
+	if lim := Query(dir, QueryOptions{Limit: 1}); len(lim) != 1 {
+		t.Errorf("limit failed: %+v", lim)
+	}
+}

--- a/internal/notif/storage_test.go
+++ b/internal/notif/storage_test.go
@@ -1,0 +1,116 @@
+package notif
+
+import (
+	"testing"
+
+	"github.com/YoooClaw/cli/internal/testutil"
+)
+
+func newStorage(t *testing.T) *Storage {
+	t.Helper()
+	s := NewStorage(t.TempDir(), PluginConfig{}, testutil.Logger{T: t})
+	if err := s.Init(); err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func TestIngestBasic(t *testing.T) {
+	t.Parallel()
+	s := newStorage(t)
+	res := s.Ingest([]RawNotification{
+		{ID: "1", App: "wechat", Title: "t1", Body: "b1", Timestamp: "2026-06-07T10:00:00+08:00"},
+		{ID: "2", App: "feishu", Title: "t2", Body: "b2", Timestamp: "2026-06-07T11:00:00+08:00"},
+	}, "phone-a")
+	if res.Received != 2 || res.Ingested != 2 {
+		t.Fatalf("ingest result: %+v", res)
+	}
+	if len(res.Inserted) != 2 {
+		t.Errorf("inserted should be 2: %+v", res.Inserted)
+	}
+}
+
+func TestIngestDedupByID(t *testing.T) {
+	t.Parallel()
+	s := newStorage(t)
+	item := RawNotification{ID: "dup", App: "wechat", Title: "t", Body: "b", Timestamp: "2026-06-07T10:00:00+08:00"}
+	s.Ingest([]RawNotification{item}, "phone-a")
+	res := s.Ingest([]RawNotification{item}, "phone-a")
+	if res.DedupedByID != 1 || res.Ingested != 0 {
+		t.Errorf("expected dedupe by id: %+v", res)
+	}
+}
+
+func TestIngestDedupByContent(t *testing.T) {
+	t.Parallel()
+	s := newStorage(t)
+	// 不同 ID，相同内容 -> 内容去重
+	a := RawNotification{ID: "a", App: "wechat", Title: "same", Body: "same body", Timestamp: "2026-06-07T10:00:00+08:00"}
+	b := RawNotification{ID: "b", App: "wechat", Title: "same", Body: "same body", Timestamp: "2026-06-07T10:00:00+08:00"}
+	s.Ingest([]RawNotification{a}, "phone-a")
+	res := s.Ingest([]RawNotification{b}, "phone-a")
+	if res.DedupedByContent != 1 {
+		t.Errorf("expected dedupe by content: %+v", res)
+	}
+}
+
+func TestIngestInvalidTimestamp(t *testing.T) {
+	t.Parallel()
+	s := newStorage(t)
+	res := s.Ingest([]RawNotification{
+		{ID: "x", App: "wechat", Title: "t", Body: "b", Timestamp: "not-a-time"},
+	}, "phone-a")
+	if res.Invalid != 1 || res.Ingested != 0 {
+		t.Errorf("expected invalid: %+v", res)
+	}
+}
+
+func TestIngestDefaultLabelAndUnknownApp(t *testing.T) {
+	t.Parallel()
+	s := newStorage(t)
+	res := s.Ingest([]RawNotification{
+		{ID: "1", Title: "t", Body: "b", Timestamp: "2026-06-07T10:00:00+08:00"},
+	}, "")
+	if res.Ingested != 1 {
+		t.Fatalf("ingest: %+v", res)
+	}
+	got := res.Inserted[0]
+	if got.ClientLabel != "default" || got.AppName != "Unknown" || got.AppDisplayName != "Unknown" {
+		t.Errorf("default label / unknown app wrong: %+v", got)
+	}
+}
+
+func TestIngestFallbackContent(t *testing.T) {
+	t.Parallel()
+	s := newStorage(t)
+	res := s.Ingest([]RawNotification{
+		{ID: "1", App: "x", Title: "t", Timestamp: "2026-06-07T10:00:00+08:00", Category: "msg", Metadata: map[string]any{"k": "v"}},
+	}, "p")
+	c := res.Inserted[0].Content
+	if c == "" || c == "-" {
+		t.Errorf("fallback content should include category/metadata, got %q", c)
+	}
+}
+
+func TestIngestPrune(t *testing.T) {
+	t.Parallel()
+	days := 1
+	s := NewStorage(t.TempDir(), PluginConfig{RetentionDays: &days}, testutil.Logger{T: t})
+	if err := s.Init(); err != nil {
+		t.Fatal(err)
+	}
+	// 一条很旧的通知，prune 后该日期文件应被删除
+	s.Ingest([]RawNotification{
+		{ID: "old", App: "x", Title: "t", Body: "b", Timestamp: "2020-01-01T10:00:00+08:00"},
+	}, "p")
+	// 再 ingest 一条今天的，触发 prune
+	s.Ingest([]RawNotification{
+		{ID: "new", App: "x", Title: "t", Body: "b2", Timestamp: timeNowISO()},
+	}, "p")
+	q := Query(s.dir, QueryOptions{Limit: 10})
+	for _, n := range q {
+		if n.Content == "b" {
+			t.Error("old notification should have been pruned")
+		}
+	}
+}

--- a/internal/notif/sync_test.go
+++ b/internal/notif/sync_test.go
@@ -1,0 +1,155 @@
+package notif
+
+import (
+	"testing"
+)
+
+func makeItems(n int) []StoredNotification {
+	items := make([]StoredNotification, n)
+	for i := range items {
+		items[i] = StoredNotification{AppName: "x", Title: "t", Content: "c", Timestamp: "2026-06-07T10:00:00Z"}
+	}
+	return items
+}
+
+func TestScanSyncEmpty(t *testing.T) {
+	t.Parallel()
+	res := ScanSync(t.TempDir())
+	if res["totalPending"].(int) != 0 {
+		t.Errorf("empty scan should have 0 pending: %+v", res)
+	}
+}
+
+func TestScanSyncPending(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeDateFile(t, dir, "2026-06-07", makeItems(5))
+	res := ScanSync(dir)
+	if res["totalPending"].(int) != 5 {
+		t.Errorf("expected 5 pending: %+v", res)
+	}
+	pending := res["pending"].([]SyncPending)
+	if len(pending) != 1 || pending[0].StartIndex != 0 || pending[0].Count != 5 {
+		t.Errorf("pending detail wrong: %+v", pending)
+	}
+}
+
+func TestFetchSyncMissingDate(t *testing.T) {
+	t.Parallel()
+	if _, err := FetchSync(t.TempDir(), "2026-06-07", ""); err == nil {
+		t.Error("missing date should error")
+	}
+}
+
+func TestFetchSync(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeDateFile(t, dir, "2026-06-07", makeItems(3))
+	res, err := FetchSync(dir, "2026-06-07", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res["startIndex"].(int) != 0 || res["endIndex"].(int) != 2 || res["returned"].(int) != 3 {
+		t.Errorf("fetch result wrong: %+v", res)
+	}
+	if res["hasMore"].(bool) {
+		t.Error("should not have more")
+	}
+}
+
+func TestFetchSyncMaxEndIndex(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeDateFile(t, dir, "2026-06-07", makeItems(10))
+	res, err := FetchSync(dir, "2026-06-07", "2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res["returned"].(int) != 3 || res["maxEndIndex"].(int) != 2 {
+		t.Errorf("max-end-index not applied: %+v", res)
+	}
+}
+
+func TestFetchSyncInvalidMaxEndIndex(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeDateFile(t, dir, "2026-06-07", makeItems(3))
+	if _, err := FetchSync(dir, "2026-06-07", "-1"); err == nil {
+		t.Error("negative max-end-index should error")
+	}
+}
+
+func TestCommitSyncLegacyBatch(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeDateFile(t, dir, "2026-06-07", makeItems(3))
+	res, err := CommitSync(dir, "2026-06-07", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res["committedIndex"].(int) != 2 || res["commitMode"] != "legacy-batch-limit" || res["hasMore"].(bool) {
+		t.Errorf("legacy commit wrong: %+v", res)
+	}
+	// checkpoint 持久化后再 scan 应无 pending
+	if ScanSync(dir)["totalPending"].(int) != 0 {
+		t.Error("after full commit no pending expected")
+	}
+}
+
+func TestCommitSyncExactEndIndex(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeDateFile(t, dir, "2026-06-07", makeItems(5))
+	res, err := CommitSync(dir, "2026-06-07", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res["committedIndex"].(int) != 1 || res["commitMode"] != "exact-end-index" || !res["hasMore"].(bool) {
+		t.Errorf("exact commit wrong: %+v", res)
+	}
+}
+
+func TestCommitSyncErrors(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeDateFile(t, dir, "2026-06-07", makeItems(3))
+	// 超范围
+	if _, err := CommitSync(dir, "2026-06-07", "99"); err == nil {
+		t.Error("out-of-range end-index should error")
+	}
+	// 缺数据
+	if _, err := CommitSync(dir, "2026-01-01", "0"); err == nil {
+		t.Error("missing date should error")
+	}
+	// 非法
+	if _, err := CommitSync(dir, "2026-06-07", "abc"); err == nil {
+		t.Error("non-numeric end-index should error")
+	}
+}
+
+func TestCommitSyncNoBackward(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeDateFile(t, dir, "2026-06-07", makeItems(5))
+	if _, err := CommitSync(dir, "2026-06-07", "3"); err != nil {
+		t.Fatal(err)
+	}
+	// 回退到更小的 index 应被拒绝
+	if _, err := CommitSync(dir, "2026-06-07", "1"); err == nil {
+		t.Error("backward commit should error")
+	}
+}
+
+func TestSafeSlice(t *testing.T) {
+	t.Parallel()
+	items := makeItems(5)
+	if got := safeSlice(items, -1, 100); len(got) != 5 {
+		t.Errorf("out of range slice should clamp: %d", len(got))
+	}
+	if got := safeSlice(items, 3, 1); len(got) != 0 {
+		t.Errorf("reversed slice should be empty: %d", len(got))
+	}
+	if got := safeSlice(items, 10, 12); len(got) != 0 {
+		t.Errorf("start beyond len should be empty: %d", len(got))
+	}
+}

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1,0 +1,130 @@
+package output
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/YoooClaw/cli/internal/errs"
+)
+
+func TestResolveFormat(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		requested string
+		isTTY     bool
+		want      Format
+		wantErr   bool
+	}{
+		{"explicit json", "json", true, JSON, false},
+		{"explicit table", "table", false, Table, false},
+		{"explicit ndjson", "ndjson", true, NDJSON, false},
+		{"explicit pretty", "pretty", false, Pretty, false},
+		{"auto on tty -> pretty", "auto", true, Pretty, false},
+		{"auto off tty -> json", "auto", false, JSON, false},
+		{"empty on tty -> pretty", "", true, Pretty, false},
+		{"empty off tty -> json", "", false, JSON, false},
+		{"unsupported", "yaml", true, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveFormat(tt.requested, tt.isTTY)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tt.requested)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderResultJSON(t *testing.T) {
+	t.Parallel()
+	var b bytes.Buffer
+	RenderResult(&b, map[string]any{"ok": true, "n": 1}, JSON)
+	got := strings.TrimSpace(b.String())
+	if got != `{"n":1,"ok":true}` {
+		t.Errorf("json render = %q", got)
+	}
+}
+
+func TestRenderResultJSONNoHTMLEscape(t *testing.T) {
+	t.Parallel()
+	var b bytes.Buffer
+	RenderResult(&b, map[string]any{"url": "a&b<c>"}, JSON)
+	if !strings.Contains(b.String(), "a&b<c>") {
+		t.Errorf("HTML should not be escaped: %q", b.String())
+	}
+}
+
+func TestRenderResultNDJSON(t *testing.T) {
+	t.Parallel()
+	var b bytes.Buffer
+	RenderResult(&b, []any{map[string]any{"a": 1}, map[string]any{"a": 2}}, NDJSON)
+	lines := strings.Split(strings.TrimSpace(b.String()), "\n")
+	if len(lines) != 2 || lines[0] != `{"a":1}` || lines[1] != `{"a":2}` {
+		t.Errorf("ndjson render = %q", b.String())
+	}
+}
+
+func TestRenderResultTable(t *testing.T) {
+	t.Parallel()
+	var b bytes.Buffer
+	RenderResult(&b, []any{
+		map[string]any{"id": "a", "n": 1},
+		map[string]any{"id": "bb", "n": 22},
+	}, Table)
+	out := b.String()
+	if !strings.Contains(out, "id") || !strings.Contains(out, "n") {
+		t.Errorf("table missing header: %q", out)
+	}
+	if !strings.Contains(out, "--") {
+		t.Errorf("table missing separator row: %q", out)
+	}
+}
+
+func TestRenderResultTableFallsBackToJSON(t *testing.T) {
+	t.Parallel()
+	var b bytes.Buffer
+	RenderResult(&b, map[string]any{"not": "array"}, Table)
+	if !strings.Contains(b.String(), `"not": "array"`) {
+		t.Errorf("non-array table should fall back to pretty JSON: %q", b.String())
+	}
+}
+
+func TestRenderErrorStructured(t *testing.T) {
+	t.Parallel()
+	var b bytes.Buffer
+	RenderError(&b, errs.New(errs.CodeNotFound, "missing").WithHint("check id"), JSON)
+	out := b.String()
+	for _, want := range []string{`"ok":false`, `"code":"YOOOCLAW_NOT_FOUND"`, `"message":"missing"`, `"hint":"check id"`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("error render missing %q: %s", want, out)
+		}
+	}
+}
+
+func TestRenderErrorPlainError(t *testing.T) {
+	t.Parallel()
+	var b bytes.Buffer
+	RenderError(&b, errsErrorf("boom"), JSON)
+	out := b.String()
+	if !strings.Contains(out, `"code":"YOOOCLAW_UNKNOWN"`) || !strings.Contains(out, `"message":"boom"`) {
+		t.Errorf("plain error should map to UNKNOWN: %s", out)
+	}
+}
+
+// errsErrorf 返回一个非 *errs.Error 的普通 error，用于验证 RenderError 的 fallback 分支。
+func errsErrorf(msg string) error { return &plainErr{msg} }
+
+type plainErr struct{ s string }
+
+func (e *plainErr) Error() string { return e.s }

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -1,0 +1,107 @@
+package paths
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRootDirEnvOverride(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YOOOCLAW_HOME", home)
+	if RootDir() != home {
+		t.Errorf("RootDir = %q, want %q", RootDir(), home)
+	}
+}
+
+func TestRootDirEnvTrimmed(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YOOOCLAW_HOME", "  "+home+"  ")
+	if RootDir() != home {
+		t.Errorf("RootDir should trim whitespace, got %q", RootDir())
+	}
+}
+
+func TestRootDirDefault(t *testing.T) {
+	t.Setenv("YOOOCLAW_HOME", "")
+	uh, _ := os.UserHomeDir()
+	want := filepath.Join(uh, ".yoooclaw")
+	if RootDir() != want {
+		t.Errorf("RootDir default = %q, want %q", RootDir(), want)
+	}
+}
+
+func TestDerivedPaths(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YOOOCLAW_HOME", home)
+	if SharedCredentialsPath() != filepath.Join(home, "credentials.json") {
+		t.Errorf("SharedCredentialsPath = %q", SharedCredentialsPath())
+	}
+	if ActiveProfilePath() != filepath.Join(home, "active-profile") {
+		t.Errorf("ActiveProfilePath = %q", ActiveProfilePath())
+	}
+	if ProfilesRoot() != filepath.Join(home, "profiles") {
+		t.Errorf("ProfilesRoot = %q", ProfilesRoot())
+	}
+	if ProfileDir("p1") != filepath.Join(home, "profiles", "p1") {
+		t.Errorf("ProfileDir = %q", ProfileDir("p1"))
+	}
+}
+
+func TestFor(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YOOOCLAW_HOME", home)
+	p := For("acme")
+	base := filepath.Join(home, "profiles", "acme")
+	if p.Profile != "acme" || p.Dir != base {
+		t.Fatalf("For base mismatch: %+v", p)
+	}
+	cases := map[string]string{
+		p.Config: "config.json", p.Credentials: "credentials.json",
+		p.DaemonLock: "daemon.lock", p.DaemonLog: "daemon.log",
+		p.Notifications: "notifications", p.Recordings: "recordings",
+		p.Images: "images", p.LightRules: "light-rules", p.State: "state",
+	}
+	for got, leaf := range cases {
+		if got != filepath.Join(base, leaf) {
+			t.Errorf("path for %q = %q", leaf, got)
+		}
+	}
+}
+
+func TestListProfileNames(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YOOOCLAW_HOME", home)
+	if got := ListProfileNames(); got != nil {
+		t.Errorf("no profiles dir -> nil, got %v", got)
+	}
+	for _, name := range []string{"zeta", "alpha", "beta"} {
+		if err := os.MkdirAll(ProfileDir(name), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// 放一个文件，确认只统计目录。
+	if err := os.WriteFile(filepath.Join(ProfilesRoot(), "stray.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := ListProfileNames()
+	want := []string{"alpha", "beta", "zeta"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("ListProfileNames = %v, want sorted %v", got, want)
+	}
+}
+
+func TestReadActiveProfile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YOOOCLAW_HOME", home)
+	if got := ReadActiveProfile(); got != "" {
+		t.Errorf("missing file -> empty, got %q", got)
+	}
+	if err := os.WriteFile(ActiveProfilePath(), []byte("  work\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := ReadActiveProfile(); got != "work" {
+		t.Errorf("ReadActiveProfile = %q, want work", got)
+	}
+}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -38,12 +38,17 @@ func Ask(question, defaultValue string) (string, error) {
 	if err := ensureInteractive(); err != nil {
 		return "", err
 	}
+	return ask(os.Stdin, os.Stdout, question, defaultValue)
+}
+
+// ask 是 Ask 的纯 I/O 核心（注入 reader/writer 以便单测）。
+func ask(in io.Reader, out io.Writer, question, defaultValue string) (string, error) {
 	suffix := ""
 	if defaultValue != "" {
 		suffix = " [" + defaultValue + "]"
 	}
-	_, _ = io.WriteString(os.Stdout, question+suffix+": ")
-	reader := bufio.NewReader(os.Stdin)
+	_, _ = io.WriteString(out, question+suffix+": ")
+	reader := bufio.NewReader(in)
 	line, _ := reader.ReadString('\n')
 	answer := strings.TrimSpace(line)
 	if answer == "" {
@@ -54,11 +59,19 @@ func Ask(question, defaultValue string) (string, error) {
 
 // Confirm 是 Yes/No 确认，默认值由 defaultYes 决定。
 func Confirm(question string, defaultYes bool) (bool, error) {
+	if err := ensureInteractive(); err != nil {
+		return false, err
+	}
+	return confirm(os.Stdin, os.Stdout, question, defaultYes)
+}
+
+// confirm 是 Confirm 的纯 I/O 核心（注入 reader/writer 以便单测）。
+func confirm(in io.Reader, out io.Writer, question string, defaultYes bool) (bool, error) {
 	hint := "y/N"
 	if defaultYes {
 		hint = "Y/n"
 	}
-	answer, err := Ask(question+" ("+hint+")", "")
+	answer, err := ask(in, out, question+" ("+hint+")", "")
 	if err != nil {
 		return false, err
 	}
@@ -71,7 +84,11 @@ func Confirm(question string, defaultYes bool) (bool, error) {
 
 // ReadStdin 读取 stdin 全部内容（用于 --from-file - / set-api-key -）。
 func ReadStdin() (string, error) {
-	data, err := io.ReadAll(os.Stdin)
+	return readAll(os.Stdin)
+}
+
+func readAll(r io.Reader) (string, error) {
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return "", err
 	}

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -1,0 +1,94 @@
+package prompt
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/YoooClaw/cli/internal/errs"
+)
+
+func TestAskCore(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   string
+		def     string
+		want    string
+		wantOut string
+	}{
+		{"answer wins", "hello\n", "def", "hello", "Q [def]: "},
+		{"empty uses default", "\n", "def", "def", "Q [def]: "},
+		{"trims whitespace", "  spaced  \n", "", "spaced", "Q: "},
+		{"empty no default", "\n", "", "", "Q: "},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out strings.Builder
+			got, err := ask(strings.NewReader(tt.input), &out, "Q", tt.def)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Errorf("ask = %q, want %q", got, tt.want)
+			}
+			if out.String() != tt.wantOut {
+				t.Errorf("prompt text = %q, want %q", out.String(), tt.wantOut)
+			}
+		})
+	}
+}
+
+func TestConfirmCore(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input      string
+		defaultYes bool
+		want       bool
+		wantHint   string
+	}{
+		{"y\n", false, true, "(y/N)"},
+		{"yes\n", false, true, "(y/N)"},
+		{"n\n", true, false, "(Y/n)"},
+		{"\n", true, true, "(Y/n)"},
+		{"\n", false, false, "(y/N)"},
+		{"garbage\n", true, false, "(Y/n)"},
+		{"YES\n", false, true, "(y/N)"},
+	}
+	for _, tt := range tests {
+		var out strings.Builder
+		got, err := confirm(strings.NewReader(tt.input), &out, "OK?", tt.defaultYes)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tt.want {
+			t.Errorf("confirm(%q, def=%v) = %v, want %v", tt.input, tt.defaultYes, got, tt.want)
+		}
+		if !strings.Contains(out.String(), tt.wantHint) {
+			t.Errorf("prompt %q missing hint %q", out.String(), tt.wantHint)
+		}
+	}
+}
+
+func TestReadAll(t *testing.T) {
+	t.Parallel()
+	got, err := readAll(strings.NewReader("piped body"))
+	if err != nil || got != "piped body" {
+		t.Errorf("readAll = %q, %v", got, err)
+	}
+}
+
+func TestEnsureInteractiveNonTTY(t *testing.T) {
+	t.Parallel()
+	// 测试环境 stdin 非 TTY，Ask/Confirm 应直接拒绝而不挂起。
+	if _, err := Ask("q", ""); !isNotInteractive(err) {
+		t.Errorf("Ask in non-tty should return NOT_INTERACTIVE, got %v", err)
+	}
+	if _, err := Confirm("q", true); !isNotInteractive(err) {
+		t.Errorf("Confirm in non-tty should return NOT_INTERACTIVE, got %v", err)
+	}
+}
+
+func isNotInteractive(err error) bool {
+	e, ok := err.(*errs.Error)
+	return ok && e.Code == errs.CodeNotInteractive
+}

--- a/internal/recording/asr_state_test.go
+++ b/internal/recording/asr_state_test.go
@@ -1,0 +1,161 @@
+package recording
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/YoooClaw/cli/internal/testutil"
+)
+
+func TestValidateTransition(t *testing.T) {
+	t.Parallel()
+	if err := ValidateTransition(StatusSyncingOpenClaw, StatusSynced); err != nil {
+		t.Errorf("valid transition should pass: %v", err)
+	}
+	err := ValidateTransition(StatusSynced, StatusReceiving)
+	if err == nil {
+		t.Fatal("invalid transition should error")
+	}
+	if _, ok := err.(*TransitionError); !ok {
+		t.Errorf("want TransitionError, got %T", err)
+	}
+	if err.Error() == "" {
+		t.Error("error message should be non-empty")
+	}
+}
+
+func TestCanStartTranscription(t *testing.T) {
+	t.Parallel()
+	for _, s := range []string{StatusSynced, StatusTranscribeFailed, StatusTranscribed} {
+		if !CanStartTranscription(s) {
+			t.Errorf("%s should allow transcription", s)
+		}
+	}
+	if CanStartTranscription(StatusReceiving) {
+		t.Error("receiving should not allow transcription")
+	}
+}
+
+func TestIsRecordingStatus(t *testing.T) {
+	t.Parallel()
+	if !IsRecordingStatus(StatusSynced) || !IsRecordingStatus(StatusTranscribed) {
+		t.Error("known statuses should be recognized")
+	}
+	if IsRecordingStatus("totally-made-up") {
+		t.Error("unknown status should be false")
+	}
+}
+
+func TestValidateAsrConfig(t *testing.T) {
+	t.Parallel()
+	if ValidateAsrConfig(nil) == "" {
+		t.Error("nil config should be invalid")
+	}
+	if ValidateAsrConfig(&AsrConfig{Mode: "api"}) != "" {
+		t.Error("api mode should be valid")
+	}
+	if ValidateAsrConfig(&AsrConfig{Mode: "local"}) == "" {
+		t.Error("local mode should be rejected (deprecated)")
+	}
+	if ValidateAsrConfig(&AsrConfig{Mode: "bogus"}) == "" {
+		t.Error("unknown mode should be invalid")
+	}
+	if !IsAsrConfigured(&AsrConfig{Mode: "api"}) {
+		t.Error("api config should be configured")
+	}
+	if IsAsrConfigured(nil) {
+		t.Error("nil should not be configured")
+	}
+}
+
+func TestLoadLocalAsrConfig(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if LoadLocalAsrConfig(dir) != nil {
+		t.Error("missing config -> nil")
+	}
+	testutil.WriteFile(t, filepath.Join(dir, "asr-config.json"), []byte(`{"mode":"api","api":{"apiKey":"k1"}}`))
+	cfg := LoadLocalAsrConfig(dir)
+	if cfg == nil || cfg.Mode != "api" || cfg.API.APIKey != "k1" {
+		t.Errorf("loaded config wrong: %+v", cfg)
+	}
+}
+
+func TestResolveAsrConfig(t *testing.T) {
+	t.Parallel()
+	// caller 优先
+	caller := &AsrConfig{Mode: "api", API: &AsrAPIConfig{APIKey: "caller-key"}}
+	local := &AsrConfig{Mode: "api", API: &AsrAPIConfig{APIKey: "local-key"}}
+	got := ResolveAsrConfig(caller, local, "fallback")
+	if got.API.APIKey != "caller-key" {
+		t.Errorf("caller key should win: %q", got.API.APIKey)
+	}
+	// caller nil -> local
+	got = ResolveAsrConfig(nil, local, "fallback")
+	if got.API.APIKey != "local-key" {
+		t.Errorf("local key should be used: %q", got.API.APIKey)
+	}
+	// 空 apiKey -> 注入 fallback
+	noKey := &AsrConfig{Mode: "api", API: &AsrAPIConfig{}}
+	got = ResolveAsrConfig(noKey, nil, "fallback-key")
+	if got.API.APIKey != "fallback-key" {
+		t.Errorf("fallback key should be injected: %q", got.API.APIKey)
+	}
+	// 非 api mode 原样返回
+	non := &AsrConfig{Mode: "yoooclaw"}
+	if ResolveAsrConfig(non, nil, "x").Mode != "yoooclaw" {
+		t.Error("non-api mode should pass through")
+	}
+	// 全 nil
+	if ResolveAsrConfig(nil, nil, "x") != nil {
+		t.Error("all nil -> nil")
+	}
+}
+
+func TestInitializeAsr(t *testing.T) {
+	testutil.Sandbox(t) // 隔离 creds（避免读到真实 api key）
+	// 校验失败
+	res := InitializeAsr(&AsrConfig{Mode: "local"})
+	if res.OK {
+		t.Error("local mode init should fail")
+	}
+	// 无 key
+	res = InitializeAsr(&AsrConfig{Mode: "api", API: &AsrAPIConfig{}})
+	if res.OK || res.KeyConfigured {
+		t.Errorf("no key should fail init: %+v", res)
+	}
+	// 有 key
+	res = InitializeAsr(&AsrConfig{Mode: "api", API: &AsrAPIConfig{APIKey: "k"}})
+	if !res.OK || !res.KeyConfigured {
+		t.Errorf("with key should succeed: %+v", res)
+	}
+}
+
+func TestAPIValue(t *testing.T) {
+	t.Parallel()
+	var nilCfg *AsrConfig
+	if nilCfg.APIValue().APIKey != "" {
+		t.Error("nil config APIValue should be zero")
+	}
+	cfg := &AsrConfig{Mode: "api", API: &AsrAPIConfig{APIKey: "k"}}
+	if cfg.APIValue().APIKey != "k" {
+		t.Error("APIValue should return api copy")
+	}
+}
+
+func TestParseTranscriptDocument(t *testing.T) {
+	t.Parallel()
+	good := []byte(`{"recordingId":"r1","generatedAt":"2026-06-07T10:00:00Z","source":{"provider":"model-proxy"},"normalized":{"text":"hi"}}`)
+	doc, ok := ParseTranscriptDocument(good)
+	if !ok || doc.RecordingID != "r1" {
+		t.Errorf("valid doc should parse: %+v ok=%v", doc, ok)
+	}
+	// 缺必填字段
+	if _, ok := ParseTranscriptDocument([]byte(`{"recordingId":"r1"}`)); ok {
+		t.Error("missing required fields should fail")
+	}
+	// 非法 JSON
+	if _, ok := ParseTranscriptDocument([]byte(`{bad`)); ok {
+		t.Error("invalid json should fail")
+	}
+}

--- a/internal/recording/store_extra_test.go
+++ b/internal/recording/store_extra_test.go
@@ -1,0 +1,168 @@
+package recording
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func newStore(t *testing.T) *Storage {
+	t.Helper()
+	s := NewStorage(filepath.Join(t.TempDir(), "recordings"), testLogger{t})
+	if err := s.Init(); err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func meta(name, created string) Metadata {
+	return Metadata{Name: name, CreatedAt: created, DurationSec: 1, OssAudioURL: "https://oss.invalid/a.ogg"}
+}
+
+func TestStoreIngestListFindRename(t *testing.T) {
+	s := newStore(t)
+	if _, err := s.Ingest("r1", meta("一", "2026-06-01T00:00:00Z"), "phone-a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Ingest("r2", meta("二", "2026-06-03T00:00:00Z"), ""); err != nil {
+		t.Fatal(err)
+	}
+	all := s.ListAll()
+	if len(all) != 2 || all[0].ID != "r2" {
+		t.Fatalf("ListAll order wrong: %+v", all)
+	}
+	if got, ok := s.FindByID("r1"); !ok || got.ClientLabel != "phone-a" {
+		t.Errorf("FindByID r1: %+v ok=%v", got, ok)
+	}
+	if _, ok := s.FindByID("ghost"); ok {
+		t.Error("missing id should be false")
+	}
+	entry, ok, err := s.Rename("r1", "新名字")
+	if err != nil || !ok || entry.Metadata.Name != "新名字" {
+		t.Errorf("rename: %+v ok=%v err=%v", entry, ok, err)
+	}
+	if _, ok, _ := s.Rename("ghost", "x"); ok {
+		t.Error("rename missing should be false")
+	}
+}
+
+func TestStoreListByStatus(t *testing.T) {
+	s := newStore(t)
+	s.Ingest("r1", meta("a", "2026-06-01T00:00:00Z"), "p")
+	syncing := s.ListByStatus(StatusSyncingOpenClaw)
+	if len(syncing) != 1 {
+		t.Errorf("expected 1 syncing, got %d", len(syncing))
+	}
+	if got := s.ListByStatus(StatusSynced); len(got) != 0 {
+		t.Errorf("expected 0 synced, got %d", len(got))
+	}
+}
+
+func TestStoreSetFilesAndTitle(t *testing.T) {
+	s := newStore(t)
+	s.Ingest("r1", meta("a", "2026-06-01T00:00:00Z"), "p")
+	if err := s.SetTranscriptDataFile("r1", "r1.json"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetTranscriptFile("r1", "r1.md"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetSummaryFile("r1", "r1.md"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetTitle("r1", "  我的标题  "); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := s.FindByID("r1")
+	if got.TranscriptDataFile != "transcript-data/r1.json" || got.TranscriptFile != "transcripts/r1.md" ||
+		got.SummaryFile != "summaries/r1.md" || got.Title != "我的标题" {
+		t.Errorf("set files/title wrong: %+v", got)
+	}
+	// missing id
+	if err := s.SetTitle("ghost", "x"); err != os.ErrNotExist {
+		t.Errorf("set on missing id should be ErrNotExist, got %v", err)
+	}
+}
+
+func TestStoreDelete(t *testing.T) {
+	s := newStore(t)
+	s.Ingest("r1", meta("a", "2026-06-01T00:00:00Z"), "p")
+	// 放一个真实音频文件，验证删除会清理引用文件
+	audioRel := "audio/r1.ogg"
+	if err := os.WriteFile(filepath.Join(s.dir, audioRel), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s.updateEntry("r1", func(e *Entry) { e.AudioFile = audioRel })
+
+	// localOnly: 保留索引、清文件引用
+	ok, err := s.Delete("r1", true)
+	if err != nil || !ok {
+		t.Fatalf("local delete: ok=%v err=%v", ok, err)
+	}
+	got, _ := s.FindByID("r1")
+	if got.AudioFile != "" {
+		t.Error("localOnly delete should clear audioFile")
+	}
+	if _, err := os.Stat(filepath.Join(s.dir, audioRel)); !os.IsNotExist(err) {
+		t.Error("audio file should be removed")
+	}
+
+	// 全删
+	ok, _ = s.Delete("r1", false)
+	if !ok {
+		t.Error("full delete should report true")
+	}
+	if _, found := s.FindByID("r1"); found {
+		t.Error("entry should be gone")
+	}
+	if ok, _ := s.Delete("ghost", false); ok {
+		t.Error("delete missing should be false")
+	}
+}
+
+func TestStoreClose(t *testing.T) {
+	s := newStore(t)
+	if err := s.Close(); err != nil {
+		t.Errorf("Close should be nil: %v", err)
+	}
+}
+
+func TestReadIndexAndEvents(t *testing.T) {
+	s := newStore(t)
+	s.Ingest("r1", meta("a", "2026-06-01T00:00:00Z"), "p")
+	idx := ReadIndex(s.dir)
+	if len(idx) != 1 || idx[0].ID != "r1" {
+		t.Errorf("ReadIndex: %+v", idx)
+	}
+	if ReadIndex(filepath.Join(t.TempDir(), "nope")) != nil {
+		t.Error("missing index -> nil")
+	}
+
+	eventsPath := filepath.Join(t.TempDir(), "events.jsonl")
+	os.WriteFile(eventsPath, []byte("{\"type\":\"a\"}\n\nnot-json\n{\"type\":\"b\"}\n"), 0o600)
+	events := ReadEvents(eventsPath)
+	if len(events) != 2 || events[0]["type"] != "a" || events[1]["type"] != "b" {
+		t.Errorf("ReadEvents should skip blank/bad lines: %+v", events)
+	}
+	if ReadEvents(filepath.Join(t.TempDir(), "none.jsonl")) != nil {
+		t.Error("missing events -> nil")
+	}
+}
+
+func TestLoadIndexRecoversTranscribing(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "recordings")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// 写一个 transcribing 状态的索引，Init 应把它改成 transcribe_failed
+	os.WriteFile(filepath.Join(dir, "index.json"),
+		[]byte(`{"recordings":[{"id":"r1","status":"transcribing","metadata":{"name":"x","created_at":"2026-06-01T00:00:00Z"}}]}`), 0o644)
+	s := NewStorage(dir, testLogger{t})
+	if err := s.Init(); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := s.FindByID("r1")
+	if got.Status != StatusTranscribeFailed || got.LastError == "" {
+		t.Errorf("interrupted transcribing should recover to failed: %+v", got)
+	}
+}

--- a/internal/relay/helpers_test.go
+++ b/internal/relay/helpers_test.go
@@ -1,0 +1,196 @@
+package relay
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestIntField(t *testing.T) {
+	t.Parallel()
+	if intField(Frame{"n": float64(42)}, "n", -1) != 42 {
+		t.Error("float64 field")
+	}
+	if intField(Frame{"n": 7}, "n", -1) != 7 {
+		t.Error("int field")
+	}
+	if intField(Frame{"n": "x"}, "n", 99) != 99 {
+		t.Error("fallback on wrong type")
+	}
+	if intField(Frame{}, "missing", 5) != 5 {
+		t.Error("fallback on missing")
+	}
+}
+
+func TestStringField(t *testing.T) {
+	t.Parallel()
+	if stringField(Frame{"s": "hi"}, "s") != "hi" {
+		t.Error("string field")
+	}
+	if stringField(Frame{"s": 1}, "s") != "" {
+		t.Error("non-string -> empty")
+	}
+}
+
+func TestHeadersFromFrame(t *testing.T) {
+	t.Parallel()
+	got := headersFromFrame(map[string]any{"A": "1", "B": 2, "C": "3"})
+	if got["A"] != "1" || got["C"] != "3" {
+		t.Errorf("string headers should survive: %+v", got)
+	}
+	if _, ok := got["B"]; ok {
+		t.Error("non-string header should be dropped")
+	}
+	if len(headersFromFrame("not-a-map")) != 0 {
+		t.Error("non-map -> empty")
+	}
+}
+
+func TestFlattenHeaders(t *testing.T) {
+	t.Parallel()
+	h := http.Header{}
+	h.Add("X-Test", "a")
+	h.Add("X-Test", "b")
+	flat := flattenHeaders(h)
+	if flat["x-test"] != "a, b" {
+		t.Errorf("flatten should lowercase + join: %+v", flat)
+	}
+}
+
+func TestMapPath(t *testing.T) {
+	t.Parallel()
+	if mapPath("/api/message/messageBridge/send") != "/notifications" {
+		t.Error("messageBridge should map to /notifications")
+	}
+	if mapPath("/foo") != "/foo" {
+		t.Error("absolute path unchanged")
+	}
+	if mapPath("foo") != "/foo" {
+		t.Error("relative path should get leading slash")
+	}
+}
+
+func TestRequestBody(t *testing.T) {
+	t.Parallel()
+	if requestBody(http.MethodGet, "body") != nil {
+		t.Error("GET should have nil body")
+	}
+	if requestBody(http.MethodHead, "body") != nil {
+		t.Error("HEAD should have nil body")
+	}
+	if requestBody(http.MethodPost, "body") == nil {
+		t.Error("POST should carry body")
+	}
+}
+
+func TestRedactURL(t *testing.T) {
+	t.Parallel()
+	got := redactURL("wss://host/ws?apiKey=supersecretkey123")
+	if strings.Contains(got, "supersecretkey123") {
+		t.Errorf("apiKey should be redacted: %q", got)
+	}
+	if redactURL("://bad") == "" {
+		t.Error("unparseable url returned as-is")
+	}
+}
+
+func TestPreview(t *testing.T) {
+	t.Parallel()
+	if preview("short", 10) != "short" {
+		t.Error("short unchanged")
+	}
+	if preview("0123456789", 4) != "0123..." {
+		t.Error("long should be truncated")
+	}
+}
+
+func TestMin(t *testing.T) {
+	t.Parallel()
+	if min(3, 5) != 3 || min(5, 3) != 3 || min(4, 4) != 4 {
+		t.Error("min")
+	}
+}
+
+func TestRelayCredential(t *testing.T) {
+	t.Parallel()
+	c := relayCredential("  Bearer my-key ")
+	if c.Query["apiKey"] != "my-key" {
+		t.Errorf("should strip Bearer + trim: %+v", c.Query)
+	}
+}
+
+func TestDispatcherInternalHeaders(t *testing.T) {
+	t.Parallel()
+	client := NewClient(ClientOptions{TunnelURL: "ws://x", CredentialProvider: func() (Credential, error) { return Credential{}, nil }})
+	d := NewDispatcher(DispatcherOptions{Client: client, HTTPBaseURL: "http://local", HTTPToken: "tok", ClientLabel: "phone-a", Logger: testLogger{t}})
+
+	m := map[string]string{}
+	d.addInternalHeaders(m)
+	if m[InternalHTTPHeader] != "1" || m[InternalClientLabelHeader] != "phone-a" || m["Authorization"] != "Bearer tok" {
+		t.Errorf("addInternalHeaders wrong: %+v", m)
+	}
+
+	h := http.Header{}
+	d.addInternalHeadersMap(h)
+	if h.Get(InternalHTTPHeader) != "1" || h.Get("Authorization") != "Bearer tok" {
+		t.Errorf("addInternalHeadersMap wrong: %+v", h)
+	}
+}
+
+func TestClientStatusAndReconnect(t *testing.T) {
+	t.Parallel()
+	c := NewClient(ClientOptions{
+		TunnelURL:          "ws://example/ws",
+		CredentialProvider: func() (Credential, error) { return Credential{}, nil },
+		ReconnectBackoffMs: 100,
+	})
+	if c.IsConnected() {
+		t.Error("new client should not be connected")
+	}
+	st := c.Status()
+	if st.Connected || st.URL != "ws://example/ws" {
+		t.Errorf("status: %+v", st)
+	}
+	c.setConnected()
+	if !c.IsConnected() {
+		t.Error("should be connected after setConnected")
+	}
+	c.setDisconnected("boom")
+	if c.IsConnected() || c.Status().LastDisconnectReason != "boom" {
+		t.Errorf("disconnect state wrong: %+v", c.Status())
+	}
+	// nextReconnectDelay 单调递增 attempt 且有上限
+	d1 := c.nextReconnectDelay()
+	d2 := c.nextReconnectDelay()
+	if d1 <= 0 || d2 < d1 {
+		t.Errorf("reconnect delays should grow: %v then %v", d1, d2)
+	}
+	if d2 > time.Minute {
+		t.Errorf("delay should cap at 1m: %v", d2)
+	}
+}
+
+func TestClientOnConnectedHandlers(t *testing.T) {
+	t.Parallel()
+	c := NewClient(ClientOptions{TunnelURL: "ws://x", CredentialProvider: func() (Credential, error) { return Credential{}, nil }})
+	connected := make(chan struct{}, 1)
+	disconnected := make(chan string, 1)
+	c.OnConnected(func() { connected <- struct{}{} })
+	c.OnDisconnected(func(reason string) { disconnected <- reason })
+	c.emitConnected()
+	c.emitDisconnected("bye")
+	select {
+	case <-connected:
+	case <-time.After(time.Second):
+		t.Error("OnConnected handler not invoked")
+	}
+	select {
+	case r := <-disconnected:
+		if r != "bye" {
+			t.Errorf("disconnect reason = %q", r)
+		}
+	case <-time.After(time.Second):
+		t.Error("OnDisconnected handler not invoked")
+	}
+}

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -1,0 +1,187 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/YoooClaw/cli/internal/errs"
+)
+
+func TestParseSkillMeta(t *testing.T) {
+	t.Parallel()
+	md := "---\nname: my-skill\ndescription: does things\n---\n# body\n"
+	name, desc := parseSkillMeta(md)
+	if name != "my-skill" || desc != "does things" {
+		t.Errorf("parsed (%q,%q)", name, desc)
+	}
+	// 无 frontmatter
+	n2, d2 := parseSkillMeta("# no frontmatter")
+	if n2 != "" || d2 != "" {
+		t.Errorf("no frontmatter should yield empties, got (%q,%q)", n2, d2)
+	}
+}
+
+func TestList(t *testing.T) {
+	t.Parallel()
+	got, err := List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) == 0 {
+		t.Fatal("expected embedded skills")
+	}
+	names := make([]string, len(got))
+	for i, b := range got {
+		names[i] = b.Name
+		if b.Title == "" {
+			t.Errorf("skill %q missing title", b.Name)
+		}
+	}
+	if !sort.StringsAreSorted(names) {
+		t.Errorf("skills should be sorted: %v", names)
+	}
+}
+
+// isolateHome 把 HOME / CODEX_HOME 指向临时目录，隔离 agent 探测。
+func isolateHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", "")
+	return home
+}
+
+func TestTargetsNoneDetected(t *testing.T) {
+	isolateHome(t)
+	for _, c := range Targets() {
+		if c.Detected {
+			t.Errorf("agent %q should not be detected in clean home", c.Agent)
+		}
+	}
+}
+
+func TestTargetsClaudeDetected(t *testing.T) {
+	home := isolateHome(t)
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	var claudeDetected bool
+	for _, c := range Targets() {
+		if c.Agent == "claude" {
+			claudeDetected = c.Detected
+		}
+	}
+	if !claudeDetected {
+		t.Error("claude should be detected when ~/.claude exists")
+	}
+}
+
+func TestResolveTargetInvalidAgent(t *testing.T) {
+	t.Parallel()
+	_, err := ResolveTarget("bogus", "")
+	if e, ok := err.(*errs.Error); !ok || e.Code != errs.CodeInvalidArgument {
+		t.Errorf("want INVALID_ARGUMENT, got %v", err)
+	}
+}
+
+func TestResolveTargetExplicit(t *testing.T) {
+	t.Parallel()
+	sel, err := ResolveTarget("auto", "/custom/dir")
+	if err != nil || sel.Agent != "custom" || sel.Target != "/custom/dir" {
+		t.Errorf("explicit auto->custom: %+v err=%v", sel, err)
+	}
+	sel, err = ResolveTarget("claude", "/x")
+	if err != nil || sel.Agent != "claude" || sel.Target != "/x" {
+		t.Errorf("explicit claude: %+v err=%v", sel, err)
+	}
+}
+
+func TestResolveTargetCustomWithoutTarget(t *testing.T) {
+	t.Parallel()
+	_, err := ResolveTarget("custom", "")
+	if e, ok := err.(*errs.Error); !ok || e.Code != errs.CodeInvalidArgument {
+		t.Errorf("custom without target should error: %v", err)
+	}
+}
+
+func TestResolveTargetAgentDefault(t *testing.T) {
+	home := isolateHome(t)
+	sel, err := ResolveTarget("codex", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sel.Source != "agent-default" || sel.Target != filepath.Join(home, ".codex", "skills") {
+		t.Errorf("agent-default mismatch: %+v", sel)
+	}
+}
+
+func TestResolveTargetAutoNoneDetected(t *testing.T) {
+	isolateHome(t)
+	_, err := ResolveTarget("auto", "")
+	if e, ok := err.(*errs.Error); !ok || e.Code != errs.CodeNotFound {
+		t.Errorf("auto none -> NOT_FOUND, got %v", err)
+	}
+}
+
+func TestResolveTargetAutoSingle(t *testing.T) {
+	home := isolateHome(t)
+	os.MkdirAll(filepath.Join(home, ".claude"), 0o700)
+	sel, err := ResolveTarget("auto", "")
+	if err != nil || sel.Agent != "claude" || sel.Source != "auto-detected" {
+		t.Errorf("auto single: %+v err=%v", sel, err)
+	}
+}
+
+func TestResolveTargetAutoMultiple(t *testing.T) {
+	home := isolateHome(t)
+	os.MkdirAll(filepath.Join(home, ".claude"), 0o700)
+	os.MkdirAll(filepath.Join(home, ".codex"), 0o700)
+	_, err := ResolveTarget("auto", "")
+	if e, ok := err.(*errs.Error); !ok || e.Code != errs.CodeConfirmationRequired {
+		t.Errorf("auto multiple -> CONFIRMATION_REQUIRED, got %v", err)
+	}
+}
+
+func TestInstall(t *testing.T) {
+	t.Parallel()
+	target := filepath.Join(t.TempDir(), "skills")
+	results, installed, err := Install(target, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(installed) == 0 || len(results) == 0 {
+		t.Fatal("expected installs")
+	}
+	// 验证至少一个 SKILL.md 真被解包
+	first := results[0]
+	if first.Status != "installed" {
+		t.Errorf("first should be installed: %+v", first)
+	}
+	if _, err := os.Stat(filepath.Join(first.Dest, "SKILL.md")); err != nil {
+		t.Errorf("SKILL.md not extracted: %v", err)
+	}
+
+	// 再次安装：全部 skipped
+	results2, _, err := Install(target, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range results2 {
+		if r.Status != "skipped" {
+			t.Errorf("expected skipped on re-install: %+v", r)
+		}
+	}
+
+	// force：重新安装
+	results3, _, err := Install(target, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range results3 {
+		if r.Status != "installed" {
+			t.Errorf("force should reinstall: %+v", r)
+		}
+	}
+}

--- a/internal/testutil/golden.go
+++ b/internal/testutil/golden.go
@@ -1,0 +1,37 @@
+package testutil
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// update 控制 golden 文件刷新：go test ./... -update 时重写期望值。
+var update = flag.Bool("update", false, "刷新 golden 测试的期望文件（testdata/*.golden）")
+
+// Golden 比对 got 与 testdata/<name>.golden 的内容。
+// 带 -update 时把 got 写回 golden 文件并通过；否则不一致即 t.Errorf。
+//
+//	body := light.BuildLightEffectApnsBody(...)
+//	testutil.Golden(t, "preset_breathing", []byte(body))
+func Golden(t *testing.T, name string, got []byte) {
+	t.Helper()
+	path := filepath.Join("testdata", name+".golden")
+	if *update {
+		if err := os.MkdirAll("testdata", 0o755); err != nil {
+			t.Fatalf("testutil.Golden: mkdir testdata: %v", err)
+		}
+		if err := os.WriteFile(path, got, 0o644); err != nil {
+			t.Fatalf("testutil.Golden: 写入 golden 失败: %v", err)
+		}
+		return
+	}
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("testutil.Golden: 读取 %s 失败（首次运行请加 -update）: %v", path, err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("golden 不一致 %s\n--- want ---\n%s\n--- got ---\n%s", path, want, got)
+	}
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -1,0 +1,63 @@
+// Package testutil 汇集单元测试公用的沙箱、假日志与 golden 帮手。
+//
+// 设计目标：每个测试自带隔离环境，不触碰真实 ~/.yoooclaw、不连网、不调系统钥匙串。
+// 仅供 *_test.go 使用（依赖 testing），不要被生产代码 import。
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/YoooClaw/cli/internal/fsutil"
+	"github.com/YoooClaw/cli/internal/paths"
+)
+
+// Sandbox 把 YOOOCLAW_HOME 指向一个临时目录，并预建好 default profile 目录。
+// 返回该 profile 的 Paths。t.Setenv 会在测试结束时自动还原环境变量。
+//
+//	p := testutil.Sandbox(t)
+//	config.Save(p, cfg)   // 写入临时目录，互不干扰
+func Sandbox(t *testing.T) paths.Paths {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("YOOOCLAW_HOME", home)
+	p := paths.For(paths.DefaultProfile)
+	if err := fsutil.EnsureDir(p.Dir, fsutil.DirMode); err != nil {
+		t.Fatalf("testutil.Sandbox: 创建 profile 目录失败: %v", err)
+	}
+	return p
+}
+
+// SandboxProfile 同 Sandbox，但解析指定 profile（多 profile 场景）。
+func SandboxProfile(t *testing.T, profile string) paths.Paths {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("YOOOCLAW_HOME", home)
+	p := paths.For(profile)
+	if err := fsutil.EnsureDir(p.Dir, fsutil.DirMode); err != nil {
+		t.Fatalf("testutil.SandboxProfile: 创建 profile 目录失败: %v", err)
+	}
+	return p
+}
+
+// Logger 是把日志转发到 t.Log 的假实现，满足各包 Info/Warn/Error(string) 日志接口。
+// 用法：testutil.Logger{T: t}
+//
+// 取代 recording / relay 等包各自重复定义的 testLogger。
+type Logger struct{ T *testing.T }
+
+func (l Logger) Info(msg string)  { l.T.Helper(); l.T.Log("[INFO] " + msg) }
+func (l Logger) Warn(msg string)  { l.T.Helper(); l.T.Log("[WARN] " + msg) }
+func (l Logger) Error(msg string) { l.T.Helper(); l.T.Log("[ERROR] " + msg) }
+
+// WriteFile 在沙箱里写一个文件（自动建父目录），失败即 t.Fatal。便于摆放 fixture。
+func WriteFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), fsutil.DirMode); err != nil {
+		t.Fatalf("testutil.WriteFile: mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, data, fsutil.SecretFileMode); err != nil {
+		t.Fatalf("testutil.WriteFile: %v", err)
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -21,7 +21,15 @@ var Version = "dev"
 // 因此运行期按可执行文件路径是否在 node_modules 下来判定，决定 update 的升级命令。
 func Dist() string {
 	exe, err := os.Executable()
-	if err == nil && strings.Contains(exe, "node_modules") {
+	if err != nil {
+		return "native"
+	}
+	return distFor(exe)
+}
+
+// distFor 按可执行文件路径判定分发渠道（抽出以便单测两个分支）。
+func distFor(exe string) string {
+	if strings.Contains(exe, "node_modules") {
 		return "npm"
 	}
 	return "native"

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,42 @@
+package version
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestVersionDefault(t *testing.T) {
+	t.Parallel()
+	if Version == "" {
+		t.Error("Version should never be empty")
+	}
+}
+
+func TestDistFor(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		exe  string
+		want string
+	}{
+		{"/usr/local/bin/yoooclaw", "native"},
+		{"/home/u/project/node_modules/.bin/yoooclaw", "npm"},
+		{"/opt/node_modules/@yoooclaw/cli-darwin-arm64/yoooclaw", "npm"},
+		{"", "native"},
+	}
+	for _, tt := range tests {
+		if got := distFor(tt.exe); got != tt.want {
+			t.Errorf("distFor(%q) = %q, want %q", tt.exe, got, tt.want)
+		}
+	}
+}
+
+func TestDist(t *testing.T) {
+	t.Parallel()
+	// 测试二进制不在 node_modules 下，应判定 native。
+	if got := Dist(); got != "native" && got != "npm" {
+		t.Errorf("Dist() = %q, want native|npm", got)
+	}
+	if strings.TrimSpace(Dist()) == "" {
+		t.Error("Dist() should never be empty")
+	}
+}

--- a/scripts/coverage-gate.sh
+++ b/scripts/coverage-gate.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# coverage-gate.sh —— 总覆盖率门禁：低于 MIN_COVERAGE 即失败（只许涨不许跌）。
+#
+# 用法：
+#   scripts/coverage-gate.sh            # 用 coverage.out（需先 go test -coverprofile）
+#   MIN_COVERAGE=60 scripts/coverage-gate.sh
+#
+# 提升阈值的节奏：补完一波测试后，把 MIN_COVERAGE 抬到略低于当前实际值。
+set -euo pipefail
+
+MIN_COVERAGE="${MIN_COVERAGE:-55}"
+PROFILE="${1:-coverage.out}"
+
+if [[ ! -f "$PROFILE" ]]; then
+  echo "覆盖率文件不存在：$PROFILE（先跑 go test -coverprofile=$PROFILE ./...）" >&2
+  exit 2
+fi
+
+total="$(go tool cover -func="$PROFILE" | awk '/^total:/ {gsub(/%/,"",$NF); print $NF}')"
+
+awk -v t="$total" -v m="$MIN_COVERAGE" 'BEGIN {
+  printf "总覆盖率 %.1f%%（门禁 %.1f%%）\n", t, m
+  if (t + 0.001 < m) { print "✗ 覆盖率低于门禁"; exit 1 }
+  print "✓ 覆盖率达标"
+}'


### PR DESCRIPTION
## What changed

- Added broad Go unit test coverage across internal packages using standard `testing` patterns.
- Added shared test helpers under `internal/testutil` plus keychain seams for deterministic tests.
- Updated CI to run `go test -race -coverprofile=coverage.out ./...`, print coverage, and enforce a 55% coverage gate.
- Added local test commands in `Makefile` and documented the testing strategy in `docs/testing.md`.

## Why

CI already had a basic `go test ./...` step, but this change makes the unit-test signal stronger by enabling race detection and a coverage gate, while keeping release/publish steps out of scope.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race -coverprofile=coverage.out ./...`
- `MIN_COVERAGE=55 scripts/coverage-gate.sh`
- `scripts/build-go.sh --current`

Coverage result: `57.5%` total statements.