### PR TITLE
cli-0.2.2

### DIFF
--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -70,6 +70,7 @@ func RunForeground(ctx *clictx.Context, opts StartOpts) error {
 	}
 
 	_ = fsutil.EnsureDir(ctx.Paths.Dir, fsutil.DirMode)
+	ctx.Paths.MigrateLogs()
 	logger := NewLogger(ctx.Paths.DaemonLog, logLevel, false)
 	st := &runtimeState{startedAt: time.Now().UTC().Format(time.RFC3339)}
 

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -6,7 +6,8 @@
 //	  profiles/<profile>/
 //	    config.json
 //	    credentials.json          instance 级密文
-//	    daemon.lock / daemon.log
+//	    daemon.lock
+//	    logs/daemon.log           daemon 日志 + 轮转文件（logs/daemon.log.YYYY-MM-DD）
 //	    notifications/ recordings/ images/ light-rules/ state/
 package paths
 
@@ -56,6 +57,7 @@ type Paths struct {
 	Config        string
 	Credentials   string
 	DaemonLock    string
+	Logs          string
 	DaemonLog     string
 	Notifications string
 	Recordings    string
@@ -73,12 +75,41 @@ func For(profile string) Paths {
 		Config:        filepath.Join(dir, "config.json"),
 		Credentials:   filepath.Join(dir, "credentials.json"),
 		DaemonLock:    filepath.Join(dir, "daemon.lock"),
-		DaemonLog:     filepath.Join(dir, "daemon.log"),
+		Logs:          filepath.Join(dir, "logs"),
+		DaemonLog:     filepath.Join(dir, "logs", "daemon.log"),
 		Notifications: filepath.Join(dir, "notifications"),
 		Recordings:    filepath.Join(dir, "recordings"),
 		Images:        filepath.Join(dir, "images"),
 		LightRules:    filepath.Join(dir, "light-rules"),
 		State:         filepath.Join(dir, "state"),
+	}
+}
+
+// MigrateLogs 把旧布局里直接放在 profile 根目录的 daemon.log（含轮转文件
+// daemon.log.YYYY-MM-DD）一次性挪进 logs/ 子目录。已是新布局时为 no-op。
+func (p Paths) MigrateLogs() {
+	entries, err := os.ReadDir(p.Dir)
+	if err != nil {
+		return
+	}
+	var moved []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if name == "daemon.log" || strings.HasPrefix(name, "daemon.log.") {
+			moved = append(moved, name)
+		}
+	}
+	if len(moved) == 0 {
+		return
+	}
+	if err := os.MkdirAll(p.Logs, 0o700); err != nil {
+		return
+	}
+	for _, name := range moved {
+		_ = os.Rename(filepath.Join(p.Dir, name), filepath.Join(p.Logs, name))
 	}
 }
 

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -59,7 +59,8 @@ func TestFor(t *testing.T) {
 	}
 	cases := map[string]string{
 		p.Config: "config.json", p.Credentials: "credentials.json",
-		p.DaemonLock: "daemon.lock", p.DaemonLog: "daemon.log",
+		p.DaemonLock: "daemon.lock", p.Logs: "logs",
+		p.DaemonLog:     filepath.Join("logs", "daemon.log"),
 		p.Notifications: "notifications", p.Recordings: "recordings",
 		p.Images: "images", p.LightRules: "light-rules", p.State: "state",
 	}
@@ -68,6 +69,43 @@ func TestFor(t *testing.T) {
 			t.Errorf("path for %q = %q", leaf, got)
 		}
 	}
+}
+
+func TestMigrateLogs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("YOOOCLAW_HOME", home)
+	p := For("acme")
+	if err := os.MkdirAll(p.Dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// 旧布局：日志直接放在 profile 根目录。
+	old := []string{"daemon.log", "daemon.log.2026-06-01", "daemon.log.2026-06-02"}
+	for _, name := range old {
+		if err := os.WriteFile(filepath.Join(p.Dir, name), []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// 非日志文件不应被搬动。
+	if err := os.WriteFile(p.Config, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	p.MigrateLogs()
+
+	for _, name := range old {
+		if _, err := os.Stat(filepath.Join(p.Dir, name)); !os.IsNotExist(err) {
+			t.Errorf("%s 仍在根目录，应已搬走", name)
+		}
+		if _, err := os.Stat(filepath.Join(p.Logs, name)); err != nil {
+			t.Errorf("%s 未出现在 logs/: %v", name, err)
+		}
+	}
+	if _, err := os.Stat(p.Config); err != nil {
+		t.Errorf("config.json 不应被搬动: %v", err)
+	}
+
+	// 已是新布局时为幂等 no-op，不报错。
+	p.MigrateLogs()
 }
 
 func TestListProfileNames(t *testing.T) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {


### PR DESCRIPTION
## 内容

### daemon 日志收进 logs/ 子目录
之前每个 profile 的 `daemon.log` 和按日轮转的 `daemon.log.YYYY-MM-DD` 全部直接堆在 profile 根目录，文件一多很乱。本次统一收进 `logs/` 子目录：

- `paths`: 新增 `Logs` 字段，`DaemonLog` 改为 `logs/daemon.log`
- `paths.MigrateLogs`: 一次性把旧布局根目录下的 `daemon.log*` 搬进 `logs/`，幂等、只动日志文件
- daemon server 启动建 logger 前调用迁移，老用户重启后自动归位

读写两端都走 `ctx.Paths.DaemonLog`，且 logger/logread 内部用 `filepath.Dir` 推导目录，无需改动即跟随新位置。

迁移后目录布局：
```
profiles/default/
  config.json  credentials.json  daemon.lock
  logs/        ← daemon.log 及所有轮转文件
  notifications/  recordings/  state/  tasks/
```

### 版本 bump
`0.2.1` → `0.2.2`

## 测试
`go build ./...` + `go test ./...` 全绿。

> 注：发布触发器是 tag 推送（`cli-v0.2.2`），本 PR 仅同步主干，未推 tag。

🤖 Generated with [Claude Code](https://claude.com/claude-code)