### PR TITLE
cli-0.2.1

### DIFF
--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -420,10 +420,13 @@ func listenWithFallback(bind string, startPort int, logger *Logger) (net.Listene
 	for attempt := 0; attempt < 64; attempt++ {
 		ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", bind, port))
 		if err == nil {
-			if port != startPort {
-				logger.Info(fmt.Sprintf("起始端口 %d 被占用，最终绑定到 %d", startPort, port))
+			actualPort := listenerPort(ln, port)
+			if startPort == 0 {
+				logger.Info(fmt.Sprintf("系统分配 daemon 端口 %d", actualPort))
+			} else if actualPort != startPort {
+				logger.Info(fmt.Sprintf("起始端口 %d 被占用，最终绑定到 %d", startPort, actualPort))
 			}
-			return ln, port, nil
+			return ln, actualPort, nil
 		}
 		if !strings.Contains(err.Error(), "address already in use") {
 			return nil, 0, err
@@ -432,6 +435,13 @@ func listenWithFallback(bind string, startPort int, logger *Logger) (net.Listene
 		port++
 	}
 	return nil, 0, errs.New(errs.CodeUnknown, "无可用端口")
+}
+
+func listenerPort(ln net.Listener, fallback int) int {
+	if addr, ok := ln.Addr().(*net.TCPAddr); ok {
+		return addr.Port
+	}
+	return fallback
 }
 
 func writeJSON(w http.ResponseWriter, status int, body any) {

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -128,6 +129,26 @@ func TestServerNotFound(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != 404 {
 		t.Errorf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestListenWithFallbackPortZeroReturnsActualPort(t *testing.T) {
+	t.Parallel()
+	logger := NewLogger(filepath.Join(t.TempDir(), "d.log"), "info", false)
+	ln, port, err := listenWithFallback("127.0.0.1", 0, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	if port == 0 {
+		t.Fatal("expected actual allocated port, got 0")
+	}
+	addr, ok := ln.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("listener addr type = %T, want *net.TCPAddr", ln.Addr())
+	}
+	if port != addr.Port {
+		t.Fatalf("returned port = %d, listener port = %d", port, addr.Port)
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {


### PR DESCRIPTION
## What changed

- Bumped `@yoooclaw/cli` to `0.2.1`.
- Fixed daemon startup with `daemon.port=0` by recording the actual OS-assigned listener port instead of keeping `0` in the lock/status path.
- Added a regression test for `listenWithFallback("127.0.0.1", 0, ...)`.

## Why

The 0.2.0 package can start a daemon when `daemon.port=0`, but follow-up commands such as `daemon status` try to connect to `127.0.0.1:0` because the lock records the configured port rather than the real listener port.

## Validation

- `go test ./...`
- `go vet ./...`
- `scripts/build-go.sh --current`
- Built `0.2.1` binary smoke test with `daemon.port=0`: `daemon start`, `daemon status`, `api GET /health`, `daemon stop` all passed.