### PR TITLE
cli-0.2.3

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,9 @@
 package config
 
 import (
+	"strings"
+
+	"github.com/YoooClaw/cli/internal/envhost"
 	"github.com/YoooClaw/cli/internal/errs"
 	"github.com/YoooClaw/cli/internal/fsutil"
 	"github.com/YoooClaw/cli/internal/paths"
@@ -20,12 +23,31 @@ const (
 	DefaultImageMaxByte = 20 * 1024 * 1024
 )
 
-// RelayHost 是默认 Relay 主机；可由构建期 ldflags 注入覆盖，未注入时回退生产域名。
-var RelayHost = "openclaw-service.yoooclaw.com"
+// RelayPath 是 Relay 隧道 WebSocket 的固定路径。
+const RelayPath = "/message/messages/ws/plugin"
 
-// DefaultRelayURL 返回默认 Relay 隧道地址（复用 phone-notifications 托管 Relay）。
+// DefaultRelayURL 返回默认 Relay 隧道地址；主机随 PHONE_NOTIFICATIONS_ENV 切换
+// （development/test/production，见 internal/envhost），复用 phone-notifications 托管 Relay。
 func DefaultRelayURL() string {
-	return "wss://" + RelayHost + "/message/messages/ws/plugin"
+	return "wss://" + envhost.Host() + RelayPath
+}
+
+// ResolveRelayURL 返回 daemon 实际应连接的 Relay 地址。
+// 若配置里持久化的仍是某个环境的内置默认主机（而非用户自定义 URL），则按当前
+// PHONE_NOTIFICATIONS_ENV 重新解析，使已初始化的 profile 也能跟随环境切换；
+// 用户显式改过的自定义 URL 始终保留。
+func ResolveRelayURL(cfg Config) string {
+	url := cfg.Relay.URL
+	if url == "" || envhost.IsDefaultHost(stripRelayURL(url)) {
+		return DefaultRelayURL()
+	}
+	return url
+}
+
+// stripRelayURL 从 Relay URL 中提取主机部分（去掉 scheme 与已知路径）供默认值判定。
+func stripRelayURL(url string) string {
+	host := envhost.Normalize(url)
+	return strings.TrimSuffix(host, RelayPath)
 }
 
 // SecretRefPaths 是 config.json 里需要遮罩展示的敏感引用字段（点号路径）。

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,11 +9,34 @@ import (
 )
 
 func TestDefaultRelayURL(t *testing.T) {
-	old := RelayHost
-	t.Cleanup(func() { RelayHost = old })
-	RelayHost = "example.test"
+	t.Setenv("PHONE_NOTIFICATIONS_ENV", "test")
+	t.Setenv("OPENCLAW_HOST_TEST", "example.test")
 	if got := DefaultRelayURL(); got != "wss://example.test/message/messages/ws/plugin" {
 		t.Errorf("DefaultRelayURL = %q", got)
+	}
+}
+
+func TestResolveRelayURL(t *testing.T) {
+	t.Setenv("PHONE_NOTIFICATIONS_ENV", "test")
+	t.Setenv("OPENCLAW_HOST_TEST", "")
+
+	// 持久化的仍是另一环境的内置默认主机 → 跟随当前环境（test）重新解析。
+	cfg := Config{Relay: RelaySection{URL: "wss://openclaw-service.yoooclaw.com" + RelayPath}}
+	if got := ResolveRelayURL(cfg); got != "wss://openclaw-service-test.yoooclaw.com"+RelayPath {
+		t.Errorf("default-host URL should follow env, got %q", got)
+	}
+
+	// 用户自定义 URL → 原样保留。
+	custom := "wss://my-relay.example.com/custom/path"
+	cfg.Relay.URL = custom
+	if got := ResolveRelayURL(cfg); got != custom {
+		t.Errorf("custom URL should be preserved, got %q", got)
+	}
+
+	// 空 URL → 回退当前环境默认。
+	cfg.Relay.URL = ""
+	if got := ResolveRelayURL(cfg); got != "wss://openclaw-service-test.yoooclaw.com"+RelayPath {
+		t.Errorf("empty URL should fall back to env default, got %q", got)
 	}
 }
 

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -114,7 +114,7 @@ func RunForeground(ctx *clictx.Context, opts StartOpts) error {
 			logger.Warn("Relay 已启用但未设置 api-key；当前仅直连 HTTP")
 		} else {
 			srv.tunnelSupervisor = relay.NewSupervisor(relay.SupervisorOptions{
-				TunnelURL:          cfg.Relay.URL,
+				TunnelURL:          config.ResolveRelayURL(cfg),
 				HTTPBaseURL:        "http://127.0.0.1:" + fmt.Sprint(actualPort),
 				HTTPToken:          token,
 				HeartbeatSec:       cfg.Relay.HeartbeatSec,
@@ -204,7 +204,7 @@ func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if s.cfg.Relay.Enabled {
 			if s.tunnelSupervisor == nil && len(s.credentialSet.Entries) > 0 {
 				s.tunnelSupervisor = relay.NewSupervisor(relay.SupervisorOptions{
-					TunnelURL:          s.cfg.Relay.URL,
+					TunnelURL:          config.ResolveRelayURL(s.cfg),
 					HTTPBaseURL:        "http://127.0.0.1:" + fmt.Sprint(s.port),
 					HTTPToken:          s.token,
 					HeartbeatSec:       s.cfg.Relay.HeartbeatSec,
@@ -382,7 +382,7 @@ func (s *server) relayStatusPayload() map[string]any {
 			note = "Relay 重连中"
 		}
 		return map[string]any{
-			"mode": "relay", "connected": connected, "url": s.cfg.Relay.URL, "enabled": s.cfg.Relay.Enabled,
+			"mode": "relay", "connected": connected, "url": config.ResolveRelayURL(s.cfg), "enabled": s.cfg.Relay.Enabled,
 			"reconnectAttempt": reconnectAttempt, "lastDisconnectReason": nilIfEmptyStr(lastDisconnectReason),
 			"note": note, "tunnels": status.Tunnels,
 		}
@@ -392,7 +392,7 @@ func (s *server) relayStatusPayload() map[string]any {
 		note = "Relay 已启用但当前 CredentialSet 没有可用 api-key"
 	}
 	return map[string]any{
-		"mode": "standalone-http", "connected": false, "url": s.cfg.Relay.URL, "enabled": s.cfg.Relay.Enabled,
+		"mode": "standalone-http", "connected": false, "url": config.ResolveRelayURL(s.cfg), "enabled": s.cfg.Relay.Enabled,
 		"reconnectAttempt": 0, "note": note, "tunnels": []any{},
 	}
 }

--- a/internal/daemon/server_services.go
+++ b/internal/daemon/server_services.go
@@ -70,7 +70,7 @@ func (s *server) handleTunnel(w http.ResponseWriter, r *http.Request, path strin
 		writeJSON(w, 200, map[string]any{
 			"ok": true, "mode": relayStatus["mode"], "credentialMode": s.credentialSet.Mode,
 			"defaultLabel": defaultEntryLabel(s.credentialSet),
-			"connected":    relayStatus["connected"], "relayUrl": s.cfg.Relay.URL, "enabled": s.cfg.Relay.Enabled,
+			"connected":    relayStatus["connected"], "relayUrl": relayStatus["url"], "enabled": s.cfg.Relay.Enabled,
 			"reconnectAttempt": relayStatus["reconnectAttempt"], "lastDisconnectReason": relayStatus["lastDisconnectReason"],
 			"note": relayStatus["note"], "tunnels": relayStatus["tunnels"],
 		})

--- a/internal/envhost/envhost.go
+++ b/internal/envhost/envhost.go
@@ -1,0 +1,77 @@
+// Package envhost 统一解析 OpenClaw 各云端接口的环境主机。
+//
+// 环境名取自 PHONE_NOTIFICATIONS_ENV（development/test/production，缺省 production），
+// 每个环境可用 OPENCLAW_HOST_{DEVELOPMENT,TEST,PRODUCTION} 覆盖默认域名。
+// daemon Relay 隧道、灯效 API、ASR 接口共用此处逻辑，保证三套接口环境切换一致。
+package envhost
+
+import (
+	"os"
+	"regexp"
+	"strings"
+)
+
+// defaultHosts 是各环境默认主机（构建期可通过 OPENCLAW_HOST_* 注入覆盖）。
+var defaultHosts = map[string]string{
+	"development": "openclaw-service-dev.yoooclaw.com",
+	"test":        "openclaw-service-test.yoooclaw.com",
+	"production":  "openclaw-service.yoooclaw.com",
+}
+
+var (
+	schemeRE        = regexp.MustCompile(`^(https?|wss?)://`)
+	trailingSlashRE = regexp.MustCompile(`/+$`)
+)
+
+// Normalize 去掉协议前缀、首尾空白与尾部斜杠，得到纯主机名。
+func Normalize(host string) string {
+	trimmed := strings.TrimSpace(host)
+	if trimmed == "" {
+		return ""
+	}
+	trimmed = schemeRE.ReplaceAllString(trimmed, "")
+	return trailingSlashRE.ReplaceAllString(trimmed, "")
+}
+
+// Name 返回当前环境名（PHONE_NOTIFICATIONS_ENV 优先，未知值回退 production）。
+func Name() string {
+	switch env := strings.TrimSpace(os.Getenv("PHONE_NOTIFICATIONS_ENV")); env {
+	case "development", "test", "production":
+		return env
+	default:
+		return "production"
+	}
+}
+
+// Host 返回当前环境主机：先看 OPENCLAW_HOST_* 覆盖，否则取默认域名。
+func Host() string {
+	env := Name()
+	var override string
+	switch env {
+	case "development":
+		override = os.Getenv("OPENCLAW_HOST_DEVELOPMENT")
+	case "test":
+		override = os.Getenv("OPENCLAW_HOST_TEST")
+	case "production":
+		override = os.Getenv("OPENCLAW_HOST_PRODUCTION")
+	}
+	if h := Normalize(override); h != "" {
+		return h
+	}
+	return defaultHosts[env]
+}
+
+// IsDefaultHost 报告 host（归一化后）是否为某个环境的默认域名。
+// 用于判断持久化的 URL 是否仍是内置默认值（而非用户自定义），从而决定可否随环境切换。
+func IsDefaultHost(host string) bool {
+	h := Normalize(host)
+	if h == "" {
+		return false
+	}
+	for _, def := range defaultHosts {
+		if h == def {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/envhost/envhost_test.go
+++ b/internal/envhost/envhost_test.go
@@ -1,0 +1,58 @@
+package envhost
+
+import "testing"
+
+func TestNormalize(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"":                      "",
+		"  example.com  ":       "example.com",
+		"https://example.com":   "example.com",
+		"wss://example.com/":    "example.com",
+		"http://example.com///": "example.com",
+	}
+	for in, want := range cases {
+		if got := Normalize(in); got != want {
+			t.Errorf("Normalize(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestName(t *testing.T) {
+	t.Setenv("PHONE_NOTIFICATIONS_ENV", "test")
+	if Name() != "test" {
+		t.Error("should read test env")
+	}
+	t.Setenv("PHONE_NOTIFICATIONS_ENV", "bogus")
+	if Name() != "production" {
+		t.Error("unknown env should fall back to production")
+	}
+}
+
+func TestHostOverrideAndDefault(t *testing.T) {
+	t.Setenv("PHONE_NOTIFICATIONS_ENV", "development")
+	t.Setenv("OPENCLAW_HOST_DEVELOPMENT", "https://dev.override.test/")
+	if got := Host(); got != "dev.override.test" {
+		t.Errorf("override host = %q", got)
+	}
+	t.Setenv("OPENCLAW_HOST_DEVELOPMENT", "")
+	if got := Host(); got != "openclaw-service-dev.yoooclaw.com" {
+		t.Errorf("default dev host = %q", got)
+	}
+}
+
+func TestIsDefaultHost(t *testing.T) {
+	t.Parallel()
+	if !IsDefaultHost("wss://openclaw-service.yoooclaw.com") {
+		t.Error("production host should be recognized as default")
+	}
+	if !IsDefaultHost("openclaw-service-test.yoooclaw.com") {
+		t.Error("test host should be recognized as default")
+	}
+	if IsDefaultHost("my-custom-relay.example.com") {
+		t.Error("custom host should not be default")
+	}
+	if IsDefaultHost("") {
+		t.Error("empty host should not be default")
+	}
+}

--- a/internal/light/env.go
+++ b/internal/light/env.go
@@ -1,58 +1,8 @@
 package light
 
-import (
-	"os"
-	"regexp"
-	"strings"
-)
+import "github.com/YoooClaw/cli/internal/envhost"
 
-// 默认环境主机（构建期可通过 OPENCLAW_HOST_* 注入覆盖）。
-var defaultEnvHosts = map[string]string{
-	"development": "openclaw-service-dev.yoooclaw.com",
-	"test":        "openclaw-service-test.yoooclaw.com",
-	"production":  "openclaw-service.yoooclaw.com",
-}
-
-var schemeRE = regexp.MustCompile(`^(https?|wss?)://`)
-var trailingSlashRE = regexp.MustCompile(`/+$`)
-
-func normalizeHost(host string) string {
-	trimmed := strings.TrimSpace(host)
-	if trimmed == "" {
-		return ""
-	}
-	trimmed = schemeRE.ReplaceAllString(trimmed, "")
-	return trailingSlashRE.ReplaceAllString(trimmed, "")
-}
-
-// loadEnvName 解析当前环境名（PHONE_NOTIFICATIONS_ENV 环境变量优先，否则 production）。
-func loadEnvName() string {
-	env := strings.TrimSpace(os.Getenv("PHONE_NOTIFICATIONS_ENV"))
-	switch env {
-	case "development", "test", "production":
-		return env
-	}
-	return "production"
-}
-
-func envHost() string {
-	env := loadEnvName()
-	var override string
-	switch env {
-	case "development":
-		override = os.Getenv("OPENCLAW_HOST_DEVELOPMENT")
-	case "test":
-		override = os.Getenv("OPENCLAW_HOST_TEST")
-	case "production":
-		override = os.Getenv("OPENCLAW_HOST_PRODUCTION")
-	}
-	if h := normalizeHost(override); h != "" {
-		return h
-	}
-	return defaultEnvHosts[env]
-}
-
-// LightAPIURL 返回灯效云 API 端点。
+// LightAPIURL 返回灯效云 API 端点（主机随 PHONE_NOTIFICATIONS_ENV 切换，见 internal/envhost）。
 func LightAPIURL() string {
-	return "https://" + envHost() + "/api/message/tob/sendMessage"
+	return "https://" + envhost.Host() + "/api/message/tob/sendMessage"
 }

--- a/internal/light/env_test.go
+++ b/internal/light/env_test.go
@@ -5,50 +5,19 @@ import (
 	"testing"
 )
 
-func TestNormalizeHost(t *testing.T) {
-	t.Parallel()
-	cases := map[string]string{
-		"":                            "",
-		"  example.com  ":             "example.com",
-		"https://example.com":         "example.com",
-		"wss://example.com/":          "example.com",
-		"http://example.com///":       "example.com",
-	}
-	for in, want := range cases {
-		if got := normalizeHost(in); got != want {
-			t.Errorf("normalizeHost(%q) = %q, want %q", in, got, want)
-		}
-	}
-}
-
-func TestLoadEnvName(t *testing.T) {
-	t.Setenv("PHONE_NOTIFICATIONS_ENV", "test")
-	if loadEnvName() != "test" {
-		t.Error("should read test env")
-	}
-	t.Setenv("PHONE_NOTIFICATIONS_ENV", "bogus")
-	if loadEnvName() != "production" {
-		t.Error("unknown env should fall back to production")
-	}
-}
-
-func TestEnvHostOverrideAndDefault(t *testing.T) {
-	t.Setenv("PHONE_NOTIFICATIONS_ENV", "development")
-	t.Setenv("OPENCLAW_HOST_DEVELOPMENT", "https://dev.override.test/")
-	if got := envHost(); got != "dev.override.test" {
-		t.Errorf("override host = %q", got)
-	}
-	t.Setenv("OPENCLAW_HOST_DEVELOPMENT", "")
-	if got := envHost(); got != defaultEnvHosts["development"] {
-		t.Errorf("default dev host = %q", got)
-	}
-}
-
 func TestLightAPIURL(t *testing.T) {
 	t.Setenv("PHONE_NOTIFICATIONS_ENV", "production")
 	t.Setenv("OPENCLAW_HOST_PRODUCTION", "")
 	url := LightAPIURL()
 	if !strings.HasPrefix(url, "https://") || !strings.HasSuffix(url, "/api/message/tob/sendMessage") {
 		t.Errorf("LightAPIURL = %q", url)
+	}
+}
+
+func TestLightAPIURLFollowsEnv(t *testing.T) {
+	t.Setenv("PHONE_NOTIFICATIONS_ENV", "test")
+	t.Setenv("OPENCLAW_HOST_TEST", "")
+	if got := LightAPIURL(); !strings.Contains(got, "openclaw-service-test.yoooclaw.com") {
+		t.Errorf("test env LightAPIURL = %q", got)
 	}
 }

--- a/internal/recording/asr.go
+++ b/internal/recording/asr.go
@@ -9,11 +9,11 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
 	"github.com/YoooClaw/cli/internal/creds"
+	"github.com/YoooClaw/cli/internal/envhost"
 	"github.com/YoooClaw/cli/internal/fsutil"
 )
 
@@ -27,13 +27,6 @@ const (
 var (
 	longRecordingRunningStatuses = map[string]bool{"PENDING": true, "RUNNING": true, "SUSPENDED": true}
 	longRecordingFailureStatuses = map[string]bool{"FAILED": true, "CANCELED": true, "UNKNOWN": true}
-	defaultEnvHosts              = map[string]string{
-		"development": "openclaw-service-dev.yoooclaw.com",
-		"test":        "openclaw-service-test.yoooclaw.com",
-		"production":  "openclaw-service.yoooclaw.com",
-	}
-	envSchemeRE        = regexp.MustCompile(`^(https?|wss?)://`)
-	envTrailingSlashRE = regexp.MustCompile(`/+$`)
 )
 
 // AsrConfig 是录音 ASR 配置。
@@ -551,7 +544,7 @@ func resolveSubmitEndpoint(apiConfig *AsrAPIConfig) string {
 	if apiConfig != nil && strings.TrimSpace(apiConfig.Endpoint) != "" {
 		return strings.TrimSpace(apiConfig.Endpoint)
 	}
-	return "https://" + envHost() + "/api/model-proxy/long-recording/submit-task"
+	return "https://" + envhost.Host() + "/api/model-proxy/long-recording/submit-task"
 }
 
 func resolveQueryBaseURL(apiConfig *AsrAPIConfig) string {
@@ -562,36 +555,7 @@ func resolveQueryBaseURL(apiConfig *AsrAPIConfig) string {
 		}
 		return endpoint
 	}
-	return "https://" + envHost() + "/api/model-proxy/long-recording/query-task-result"
-}
-
-func envHost() string {
-	env := strings.TrimSpace(os.Getenv("PHONE_NOTIFICATIONS_ENV"))
-	if env != "development" && env != "test" && env != "production" {
-		env = "production"
-	}
-	var override string
-	switch env {
-	case "development":
-		override = os.Getenv("OPENCLAW_HOST_DEVELOPMENT")
-	case "test":
-		override = os.Getenv("OPENCLAW_HOST_TEST")
-	case "production":
-		override = os.Getenv("OPENCLAW_HOST_PRODUCTION")
-	}
-	if h := normalizeEnvHost(override); h != "" {
-		return h
-	}
-	return defaultEnvHosts[env]
-}
-
-func normalizeEnvHost(host string) string {
-	trimmed := strings.TrimSpace(host)
-	if trimmed == "" {
-		return ""
-	}
-	trimmed = envSchemeRE.ReplaceAllString(trimmed, "")
-	return envTrailingSlashRE.ReplaceAllString(trimmed, "")
+	return "https://" + envhost.Host() + "/api/model-proxy/long-recording/query-task-result"
 }
 
 func normalizeAPIKeyHeader(apiKey string) string {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {


### PR DESCRIPTION
## 版本

cli-0.2.3（tag `cli-v0.2.3`，发布 workflow 已由 tag 推送触发）

## 改动

daemon Relay 现在支持按 `PHONE_NOTIFICATIONS_ENV` 切换环境，与灯效 API / ASR 三套接口统一：

- 新增 `internal/envhost`：统一解析环境主机（`development`/`test`/`production` + `OPENCLAW_HOST_*` 覆盖），消除原本散落在 light / asr 的三份重复逻辑。
- `internal/light`、`internal/recording` 改用 `envhost`，行为不变。
- `config.DefaultRelayURL()` 主机改为 `envhost.Host()`；新增 `config.ResolveRelayURL()`：
  - 持久化的 `relay.url` 若仍是某环境内置默认主机 → 按当前环境重新解析（已初始化 profile 无需重新 init 即可跟随环境切换）；
  - 用户自定义 URL → 原样保留；空 URL → 回退当前环境默认。
- daemon 连接与 `yc status` / `tunnel status` 上报均改用 `ResolveRelayURL`，显示实际连接地址。

## 验证

- `go test ./...` 全部通过（新增 `internal/envhost` 与 `config.ResolveRelayURL` 测试）。
- `scripts/build-go.sh` 全 5 平台交叉编译成功，二进制 `--version` 输出 `0.2.3`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)