### PR TITLE
cli-0.2.4

### DIFF
--- a/internal/creds/store.go
+++ b/internal/creds/store.go
@@ -3,7 +3,6 @@ package creds
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -209,13 +208,10 @@ func writeAPIKeys(entries []storedEntry) (ApiKeyResolution, error) {
 	return res, nil
 }
 
-// ResolveAPIKeyEntries 分层解析 account 级 api-key（env > keychain > file），命中即停。
+// ResolveAPIKeyEntries 解析 account 级 api-key——仅从 credentials.json 读取；
+// 环境变量 YOOOCLAW_API_KEY 与 keychain 不再参与解析（keychain 若存在仅作 shadowed 提示）。
 func ResolveAPIKeyEntries() CredentialSet {
 	file := paths.SharedCredentialsPath()
-	if env := strings.TrimSpace(os.Getenv(APIKeyEnv)); env != "" {
-		entry := ApiKeyEntry{Label: "env", Key: env, Default: true, Source: "env"}
-		return CredentialSet{Mode: "env-single", Entries: []ApiKeyEntry{entry}, DefaultEntry: &entry, Location: APIKeyEnv}
-	}
 
 	data := readSharedCredentials()
 	legacyRaw, _ := data[apiKeyField].(string)
@@ -242,20 +238,14 @@ func ResolveAPIKeyEntries() CredentialSet {
 		}
 	}
 
-	if kc != "" {
-		entry := ApiKeyEntry{Label: "keychain", Key: kc, Default: true, Source: "keychain"}
-		return CredentialSet{Mode: "keychain-single", Entries: []ApiKeyEntry{entry}, DefaultEntry: &entry,
-			Location: KeychainService + "/" + KeychainAPIKeyAccount, LegacyAPIKeyPresent: legacy}
-	}
-
 	if legacy {
 		val := strings.TrimSpace(legacyRaw)
 		entry := ApiKeyEntry{Label: "default", Key: val, Default: true, Source: "file"}
 		return CredentialSet{Mode: "legacy-file-single", Entries: []ApiKeyEntry{entry}, DefaultEntry: &entry,
-			Location: file, LegacyAPIKeyPresent: true}
+			Location: file, LegacyAPIKeyPresent: true, ShadowedKeychainPresent: kc != ""}
 	}
 
-	return CredentialSet{Mode: "none", Location: file}
+	return CredentialSet{Mode: "none", Location: file, ShadowedKeychainPresent: kc != ""}
 }
 
 // ResolveAPIKey 返回当前默认 api-key。

--- a/internal/creds/store_test.go
+++ b/internal/creds/store_test.go
@@ -125,9 +125,12 @@ func TestSetAPIKeyKeychain(t *testing.T) {
 	if fk.store[key(KeychainService, KeychainAPIKeyAccount)] != "sk-kc-abcdefgh" {
 		t.Error("key not written to fake keychain")
 	}
-	// 解析应优先 keychain（无 file apiKeys 时）
-	if got := ResolveAPIKey(); got.Source != "keychain" || got.Value != "sk-kc-abcdefgh" {
-		t.Errorf("resolve keychain: %+v", got)
+	// 解析只看 credentials.json：keychain key 不再被采用，仅作 shadowed 提示
+	if got := ResolveAPIKey(); got.Source != "none" || got.Value != "" {
+		t.Errorf("keychain must not resolve: %+v", got)
+	}
+	if set := ResolveAPIKeyEntries(); !set.ShadowedKeychainPresent {
+		t.Errorf("keychain should be reported as shadowed: %+v", set)
 	}
 }
 
@@ -139,13 +142,14 @@ func TestSetAPIKeyKeychainUnavailable(t *testing.T) {
 	}
 }
 
-func TestResolveAPIKeyEnvWins(t *testing.T) {
+func TestResolveAPIKeyEnvIgnored(t *testing.T) {
 	setup(t)
 	t.Setenv(APIKeyEnv, "sk-env-override")
 	SetAPIKey("sk-file-key-12345678", false)
 	got := ResolveAPIKey()
-	if got.Source != "env" || got.Value != "sk-env-override" {
-		t.Errorf("env should win: %+v", got)
+	// 环境变量不再参与解析，只认 credentials.json
+	if got.Source != "file" || got.Value != "sk-file-key-12345678" {
+		t.Errorf("file should win, env ignored: %+v", got)
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {


### PR DESCRIPTION
## 发布 0.2.4 并合回主干

### 改动
- **api-key 仅从 `credentials.json` 解析**：去掉 `ResolveAPIKeyEntries` 里的环境变量（`YOOOCLAW_API_KEY`）与 keychain 解析分支。account 级 api-key 现在只认 `credentials.json`（`apiKeys[]` 优先，否则回退 legacy 单字段）。keychain 若仍存在 key，仅通过 `ShadowedKeychainPresent` 提示，不再被采用。
- 版本号 bump：`0.2.3` → `0.2.4`。

### 备注
- 发布由 tag `cli-v0.2.4` 推送触发，本 PR 仅为同步主干。
- `yc auth set-api-key --keychain` 写入路径未改动，但写进去的 key 将不再被读取（list/status 会以 `shadowedKeychainPresent` 提示）。
- `go build ./...` 与 `go test ./...` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)