### PR TITLE
cli-0.3.0-beta.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ npx skills@latest add YoooClaw/skills --skill yoooclaw-cli --global --agent clau
 
 | Skill                         | 说明                                                                                                            |
 | ----------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `yoooclaw-notification-query` | 流式查询手机通知原始数据：「看看最近的通知」「谁找过我」「总结今天的消息」。纯读磁盘、不需要 daemon             |
+| `yoooclaw-notification-query` | 查询/汇总/总结手机通知：「看看最近的通知」「谁找过我」「总结最近约 N 条通知」。小批量走 `summary`、大批量走 `summary-job`，纯读磁盘、不需要 daemon |
 | `yoooclaw-lightrule-create`   | 从自然语言或 stdin 创建/管理「通知 → 灯效」持久规则，由 daemon 在 ingest 后评估命中并触发灯效（🟡）             |
 | `yoooclaw-tunnel-debug`       | 排查手机端推送链路：组合 auth / daemon / tunnel / gateway 状态定位本地配置、ingest 鉴权与 Relay WebSocket（🟡） |
 
@@ -199,6 +199,7 @@ yoooclaw log +errors                  # 昨天起的 error 级日志
 ```bash
 yoooclaw notification search --app 微信 --keyword 会议 --limit 50
 yoooclaw notification stats --dim app --from 2026-05-26
+yoooclaw notification summary-job create --from 2026-06-01T00:00:00+08:00 --chunk-size 150  # 大批量通知分片总结：create→next→commit→result
 yoooclaw recording list --status synced
 yoooclaw recording setup-asr --mode api --language auto --non-interactive
 yoooclaw lightrule create --from-file -          # 从 stdin 提交规则定义

--- a/internal/cli/cmd_notification.go
+++ b/internal/cli/cmd_notification.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/YoooClaw/cli/internal/clictx"
@@ -15,7 +16,9 @@ import (
 // maxLimit 充当 summary/stats 的"全部"上限（对齐 TS 的 MAX_SAFE_INTEGER 语义）。
 const maxLimit = 1 << 60
 
-func addQueryFlags(cmd *cobra.Command) {
+func addQueryFlags(cmd *cobra.Command) { addQueryFlagsWithLimit(cmd, "100") }
+
+func addQueryFlagsWithLimit(cmd *cobra.Command, defaultLimit string) {
 	f := cmd.Flags()
 	f.String("from", "", "开始时间，如 2026-03-01T09:00:00+08:00")
 	f.String("to", "", "结束时间")
@@ -24,7 +27,7 @@ func addQueryFlags(cmd *cobra.Command) {
 	f.String("conversation-type", "", "会话类型 group|private")
 	f.String("keyword", "", "在标题/内容/发送人/会话名中搜索")
 	f.String("client", "", "按 clientLabel 过滤；all 为全部")
-	f.String("limit", "100", "最大返回条数")
+	f.String("limit", defaultLimit, "最大返回条数")
 }
 
 func rawQueryFromCmd(cmd *cobra.Command) notif.RawQueryOpts {
@@ -62,7 +65,7 @@ func newNotificationCmd() *cobra.Command {
 	recent.Flags().String("client", "", "按 clientLabel 过滤；all 为全部")
 	unread := &cobra.Command{Use: "+unread", Short: "（预留）未读通知", Args: cobra.NoArgs, RunE: run(notificationUnread)}
 
-	c.AddCommand(search, summary, stats, storagePath, today, recent, unread)
+	c.AddCommand(search, summary, newSummaryJobCmd(), stats, storagePath, today, recent, unread)
 	return c
 }
 
@@ -78,10 +81,20 @@ func notificationSummary(ctx *clictx.Context, cmd *cobra.Command, _ []string) (a
 	sample := atoiDefault(flagStr(cmd, "sample"), 30)
 	top := atoiDefault(flagStr(cmd, "top"), 10)
 	raw := rawQueryFromCmd(cmd)
+	// 显式传 --limit 时聚合最近 N 条（供「总结约 X 条」场景）；
+	// 不传时维持原行为：聚合范围内全部通知。
+	limitRaw := raw.Limit
 	raw.Limit = ""
 	opts, err := notif.BuildQueryOptions(raw, maxLimit)
 	if err != nil {
 		return nil, err
+	}
+	if cmd.Flags().Changed("limit") {
+		n, err := strconv.Atoi(limitRaw)
+		if err != nil || n <= 0 {
+			return nil, errs.New(errs.CodeInvalidArgument, "--limit 必须是大于 0 的整数")
+		}
+		opts.Limit = n
 	}
 	items := notif.Query(ctx.Paths.Notifications, opts)
 	return map[string]any{

--- a/internal/cli/cmd_summary_job.go
+++ b/internal/cli/cmd_summary_job.go
@@ -1,0 +1,137 @@
+package cli
+
+import (
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/YoooClaw/cli/internal/clictx"
+	"github.com/YoooClaw/cli/internal/errs"
+	"github.com/YoooClaw/cli/internal/notif"
+	"github.com/YoooClaw/cli/internal/summaryjob"
+	"github.com/spf13/cobra"
+)
+
+func newSummaryJobCmd() *cobra.Command {
+	c := &cobra.Command{Use: "summary-job", Short: "分片通知总结任务：大批量通知切片→逐片总结→合并结果 🟢"}
+
+	create := &cobra.Command{Use: "create", Short: "创建分片通知总结任务", Args: cobra.NoArgs, RunE: run(summaryJobCreate)}
+	addQueryFlagsWithLimit(create, strconv.Itoa(summaryjob.DefaultJobLimit))
+	create.Flags().String("chunk-size", strconv.Itoa(summaryjob.DefaultChunkSize), "每个分片的通知条数")
+	create.Flags().String("max-content", strconv.Itoa(summaryjob.DefaultMaxContent), "分片中单条通知标题/正文最大字数")
+
+	status := &cobra.Command{Use: "status <id>", Short: "查看任务状态", Args: cobra.ExactArgs(1), RunE: run(summaryJobStatus)}
+	next := &cobra.Command{Use: "next <id>", Short: "领取或重试下一个待总结分片", Args: cobra.ExactArgs(1), RunE: run(summaryJobNext)}
+
+	commit := &cobra.Command{Use: "commit <id>", Short: "提交分片摘要并标记分片完成", Args: cobra.ExactArgs(1), RunE: run(summaryJobCommit)}
+	commit.Flags().String("chunk-id", "", "next 返回的分片 id（必填）")
+	commit.Flags().String("summary", "", "直接传入分片摘要文本")
+	commit.Flags().String("summary-file", "", "读取文件内容作为分片摘要")
+
+	runc := &cobra.Command{Use: "run <id>", Short: "用抽取式摘要自动处理待总结分片（无需模型）", Args: cobra.ExactArgs(1), RunE: run(summaryJobRun)}
+	runc.Flags().String("max-chunks", strconv.Itoa(summaryjob.DefaultRunMaxChunks), "本次最多自动处理的分片数")
+	runc.Flags().Bool("include-result", false, "完成时在输出中包含 markdown 结果")
+
+	result := &cobra.Command{Use: "result <id>", Short: "合并已提交的分片摘要并返回结果", Args: cobra.ExactArgs(1), RunE: run(summaryJobResult)}
+	cancel := &cobra.Command{Use: "cancel <id>", Short: "取消任务（保留已落盘分片与摘要）", Args: cobra.ExactArgs(1), RunE: run(summaryJobCancel)}
+
+	c.AddCommand(create, status, next, commit, runc, result, cancel)
+	return c
+}
+
+func parsePositiveInt(cmd *cobra.Command, flag string, def int) (int, error) {
+	raw := flagStr(cmd, flag)
+	if raw == "" {
+		return def, nil
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 || strconv.Itoa(n) != raw {
+		return 0, errs.Newf(errs.CodeInvalidArgument, "--%s 必须是大于 0 的整数", flag)
+	}
+	return n, nil
+}
+
+func summaryJobCreate(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error) {
+	raw := rawQueryFromCmd(cmd)
+	if raw.Limit == "" {
+		raw.Limit = strconv.Itoa(summaryjob.DefaultJobLimit)
+	}
+	opts, err := notif.BuildQueryOptions(raw, summaryjob.DefaultJobLimit)
+	if err != nil {
+		return nil, err
+	}
+	chunkSize, err := parsePositiveInt(cmd, "chunk-size", summaryjob.DefaultChunkSize)
+	if err != nil {
+		return nil, err
+	}
+	maxContent, err := parsePositiveInt(cmd, "max-content", summaryjob.DefaultMaxContent)
+	if err != nil {
+		return nil, err
+	}
+	return summaryjob.Create(ctx.Paths.Notifications, summaryjob.CreateParams{
+		Query: opts,
+		Meta: summaryjob.QueryMeta{
+			From: raw.From, To: raw.To, App: raw.App, Sender: raw.Sender,
+			ConversationType: raw.ConversationType, Keyword: raw.Keyword, Limit: opts.Limit,
+		},
+		ChunkSize: chunkSize, MaxContent: maxContent,
+	})
+}
+
+func summaryJobStatus(ctx *clictx.Context, _ *cobra.Command, args []string) (any, error) {
+	return summaryjob.Status(ctx.Paths.Notifications, args[0])
+}
+
+func summaryJobNext(ctx *clictx.Context, _ *cobra.Command, args []string) (any, error) {
+	return summaryjob.Next(ctx.Paths.Notifications, args[0])
+}
+
+func summaryJobCommit(ctx *clictx.Context, cmd *cobra.Command, args []string) (any, error) {
+	chunkID := flagStr(cmd, "chunk-id")
+	if chunkID == "" {
+		return nil, errs.New(errs.CodeInvalidArgument, "--chunk-id 必填")
+	}
+	text, err := resolveSummaryText(cmd)
+	if err != nil {
+		return nil, err
+	}
+	return summaryjob.Commit(ctx.Paths.Notifications, args[0], chunkID, text)
+}
+
+func resolveSummaryText(cmd *cobra.Command) (string, error) {
+	summary := flagStr(cmd, "summary")
+	summaryFile := flagStr(cmd, "summary-file")
+	if summary != "" && summaryFile != "" {
+		return "", errs.New(errs.CodeInvalidArgument, "--summary 和 --summary-file 只能二选一")
+	}
+	if summary == "" && summaryFile == "" {
+		return "", errs.New(errs.CodeInvalidArgument, "必须提供 --summary 或 --summary-file")
+	}
+	if summary != "" {
+		return summary, nil
+	}
+	raw, err := os.ReadFile(summaryFile)
+	if err != nil {
+		return "", errs.Newf(errs.CodeNotFound, "无法读取 --summary-file: %s", summaryFile)
+	}
+	if strings.TrimSpace(string(raw)) == "" {
+		return "", errs.New(errs.CodeInvalidArgument, "分片摘要不能为空")
+	}
+	return string(raw), nil
+}
+
+func summaryJobRun(ctx *clictx.Context, cmd *cobra.Command, args []string) (any, error) {
+	maxChunks, err := parsePositiveInt(cmd, "max-chunks", summaryjob.DefaultRunMaxChunks)
+	if err != nil {
+		return nil, err
+	}
+	return summaryjob.Run(ctx.Paths.Notifications, args[0], maxChunks, flagBool(cmd, "include-result"))
+}
+
+func summaryJobResult(ctx *clictx.Context, _ *cobra.Command, args []string) (any, error) {
+	return summaryjob.Result(ctx.Paths.Notifications, args[0])
+}
+
+func summaryJobCancel(ctx *clictx.Context, _ *cobra.Command, args []string) (any, error) {
+	return summaryjob.Cancel(ctx.Paths.Notifications, args[0])
+}

--- a/internal/cli/cmd_sync.go
+++ b/internal/cli/cmd_sync.go
@@ -11,9 +11,16 @@ func newSyncCmd() *cobra.Command {
 	c := &cobra.Command{Use: "sync", Short: "通知同步给记忆系统 🟢"}
 
 	scan := &cobra.Command{
-		Use: "scan", Short: "扫描未处理通知，返回各日期待同步摘要",
+		Use: "scan", Short: "扫描未处理通知，默认只返回本地当天待同步摘要",
 		Args: cobra.NoArgs, RunE: run(syncScan),
 	}
+	addScopeFlags(scan)
+
+	next := &cobra.Command{
+		Use: "next", Short: "通用批次迭代器：返回范围内下一批未处理通知（≤100 条）及 commitCommand；处理完返回 done=true",
+		Args: cobra.NoArgs, RunE: run(syncNext),
+	}
+	addScopeFlags(next)
 
 	fetch := &cobra.Command{
 		Use: "fetch", Short: "获取指定日期未处理通知详情",
@@ -29,12 +36,42 @@ func newSyncCmd() *cobra.Command {
 	commit.Flags().String("date", "", "目标日期（必填，YYYY-MM-DD）")
 	commit.Flags().String("end-index", "", "本批次 fetch 返回的 endIndex")
 
-	c.AddCommand(scan, fetch, commit)
+	c.AddCommand(scan, next, fetch, commit)
 	return c
 }
 
-func syncScan(ctx *clictx.Context, _ *cobra.Command, _ []string) (any, error) {
-	return notif.ScanSync(ctx.Paths.Notifications), nil
+// addScopeFlags 给 scan / next 挂上统一的日期范围筛选 flags。
+func addScopeFlags(c *cobra.Command) {
+	c.Flags().Bool("all", false, "处理 checkpoint 之后所有日期的未处理通知")
+	c.Flags().String("date", "", "只处理指定日期 YYYY-MM-DD")
+	c.Flags().String("from-date", "", "只处理该日期及之后的数据 YYYY-MM-DD")
+	c.Flags().String("to-date", "", "只处理该日期及之前的数据 YYYY-MM-DD")
+}
+
+// resolveScope 从命令 flags 解析同步范围（缺省本地当天）。
+func resolveScope(cmd *cobra.Command) (notif.SyncScope, error) {
+	return notif.ResolveScanScope(notif.SyncScopeOptions{
+		All:      flagBool(cmd, "all"),
+		Date:     flagStr(cmd, "date"),
+		FromDate: flagStr(cmd, "from-date"),
+		ToDate:   flagStr(cmd, "to-date"),
+	})
+}
+
+func syncScan(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error) {
+	scope, err := resolveScope(cmd)
+	if err != nil {
+		return nil, err
+	}
+	return notif.ScanSync(ctx.Paths.Notifications, scope), nil
+}
+
+func syncNext(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error) {
+	scope, err := resolveScope(cmd)
+	if err != nil {
+		return nil, err
+	}
+	return notif.NextSync(ctx.Paths.Notifications, scope), nil
 }
 
 func syncFetch(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error) {

--- a/internal/daemon/server_gateway_compat.go
+++ b/internal/daemon/server_gateway_compat.go
@@ -77,7 +77,7 @@ func gatewayMethodNames() []string {
 		"agents.list", "channels.status", "chat.history", "cron.list", "health",
 		"lightrules.create", "lightrules.delete", "lightrules.list", "lightrules.update",
 		"notifications.push", "recordings.asr.init", "recordings.delete", "recordings.list",
-		"recordings.rename", "recordings.retranscribe", "recordings.status", "recordings.sync",
+		"recordings.rename", "recordings.result.write", "recordings.retranscribe", "recordings.status", "recordings.sync",
 		"sessions.list", "usage.cost", "wake",
 	}
 }

--- a/internal/daemon/server_ingest.go
+++ b/internal/daemon/server_ingest.go
@@ -71,6 +71,37 @@ func (s *server) handleRecordingGateway(w http.ResponseWriter, r *http.Request, 
 			gatewayErr(w, "SYNC_FAILED", firstNonEmptyStr(result.Error, "Unknown error"))
 		}
 
+	case "recordings.result.write":
+		var body recording.ResultWriteParams
+		if !decodeBody(w, r, &body) {
+			return
+		}
+		recordingID := strings.TrimSpace(body.RecordingID)
+		if recordingID == "" {
+			gatewayErr(w, "INVALID_PARAMS", "recordingId is required")
+			return
+		}
+		if body.Transcript == nil && body.Summary == nil {
+			gatewayErr(w, "INVALID_PARAMS", "transcript or summary is required")
+			return
+		}
+		body.RecordingID = recordingID
+		result, err := recording.HandleRecordingResultWrite(body, s.recordingStorage, s.logger, recording.SyncOptions{
+			NotifyStatus: s.notifyRecordingStatus,
+		})
+		if err != nil {
+			code := "RESULT_WRITE_FAILED"
+			switch {
+			case strings.HasPrefix(err.Error(), "Recording not found:"):
+				code = "NOT_FOUND"
+			case err.Error() == "recordingId is required" || err.Error() == "transcript or summary is required":
+				code = "INVALID_PARAMS"
+			}
+			gatewayErr(w, code, err.Error())
+			return
+		}
+		gatewayOK(w, result)
+
 	case "recordings.retranscribe":
 		var body recordingIDBody
 		if !decodeBody(w, r, &body) {

--- a/internal/notif/query.go
+++ b/internal/notif/query.go
@@ -121,6 +121,52 @@ func Query(notificationsDir string, opts QueryOptions) []StoredNotification {
 	return collectMatching(notificationsDir, opts)
 }
 
+// ScanStats 是一次查询扫描的统计（对齐 TS NotificationQueryStats）。
+type ScanStats struct {
+	DaysScanned       int  `json:"daysScanned"`
+	ItemsScanned      int  `json:"itemsScanned"`
+	Matched           int  `json:"matched"`
+	StoppedAfterLimit bool `json:"stoppedAfterLimit"`
+}
+
+// QueryWithStats 在收集匹配通知的同时统计扫描量，达到 limit 即早停
+// （对齐 TS collectMatchingNotificationsWithStats）。
+func QueryWithStats(notificationsDir string, opts QueryOptions) ([]StoredNotification, ScanStats) {
+	stats := ScanStats{}
+	if !dirExists(notificationsDir) {
+		return nil, stats
+	}
+	var results []StoredNotification
+	for _, dateKey := range listDateKeys(notificationsDir) {
+		if opts.FromDateKey != "" && dateKey < opts.FromDateKey {
+			continue
+		}
+		if opts.ToDateKey != "" && dateKey > opts.ToDateKey {
+			continue
+		}
+		stats.DaysScanned++
+		items := readDateFile(notificationsDir, dateKey)
+		sortByTimestampDesc(items)
+		for _, item := range items {
+			stats.ItemsScanned++
+			if !MatchesQuery(item, opts) {
+				continue
+			}
+			stats.Matched++
+			results = append(results, item)
+			if len(results) >= opts.Limit {
+				stats.StoppedAfterLimit = true
+				return results, stats
+			}
+		}
+	}
+	sortByTimestampDesc(results)
+	if len(results) > opts.Limit {
+		results = results[:opts.Limit]
+	}
+	return results, stats
+}
+
 func dirExists(dir string) bool {
 	info, err := os.Stat(dir)
 	return err == nil && info.IsDir()

--- a/internal/notif/sync.go
+++ b/internal/notif/sync.go
@@ -4,14 +4,18 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
+	"time"
 
 	"github.com/YoooClaw/cli/internal/errs"
 	"github.com/YoooClaw/cli/internal/fsutil"
 )
 
-// SyncFetchLimit 单批 fetch 返回上限（对齐 TS SYNC_FETCH_LIMIT）。
-const SyncFetchLimit = 300
+// SyncFetchLimit 单批同步上限（对齐 TS SYNC_FETCH_LIMIT）。
+// 刻意调小到 100，使每个批次（模型阅读+总结+写记忆）能在数十秒内完成，
+// 让前台/后台都能频繁提交 checkpoint 并快速给用户进度反馈，避免单回合塞太多导致超时卡死。
+const SyncFetchLimit = 100
 
 // checkpointEntry 是每个日期的消费进度（已处理到的最大下标）。
 type checkpointEntry struct {
@@ -55,6 +59,94 @@ func parseIndexOption(raw, label string) (int, error) {
 	return n, nil
 }
 
+// SyncScope 描述一次扫描/同步的日期范围（对齐 TS SyncScanScope）。
+type SyncScope struct {
+	Mode     string `json:"mode"` // all | today | date | range
+	FromDate string `json:"fromDate,omitempty"`
+	ToDate   string `json:"toDate,omitempty"`
+}
+
+// SyncScopeOptions 是 scope 的原始 CLI 入参。
+type SyncScopeOptions struct {
+	All      bool
+	Date     string
+	FromDate string
+	ToDate   string
+}
+
+var dateKeyRE = regexp.MustCompile(`^(\d{4})-(\d{2})-(\d{2})$`)
+
+// localToday 返回本地时区当天日期 YYYY-MM-DD（与落盘 dateKey 同语义）。
+func localToday() string {
+	return time.Now().In(time.Local).Format("2006-01-02")
+}
+
+func validateDateKey(value, optionName string) error {
+	m := dateKeyRE.FindStringSubmatch(value)
+	if m == nil {
+		return errs.Newf(errs.CodeInvalidArgument, "%s 必须是 YYYY-MM-DD 格式", optionName)
+	}
+	if _, err := time.Parse("2006-01-02", value); err != nil {
+		return errs.Newf(errs.CodeInvalidArgument, "%s 不是合法日期", optionName)
+	}
+	return nil
+}
+
+// ResolveScanScope 把 CLI 入参解析为 SyncScope（缺省为本地当天，对齐 TS resolveScanScope）。
+func ResolveScanScope(opts SyncScopeOptions) (SyncScope, error) {
+	hasRange := opts.FromDate != "" || opts.ToDate != ""
+	if opts.All && (opts.Date != "" || hasRange) {
+		return SyncScope{}, errs.New(errs.CodeInvalidArgument, "--all 不能与日期范围参数同时使用")
+	}
+	if opts.Date != "" && hasRange {
+		return SyncScope{}, errs.New(errs.CodeInvalidArgument, "--date 不能与日期范围参数同时使用")
+	}
+
+	if opts.All {
+		return SyncScope{Mode: "all"}, nil
+	}
+
+	if opts.Date != "" {
+		if err := validateDateKey(opts.Date, "--date"); err != nil {
+			return SyncScope{}, err
+		}
+		return SyncScope{Mode: "date", FromDate: opts.Date, ToDate: opts.Date}, nil
+	}
+
+	if hasRange {
+		if opts.FromDate != "" {
+			if err := validateDateKey(opts.FromDate, "--from-date"); err != nil {
+				return SyncScope{}, err
+			}
+		}
+		if opts.ToDate != "" {
+			if err := validateDateKey(opts.ToDate, "--to-date"); err != nil {
+				return SyncScope{}, err
+			}
+		}
+		if opts.FromDate != "" && opts.ToDate != "" && opts.FromDate > opts.ToDate {
+			return SyncScope{}, errs.New(errs.CodeInvalidArgument, "--from-date 不能晚于 --to-date")
+		}
+		return SyncScope{Mode: "range", FromDate: opts.FromDate, ToDate: opts.ToDate}, nil
+	}
+
+	current := localToday()
+	return SyncScope{Mode: "today", FromDate: current, ToDate: current}, nil
+}
+
+func isDateInScope(dateKey string, scope SyncScope) bool {
+	if scope.Mode == "all" {
+		return true
+	}
+	if scope.FromDate != "" && dateKey < scope.FromDate {
+		return false
+	}
+	if scope.ToDate != "" && dateKey > scope.ToDate {
+		return false
+	}
+	return true
+}
+
 // SyncPending 是 scan 返回的单个日期待同步摘要。
 type SyncPending struct {
 	Date       string `json:"date"`
@@ -62,21 +154,96 @@ type SyncPending struct {
 	StartIndex int    `json:"startIndex"`
 }
 
-// ScanSync 扫描各日期未处理通知，返回待同步摘要。
-func ScanSync(dir string) map[string]any {
+// ScanSync 扫描各日期未处理通知，返回范围内待同步摘要（缺省只看本地当天）。
+func ScanSync(dir string, scope SyncScope) map[string]any {
 	checkpoint := readCheckpoint(dir)
 	pending := []SyncPending{}
 	totalPending := 0
+	outsideScopePending := 0
 	for _, dateKey := range listDateKeys(dir) {
 		items := readDateFile(dir, dateKey)
 		lastIndex := lastIndexFor(checkpoint, dateKey)
 		unprocessed := len(items) - (lastIndex + 1)
-		if unprocessed > 0 {
+		if unprocessed <= 0 {
+			continue
+		}
+		if isDateInScope(dateKey, scope) {
 			pending = append(pending, SyncPending{Date: dateKey, Count: unprocessed, StartIndex: lastIndex + 1})
 			totalPending += unprocessed
+		} else {
+			outsideScopePending += unprocessed
 		}
 	}
-	return map[string]any{"ok": true, "pending": pending, "totalPending": totalPending}
+	return map[string]any{
+		"ok":                   true,
+		"scope":                scope,
+		"pending":              pending,
+		"totalPending":         totalPending,
+		"outsideScopePending":  outsideScopePending,
+		"allDatesTotalPending": totalPending + outsideScopePending,
+	}
+}
+
+// NextSync 是通用批次迭代器：返回范围内下一批未处理通知（≤SyncFetchLimit 条）及
+// 配套的 commitCommand，供任意下游处理；全部处理完时返回 done=true。
+// 不推进 checkpoint，由调用方在处理完本批后执行 commitCommand。
+func NextSync(dir string, scope SyncScope) map[string]any {
+	checkpoint := readCheckpoint(dir)
+
+	totalPending := 0
+	outsideScopePending := 0
+	nextDate := ""
+	var nextItems []StoredNotification
+	nextStartIndex := 0
+
+	for _, dateKey := range listDateKeys(dir) { // 降序：从最新日期开始处理
+		items := readDateFile(dir, dateKey)
+		lastIndex := lastIndexFor(checkpoint, dateKey)
+		unprocessed := len(items) - (lastIndex + 1)
+		if unprocessed <= 0 {
+			continue
+		}
+		if !isDateInScope(dateKey, scope) {
+			outsideScopePending += unprocessed
+			continue
+		}
+		totalPending += unprocessed
+		if nextDate == "" {
+			nextDate = dateKey
+			nextItems = items
+			nextStartIndex = lastIndex + 1
+		}
+	}
+
+	if nextDate == "" {
+		return map[string]any{
+			"ok":                   true,
+			"done":                 true,
+			"scope":                scope,
+			"totalPending":         0,
+			"outsideScopePending":  outsideScopePending,
+			"allDatesTotalPending": outsideScopePending,
+		}
+	}
+
+	notifications := safeSlice(nextItems, nextStartIndex, nextStartIndex+SyncFetchLimit)
+	endIndex := nextStartIndex + len(notifications) - 1
+	unprocessedInDate := len(nextItems) - nextStartIndex
+
+	return map[string]any{
+		"ok":                  true,
+		"done":                false,
+		"scope":               scope,
+		"date":                nextDate,
+		"startIndex":          nextStartIndex,
+		"endIndex":            endIndex,
+		"returned":            len(notifications),
+		"hasMoreInDate":       unprocessedInDate > len(notifications),
+		"remainingInScope":    totalPending - len(notifications),
+		"outsideScopePending": outsideScopePending,
+		"commitCommand":       "yoooclaw sync commit --date " + nextDate + " --end-index " + strconv.Itoa(endIndex),
+		"notifications":       notifications,
+	}
 }
 
 // FetchSync 返回指定日期未处理通知的一批快照（不推进 checkpoint）。

--- a/internal/notif/sync_test.go
+++ b/internal/notif/sync_test.go
@@ -12,9 +12,11 @@ func makeItems(n int) []StoredNotification {
 	return items
 }
 
+var allScope = SyncScope{Mode: "all"}
+
 func TestScanSyncEmpty(t *testing.T) {
 	t.Parallel()
-	res := ScanSync(t.TempDir())
+	res := ScanSync(t.TempDir(), allScope)
 	if res["totalPending"].(int) != 0 {
 		t.Errorf("empty scan should have 0 pending: %+v", res)
 	}
@@ -24,13 +26,99 @@ func TestScanSyncPending(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	writeDateFile(t, dir, "2026-06-07", makeItems(5))
-	res := ScanSync(dir)
+	res := ScanSync(dir, allScope)
 	if res["totalPending"].(int) != 5 {
 		t.Errorf("expected 5 pending: %+v", res)
 	}
 	pending := res["pending"].([]SyncPending)
 	if len(pending) != 1 || pending[0].StartIndex != 0 || pending[0].Count != 5 {
 		t.Errorf("pending detail wrong: %+v", pending)
+	}
+}
+
+func TestScanSyncScopeFilters(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeDateFile(t, dir, "2026-06-07", makeItems(3))
+	writeDateFile(t, dir, "2026-06-08", makeItems(2))
+	res := ScanSync(dir, SyncScope{Mode: "date", FromDate: "2026-06-08", ToDate: "2026-06-08"})
+	if res["totalPending"].(int) != 2 {
+		t.Errorf("scoped totalPending should be 2: %+v", res)
+	}
+	if res["outsideScopePending"].(int) != 3 {
+		t.Errorf("outsideScopePending should be 3: %+v", res)
+	}
+	if res["allDatesTotalPending"].(int) != 5 {
+		t.Errorf("allDatesTotalPending should be 5: %+v", res)
+	}
+}
+
+func TestResolveScanScope(t *testing.T) {
+	t.Parallel()
+	if s, err := ResolveScanScope(SyncScopeOptions{}); err != nil || s.Mode != "today" {
+		t.Errorf("default scope should be today: %+v %v", s, err)
+	}
+	if s, err := ResolveScanScope(SyncScopeOptions{All: true}); err != nil || s.Mode != "all" {
+		t.Errorf("--all scope wrong: %+v %v", s, err)
+	}
+	if _, err := ResolveScanScope(SyncScopeOptions{All: true, Date: "2026-06-07"}); err == nil {
+		t.Error("--all + --date should error")
+	}
+	if _, err := ResolveScanScope(SyncScopeOptions{Date: "2026-13-99"}); err == nil {
+		t.Error("invalid --date should error")
+	}
+	if _, err := ResolveScanScope(SyncScopeOptions{FromDate: "2026-06-08", ToDate: "2026-06-07"}); err == nil {
+		t.Error("from > to should error")
+	}
+}
+
+func TestNextSync(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeDateFile(t, dir, "2026-06-07", makeItems(3))
+	writeDateFile(t, dir, "2026-06-08", makeItems(2))
+
+	// 降序：先返回最新日期 2026-06-08。
+	res := NextSync(dir, allScope)
+	if res["done"].(bool) {
+		t.Fatalf("should not be done: %+v", res)
+	}
+	if res["date"].(string) != "2026-06-08" || res["returned"].(int) != 2 || res["endIndex"].(int) != 1 {
+		t.Errorf("next batch wrong: %+v", res)
+	}
+	if res["commitCommand"].(string) != "yoooclaw sync commit --date 2026-06-08 --end-index 1" {
+		t.Errorf("commitCommand wrong: %+v", res["commitCommand"])
+	}
+
+	// commit 2026-06-08 后，下一批应是 2026-06-07。
+	if _, err := CommitSync(dir, "2026-06-08", "1"); err != nil {
+		t.Fatal(err)
+	}
+	res = NextSync(dir, allScope)
+	if res["done"].(bool) || res["date"].(string) != "2026-06-07" {
+		t.Errorf("second batch should be 2026-06-07: %+v", res)
+	}
+
+	// 全部 commit 后应 done。
+	if _, err := CommitSync(dir, "2026-06-07", "2"); err != nil {
+		t.Fatal(err)
+	}
+	res = NextSync(dir, allScope)
+	if !res["done"].(bool) {
+		t.Errorf("should be done: %+v", res)
+	}
+}
+
+func TestNextSyncOutsideScope(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeDateFile(t, dir, "2026-06-07", makeItems(3))
+	res := NextSync(dir, SyncScope{Mode: "date", FromDate: "2026-06-08", ToDate: "2026-06-08"})
+	if !res["done"].(bool) {
+		t.Errorf("out-of-scope should be done: %+v", res)
+	}
+	if res["outsideScopePending"].(int) != 3 {
+		t.Errorf("outsideScopePending should be 3: %+v", res)
 	}
 }
 
@@ -91,7 +179,7 @@ func TestCommitSyncLegacyBatch(t *testing.T) {
 		t.Errorf("legacy commit wrong: %+v", res)
 	}
 	// checkpoint 持久化后再 scan 应无 pending
-	if ScanSync(dir)["totalPending"].(int) != 0 {
+	if ScanSync(dir, allScope)["totalPending"].(int) != 0 {
 		t.Error("after full commit no pending expected")
 	}
 }

--- a/internal/recording/events.go
+++ b/internal/recording/events.go
@@ -16,6 +16,7 @@ type StatusEvent struct {
 	SrtFile            string           `json:"srtFile,omitempty"`
 	TranscriptDataFile string           `json:"transcriptDataFile,omitempty"`
 	TranscriptFile     string           `json:"transcriptFile,omitempty"`
+	SummaryFile        string           `json:"summaryFile,omitempty"`
 	Transcript         []TranscriptItem `json:"transcript,omitempty"`
 	Summary            string           `json:"summary,omitempty"`
 	Title              string           `json:"title"`

--- a/internal/recording/handler.go
+++ b/internal/recording/handler.go
@@ -207,6 +207,7 @@ func emitRecordingStatus(recordingID string, storage *Storage, logger Logger, no
 		SrtFile:            entry.SrtFile,
 		TranscriptDataFile: entry.TranscriptDataFile,
 		TranscriptFile:     entry.TranscriptFile,
+		SummaryFile:        entry.SummaryFile,
 		Title:              title,
 		UpdatedAt:          entry.UpdatedAt,
 		Error:              errMessage,

--- a/internal/recording/result_writer.go
+++ b/internal/recording/result_writer.go
@@ -1,0 +1,401 @@
+package recording
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/YoooClaw/cli/internal/fsutil"
+)
+
+// ResultTranscriptSource 是 result.write 入参里转写的上游来源。
+type ResultTranscriptSource struct {
+	Provider  string `json:"provider,omitempty"`
+	TaskID    string `json:"taskId,omitempty"`
+	RequestID string `json:"requestId,omitempty"`
+	Status    string `json:"status,omitempty"`
+}
+
+// ResultTranscriptSegment 是 result.write 入参里的转写分段。
+type ResultTranscriptSegment struct {
+	Text      string   `json:"text"`
+	StartMS   *float64 `json:"startMs,omitempty"`
+	EndMS     *float64 `json:"endMs,omitempty"`
+	SpeakerID *int     `json:"speakerId,omitempty"`
+}
+
+// ResultTranscript 是 result.write 写入的转写结果。
+type ResultTranscript struct {
+	GeneratedAt string                    `json:"generatedAt,omitempty"`
+	Source      *ResultTranscriptSource   `json:"source,omitempty"`
+	Title       string                    `json:"title,omitempty"`
+	Category    string                    `json:"category,omitempty"`
+	Brief       string                    `json:"brief,omitempty"`
+	Text        string                    `json:"text,omitempty"`
+	Segments    []ResultTranscriptSegment `json:"segments,omitempty"`
+	Markdown    string                    `json:"markdown,omitempty"`
+}
+
+// ResultSummary 是 result.write 写入的总结结果。
+type ResultSummary struct {
+	GeneratedAt string          `json:"generatedAt,omitempty"`
+	Format      string          `json:"format,omitempty"`
+	Markdown    string          `json:"markdown,omitempty"`
+	Structured  json.RawMessage `json:"structured,omitempty"`
+}
+
+// ResultWriteParams 是 recordings.result.write 的入参。
+type ResultWriteParams struct {
+	RecordingID string            `json:"recordingId"`
+	OssURL      string            `json:"ossUrl,omitempty"`
+	Transcript  *ResultTranscript `json:"transcript,omitempty"`
+	Summary     *ResultSummary    `json:"summary,omitempty"`
+}
+
+// ResultWriteStored 记录 result.write 落盘的相对路径。
+type ResultWriteStored struct {
+	TranscriptDataFile string `json:"transcriptDataFile,omitempty"`
+	TranscriptFile     string `json:"transcriptFile,omitempty"`
+	SummaryFile        string `json:"summaryFile,omitempty"`
+}
+
+// ResultWriteResult 是 recordings.result.write 的返回。
+type ResultWriteResult struct {
+	OK             bool              `json:"ok"`
+	RecordingID    string            `json:"recordingId"`
+	TransferStatus string            `json:"transfer_status"`
+	Stored         ResultWriteStored `json:"stored"`
+}
+
+// HandleRecordingResultWrite 处理 recordings.result.write：写入 App / 云端生成的
+// 转录与总结，覆盖同一录音的 transcript-data/transcripts/summaries 文件。
+// 找不到录音时按占位元数据 upsert 新建（与 recordings.sync 的 upsert 语义一致）；
+// 可选 ossUrl 时在后台下载并覆盖本地音频。不触发插件侧 ASR。
+func HandleRecordingResultWrite(params ResultWriteParams, storage *Storage, logger Logger, opts SyncOptions) (ResultWriteResult, error) {
+	recordingID := strings.TrimSpace(params.RecordingID)
+	if recordingID == "" {
+		return ResultWriteResult{}, errors.New("recordingId is required")
+	}
+	if params.Transcript == nil && params.Summary == nil {
+		return ResultWriteResult{}, errors.New("transcript or summary is required")
+	}
+
+	entry, found := storage.FindByID(recordingID)
+	if !found {
+		if _, err := storage.Ingest(recordingID, buildPlaceholderMetadata(recordingID, params), ""); err != nil {
+			return ResultWriteResult{}, err
+		}
+		var ok bool
+		entry, ok = storage.FindByID(recordingID)
+		if !ok {
+			return ResultWriteResult{}, fmt.Errorf("Recording not found: %s", recordingID)
+		}
+		logger.Info("[recording-result] 录音不存在，已按结果写入新建: " + recordingID)
+	}
+
+	var transcript []TranscriptItem
+	title := firstNonEmpty(entry.Title, entry.Metadata.Name, recordingID)
+	var summaryText string
+
+	if params.Transcript != nil {
+		t, items, err := writeResultTranscript(recordingID, entry.Metadata, *params.Transcript, storage, logger)
+		if err != nil {
+			return ResultWriteResult{}, err
+		}
+		title = t
+		transcript = items
+	}
+
+	if params.Summary != nil {
+		st, err := writeResultSummary(recordingID, *params.Summary, storage, logger)
+		if err != nil {
+			return ResultWriteResult{}, err
+		}
+		summaryText = st
+	}
+
+	updated, err := storage.MarkResultWritten(recordingID)
+	if err != nil {
+		return ResultWriteResult{}, err
+	}
+
+	if summaryText == "" {
+		summaryText = readSummaryFile(storage, recordingID)
+	}
+	emitResultStatus(recordingID, storage, logger, opts.NotifyStatus, transcript, summaryText, title)
+
+	if oss := strings.TrimSpace(params.OssURL); oss != "" {
+		go downloadResultAudio(recordingID, oss, storage, logger, opts)
+	}
+
+	return ResultWriteResult{
+		OK:             true,
+		RecordingID:    recordingID,
+		TransferStatus: updated.Status,
+		Stored: ResultWriteStored{
+			TranscriptDataFile: updated.TranscriptDataFile,
+			TranscriptFile:     updated.TranscriptFile,
+			SummaryFile:        updated.SummaryFile,
+		},
+	}, nil
+}
+
+// buildPlaceholderMetadata 在找不到录音时，用请求里能拿到的信息拼一份占位元数据。
+// 后续 recordings.sync 会用真实元数据覆盖。
+func buildPlaceholderMetadata(recordingID string, params ResultWriteParams) Metadata {
+	name := recordingID
+	createdAt := nowISO()
+	if params.Transcript != nil {
+		if t := strings.TrimSpace(params.Transcript.Title); t != "" {
+			name = t
+		}
+		if g := strings.TrimSpace(params.Transcript.GeneratedAt); g != "" {
+			createdAt = g
+		}
+	}
+	return Metadata{
+		Name:        name,
+		CreatedAt:   createdAt,
+		OssAudioURL: strings.TrimSpace(params.OssURL),
+		Status:      StatusSynced,
+	}
+}
+
+func writeResultTranscript(recordingID string, meta Metadata, t ResultTranscript, storage *Storage, logger Logger) (string, []TranscriptItem, error) {
+	title := firstNonEmpty(strings.TrimSpace(t.Title), strings.TrimSpace(meta.Name), recordingID)
+	segments := normalizeResultSegments(t.Segments)
+	text := firstNonEmpty(normalizeMultiline(t.Text), joinSegmentTexts(segments), normalizeMultiline(t.Markdown))
+
+	source := TranscriptSource{Provider: "app", Delivery: "result-write"}
+	if t.Source != nil {
+		if p := strings.TrimSpace(t.Source.Provider); p != "" {
+			source.Provider = p
+		}
+		source.TaskID = strings.TrimSpace(t.Source.TaskID)
+		source.RequestID = strings.TrimSpace(t.Source.RequestID)
+		source.Status = strings.TrimSpace(t.Source.Status)
+	}
+
+	doc := BuildTranscriptDocument(recordingID, source, title, strings.TrimSpace(t.Category), normalizeMultiline(t.Brief), text, segments, t)
+	if g := strings.TrimSpace(t.GeneratedAt); g != "" {
+		doc.GeneratedAt = g
+	}
+
+	dataBytes, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return "", nil, err
+	}
+	dataName := TranscriptDataFilename(recordingID)
+	if err := fsutil.WriteAtomic(filepath.Join(storage.TranscriptDataDir(), dataName), dataBytes, fsutil.ConfigFileMode); err != nil {
+		return "", nil, err
+	}
+	_ = storage.SetTranscriptDataFile(recordingID, dataName)
+
+	markdown := normalizeMultiline(t.Markdown)
+	if strings.TrimSpace(markdown) == "" {
+		markdown = buildResultTranscriptMarkdown(meta, title, text, segments)
+	}
+	mdName := TranscriptFilename(recordingID, title)
+	if err := fsutil.WriteAtomic(filepath.Join(storage.TranscriptsDir(), mdName), []byte(ensureTrailingNewline(markdown)), fsutil.ConfigFileMode); err != nil {
+		return "", nil, err
+	}
+	_ = storage.SetTranscriptFile(recordingID, mdName)
+	_ = storage.SetTitle(recordingID, title)
+	logger.Info("[recording-result] 转录文本已写入: " + recordingID)
+
+	return title, ExtractSourceTextListFromDocument(doc), nil
+}
+
+func writeResultSummary(recordingID string, sm ResultSummary, storage *Storage, logger Logger) (string, error) {
+	markdown := normalizeMultiline(sm.Markdown)
+	if strings.TrimSpace(markdown) == "" {
+		markdown = buildStructuredSummaryMarkdown(sm.Structured)
+	}
+	if strings.TrimSpace(markdown) == "" {
+		return "", nil
+	}
+	name := SummaryFilename(recordingID)
+	if err := fsutil.WriteAtomic(filepath.Join(storage.SummariesDir(), name), []byte(ensureTrailingNewline(markdown)), fsutil.ConfigFileMode); err != nil {
+		return "", err
+	}
+	_ = storage.SetSummaryFile(recordingID, name)
+	logger.Info("[recording-result] 总结已写入: " + recordingID)
+	return strings.TrimSpace(markdown), nil
+}
+
+func downloadResultAudio(recordingID, ossURL string, storage *Storage, logger Logger, opts SyncOptions) {
+	dest := storage.AudioFilePath(recordingID, ossURL)
+	logger.Info("[recording-result] 开始下载音频: " + recordingID + ", audio=" + ossURL)
+	result := DownloadFile(ossURL, dest, logger, opts.DownloadOptions)
+	if !result.OK {
+		message := "音频下载失败: " + result.Error
+		logger.Error("[recording-result] " + message + ": " + recordingID)
+		_ = storage.SetLastError(recordingID, message)
+		emitResultDownloadStatus(recordingID, storage, logger, opts.NotifyStatus)
+		return
+	}
+	_ = storage.SetAudioFile(recordingID, AudioFilename(recordingID, ossURL))
+	logger.Info("[recording-result] 音频已更新: " + recordingID)
+	emitResultDownloadStatus(recordingID, storage, logger, opts.NotifyStatus)
+}
+
+func emitResultDownloadStatus(recordingID string, storage *Storage, logger Logger, notify func(StatusEvent)) {
+	entry, ok := storage.FindByID(recordingID)
+	if !ok {
+		return
+	}
+	title := firstNonEmpty(entry.Title, entry.Metadata.Name, recordingID)
+	emitResultStatus(recordingID, storage, logger, notify, nil, readSummaryFile(storage, recordingID), title)
+}
+
+func emitResultStatus(recordingID string, storage *Storage, logger Logger, notify func(StatusEvent), transcript []TranscriptItem, summary, title string) {
+	if notify == nil {
+		return
+	}
+	entry, ok := storage.FindByID(recordingID)
+	if !ok {
+		return
+	}
+	if title == "" {
+		title = firstNonEmpty(entry.Title, entry.Metadata.Name, recordingID)
+	}
+	event := StatusEvent{
+		RecordingID:        entry.ID,
+		TransferStatus:     entry.Status,
+		AudioFile:          entry.AudioFile,
+		SrtFile:            entry.SrtFile,
+		TranscriptDataFile: entry.TranscriptDataFile,
+		TranscriptFile:     entry.TranscriptFile,
+		SummaryFile:        entry.SummaryFile,
+		Transcript:         transcript,
+		Summary:            summary,
+		Title:              title,
+		UpdatedAt:          entry.UpdatedAt,
+		Error:              entry.LastError,
+	}
+	defer func() {
+		if rec := recover(); rec != nil {
+			logger.Error(fmt.Sprintf("[recording-result] 状态事件发送失败: %s, %v", recordingID, rec))
+		}
+	}()
+	notify(event)
+}
+
+func normalizeResultSegments(segments []ResultTranscriptSegment) []TranscriptSegment {
+	out := make([]TranscriptSegment, 0, len(segments))
+	for _, seg := range segments {
+		text := strings.TrimSpace(seg.Text)
+		if text == "" {
+			continue
+		}
+		out = append(out, TranscriptSegment{
+			Text:      text,
+			StartMS:   seg.StartMS,
+			EndMS:     seg.EndMS,
+			SpeakerID: seg.SpeakerID,
+		})
+	}
+	return out
+}
+
+func joinSegmentTexts(segments []TranscriptSegment) string {
+	parts := make([]string, 0, len(segments))
+	for _, seg := range segments {
+		if t := strings.TrimSpace(seg.Text); t != "" {
+			parts = append(parts, t)
+		}
+	}
+	return strings.TrimSpace(strings.Join(parts, "\n\n"))
+}
+
+func buildResultTranscriptMarkdown(meta Metadata, title, text string, segments []TranscriptSegment) string {
+	var lines []string
+	lines = append(lines, "# "+title, "")
+	lines = append(lines, "> 录音名称："+meta.Name)
+	lines = append(lines, "> 时长："+formatDuration(meta.DurationSec))
+	lines = append(lines, "> 创建时间："+meta.CreatedAt)
+	if len(meta.Markers) > 0 {
+		lines = append(lines, fmt.Sprintf("> 关键点数：%d", len(meta.Markers)))
+	}
+	lines = append(lines, "", "---", "")
+
+	if len(segments) > 0 {
+		for _, seg := range segments {
+			prefix := ""
+			if seg.StartMS != nil {
+				prefix = "[" + formatTimestamp(*seg.StartMS) + "] "
+			}
+			lines = append(lines, strings.TrimSpace(prefix+seg.Text), "")
+		}
+	} else {
+		lines = append(lines, text, "")
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func buildStructuredSummaryMarkdown(raw json.RawMessage) string {
+	if len(raw) == 0 || strings.TrimSpace(string(raw)) == "null" {
+		return ""
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return ""
+	}
+	switch val := v.(type) {
+	case string:
+		return val
+	case map[string]any:
+		lines := []string{"# 总结", ""}
+		appendSummarySection(&lines, "结论", val["decisions"])
+		appendSummarySection(&lines, "待办", val["todos"])
+		appendSummarySection(&lines, "风险", val["risks"])
+		appendSummarySection(&lines, "未决问题", val["openQuestions"])
+		if len(lines) == 2 {
+			pretty, _ := json.MarshalIndent(v, "", "  ")
+			lines = append(lines, "```json", string(pretty), "```")
+		}
+		return strings.Join(lines, "\n")
+	default:
+		return fmt.Sprintf("%v", val)
+	}
+}
+
+func appendSummarySection(lines *[]string, title string, value any) {
+	arr, ok := value.([]any)
+	if !ok || len(arr) == 0 {
+		return
+	}
+	*lines = append(*lines, "## "+title, "")
+	for _, item := range arr {
+		if str, ok := item.(string); ok {
+			*lines = append(*lines, "- "+str)
+			continue
+		}
+		b, _ := json.Marshal(item)
+		*lines = append(*lines, "- "+string(b))
+	}
+	*lines = append(*lines, "")
+}
+
+func readSummaryFile(storage *Storage, recordingID string) string {
+	data, err := os.ReadFile(filepath.Join(storage.SummariesDir(), SummaryFilename(recordingID)))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func normalizeMultiline(v string) string {
+	return strings.ReplaceAll(v, "\r\n", "\n")
+}
+
+func ensureTrailingNewline(v string) string {
+	if strings.HasSuffix(v, "\n") {
+		return v
+	}
+	return v + "\n"
+}

--- a/internal/recording/result_writer_test.go
+++ b/internal/recording/result_writer_test.go
@@ -1,0 +1,222 @@
+package recording
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func newResultStorage(t *testing.T) *Storage {
+	t.Helper()
+	storage := NewStorage(filepath.Join(t.TempDir(), "recordings"), testLogger{t})
+	if err := storage.Init(); err != nil {
+		t.Fatal(err)
+	}
+	return storage
+}
+
+func ptrF(v float64) *float64 { return &v }
+func ptrI(v int) *int         { return &v }
+
+func TestResultWriteTranscriptAndSummary(t *testing.T) {
+	t.Parallel()
+	storage := newResultStorage(t)
+	if _, err := storage.Ingest("rec_1", Metadata{Name: "会议", CreatedAt: "2026-06-09T20:30:00+08:00", OssAudioURL: "https://oss/rec_1.m4a"}, "phone-a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := storage.UpdateStatus("rec_1", StatusSynced); err == nil {
+		// syncing_openclaw -> synced is valid; ignore error result
+	}
+
+	var events []StatusEvent
+	result, err := HandleRecordingResultWrite(ResultWriteParams{
+		RecordingID: "rec_1",
+		Transcript: &ResultTranscript{
+			GeneratedAt: "2026-06-09T20:25:00+08:00",
+			Source:      &ResultTranscriptSource{Provider: "model-proxy", TaskID: "asr-1", Status: "SUCCEEDED"},
+			Title:       "产品方案讨论",
+			Category:    "meeting",
+			Brief:       "讨论新链路。",
+			Segments: []ResultTranscriptSegment{
+				{Text: "第一段。", StartMS: ptrF(0), EndMS: ptrF(4200), SpeakerID: ptrI(1)},
+				{Text: "第二段。", StartMS: ptrF(4200), EndMS: ptrF(8000), SpeakerID: ptrI(2)},
+			},
+		},
+		Summary: &ResultSummary{Markdown: "# 总结\n\n- App 写入结果。"},
+	}, storage, testLogger{t}, SyncOptions{
+		NotifyStatus: func(e StatusEvent) { events = append(events, e) },
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.OK || result.TransferStatus != StatusTranscribed {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if result.Stored.TranscriptDataFile == "" || result.Stored.TranscriptFile == "" || result.Stored.SummaryFile == "" {
+		t.Fatalf("missing stored files: %+v", result.Stored)
+	}
+
+	// transcript-data 落盘并标记 delivery=result-write
+	raw, err := os.ReadFile(filepath.Join(storage.dir, result.Stored.TranscriptDataFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc, ok := ParseTranscriptDocument(raw)
+	if !ok {
+		t.Fatalf("invalid transcript-data: %s", raw)
+	}
+	if doc.Source.Provider != "model-proxy" || doc.Source.Delivery != "result-write" {
+		t.Fatalf("unexpected source: %+v", doc.Source)
+	}
+	if doc.GeneratedAt != "2026-06-09T20:25:00+08:00" {
+		t.Fatalf("generatedAt not preserved: %s", doc.GeneratedAt)
+	}
+	if len(doc.Normalized.Segments) != 2 || doc.Normalized.Summary != "讨论新链路。" {
+		t.Fatalf("unexpected normalized: %+v", doc.Normalized)
+	}
+
+	summary, err := os.ReadFile(filepath.Join(storage.dir, result.Stored.SummaryFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(summary), "App 写入结果") {
+		t.Fatalf("unexpected summary: %s", summary)
+	}
+
+	entry, _ := storage.FindByID("rec_1")
+	if entry.Title != "产品方案讨论" {
+		t.Fatalf("title not set: %q", entry.Title)
+	}
+	if len(events) == 0 || events[len(events)-1].TransferStatus != StatusTranscribed {
+		t.Fatalf("missing transcribed status event: %+v", events)
+	}
+}
+
+func TestResultWriteUpsertsWhenMissing(t *testing.T) {
+	t.Parallel()
+	storage := newResultStorage(t)
+	result, err := HandleRecordingResultWrite(ResultWriteParams{
+		RecordingID: "rec_new",
+		Summary:     &ResultSummary{Markdown: "# 总结\n\n仅总结。"},
+	}, storage, testLogger{t}, SyncOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.OK || result.TransferStatus != StatusTranscribed {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if _, ok := storage.FindByID("rec_new"); !ok {
+		t.Fatal("recording not upserted")
+	}
+}
+
+func TestResultWriteRejectsEmptyPayload(t *testing.T) {
+	t.Parallel()
+	storage := newResultStorage(t)
+	if _, err := HandleRecordingResultWrite(ResultWriteParams{RecordingID: "rec_1"}, storage, testLogger{t}, SyncOptions{}); err == nil {
+		t.Fatal("expected error for empty payload")
+	}
+	if _, err := HandleRecordingResultWrite(ResultWriteParams{Summary: &ResultSummary{Markdown: "x"}}, storage, testLogger{t}, SyncOptions{}); err == nil {
+		t.Fatal("expected error for missing recordingId")
+	}
+}
+
+func TestResultWriteStructuredSummary(t *testing.T) {
+	t.Parallel()
+	storage := newResultStorage(t)
+	_, _ = storage.Ingest("rec_1", Metadata{Name: "x", CreatedAt: "t", OssAudioURL: "u"}, "")
+	result, err := HandleRecordingResultWrite(ResultWriteParams{
+		RecordingID: "rec_1",
+		Summary:     &ResultSummary{Structured: json.RawMessage(`{"decisions":["保持 sync 不变"],"todos":["新增 result.write"]}`)},
+	}, storage, testLogger{t}, SyncOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(storage.dir, result.Stored.SummaryFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	md := string(data)
+	if !strings.Contains(md, "## 结论") || !strings.Contains(md, "- 保持 sync 不变") || !strings.Contains(md, "## 待办") {
+		t.Fatalf("unexpected structured summary markdown: %s", md)
+	}
+}
+
+func TestResultWriteDownloadsOssAudio(t *testing.T) {
+	t.Parallel()
+	oss := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("final-audio"))
+	}))
+	defer oss.Close()
+
+	storage := newResultStorage(t)
+	_, _ = storage.Ingest("rec_1", Metadata{Name: "x", CreatedAt: "t", OssAudioURL: ""}, "")
+
+	var mu sync.Mutex
+	var events []StatusEvent
+	result, err := HandleRecordingResultWrite(ResultWriteParams{
+		RecordingID: "rec_1",
+		OssURL:      oss.URL + "/final.m4a",
+		Transcript:  &ResultTranscript{Title: "标题", Text: "正文"},
+	}, storage, testLogger{t}, SyncOptions{
+		NotifyStatus:    func(e StatusEvent) { mu.Lock(); events = append(events, e); mu.Unlock() },
+		DownloadOptions: DownloadOptions{MaxRetries: 1},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = result
+
+	waitFor(t, 2*time.Second, func() bool {
+		entry, ok := storage.FindByID("rec_1")
+		return ok && entry.AudioFile != ""
+	})
+	entry, _ := storage.FindByID("rec_1")
+	audioBytes, err := os.ReadFile(filepath.Join(storage.dir, entry.AudioFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(audioBytes) != "final-audio" {
+		t.Fatalf("unexpected audio content: %s", audioBytes)
+	}
+}
+
+func TestResultWriteOverwritesPreviousFiles(t *testing.T) {
+	t.Parallel()
+	storage := newResultStorage(t)
+	_, _ = storage.Ingest("rec_1", Metadata{Name: "x", CreatedAt: "t", OssAudioURL: "u"}, "")
+
+	first, err := HandleRecordingResultWrite(ResultWriteParams{
+		RecordingID: "rec_1",
+		Transcript:  &ResultTranscript{Title: "旧标题", Text: "旧正文"},
+	}, storage, testLogger{t}, SyncOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := HandleRecordingResultWrite(ResultWriteParams{
+		RecordingID: "rec_1",
+		Transcript:  &ResultTranscript{Title: "新标题", Text: "新正文"},
+	}, storage, testLogger{t}, SyncOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// 标题变化 → 旧 transcript markdown 文件被删除
+	if first.Stored.TranscriptFile == second.Stored.TranscriptFile {
+		t.Fatal("expected transcript filename to change with title")
+	}
+	if _, err := os.Stat(filepath.Join(storage.dir, first.Stored.TranscriptFile)); !os.IsNotExist(err) {
+		t.Fatalf("old transcript file should be removed, err=%v", err)
+	}
+	entry, _ := storage.FindByID("rec_1")
+	if entry.Title != "新标题" {
+		t.Fatalf("title not overwritten: %q", entry.Title)
+	}
+}

--- a/internal/recording/store.go
+++ b/internal/recording/store.go
@@ -331,10 +331,35 @@ func (s *Storage) UpdateStatus(recordingID, newStatus string) (Entry, error) {
 	return *entry, nil
 }
 
+// MarkResultWritten 在外部结果（result.write）写入后直接置为 transcribed。
+// 与插件 storage.markResultWritten 一致：绕过状态机校验，因为 synced/syncing →
+// transcribed 不是状态机的合法边，但这是带外（out-of-band）写入的预期终态。
+func (s *Storage) MarkResultWritten(recordingID string) (Entry, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	idx := s.findIndexLocked(recordingID)
+	if idx < 0 {
+		return Entry{}, os.ErrNotExist
+	}
+	entry := &s.index.Recordings[idx]
+	entry.Status = StatusTranscribed
+	entry.LastError = ""
+	entry.UpdatedAt = nowISO()
+	if err := s.saveIndexLocked(); err != nil {
+		return Entry{}, err
+	}
+	s.logger.Info("录音结果已写入: " + recordingID)
+	return *entry, nil
+}
+
 // SetAudioFile 记录本地音频文件。
 func (s *Storage) SetAudioFile(recordingID, filename string) error {
 	return s.updateEntry(recordingID, func(entry *Entry) {
-		entry.AudioFile = audioDirName + "/" + filename
+		next := audioDirName + "/" + filename
+		if entry.AudioFile != "" && entry.AudioFile != next {
+			s.removeRelativeLocked(entry.AudioFile)
+		}
+		entry.AudioFile = next
 	})
 }
 

--- a/internal/recording/transcript.go
+++ b/internal/recording/transcript.go
@@ -14,6 +14,8 @@ type TranscriptSource struct {
 	TaskID    string `json:"taskId,omitempty"`
 	RequestID string `json:"requestId,omitempty"`
 	Status    string `json:"status,omitempty"`
+	// Delivery 标记结果写入通道，例如 result.write 写入时为 "result-write"。
+	Delivery string `json:"delivery,omitempty"`
 }
 
 // TranscriptSegment 是 transcript-data normalized.segments 的单段。

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -27,11 +27,48 @@ type Bundled struct {
 var fmBlockRE = regexp.MustCompile(`(?s)^---\r?\n(.*?)\r?\n---`)
 
 func pickMeta(block, key string) string {
-	re := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(key) + `:\s*(.+)$`)
-	if m := re.FindStringSubmatch(block); m != nil {
-		return strings.TrimSpace(m[1])
+	lines := strings.Split(block, "\n")
+	prefix := key + ":"
+	for i, line := range lines {
+		if !strings.HasPrefix(line, prefix) {
+			continue
+		}
+		val := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+		// YAML 块标量（description: | 或 >）：收集后续更深缩进的行。
+		if val == "|" || val == ">" || strings.HasPrefix(val, "|") || strings.HasPrefix(val, ">") {
+			return collectBlockScalar(lines[i+1:], val[:1] == ">")
+		}
+		return val
 	}
 	return ""
+}
+
+// collectBlockScalar 读取块标量的后续缩进行，直到回到顶层键或 frontmatter 结束。
+// folded 为 true（>）时用空格连接行，否则（|）保留换行。
+func collectBlockScalar(rest []string, folded bool) string {
+	var out []string
+	for _, line := range rest {
+		trimmed := strings.TrimSpace(line)
+		// 空行属于块的一部分。
+		if trimmed == "" {
+			out = append(out, "")
+			continue
+		}
+		// 顶层键（无前导空格且形如 key:）表示块结束。
+		if line[0] != ' ' && line[0] != '\t' {
+			break
+		}
+		out = append(out, trimmed)
+	}
+	// 去掉尾部空行。
+	for len(out) > 0 && out[len(out)-1] == "" {
+		out = out[:len(out)-1]
+	}
+	sep := "\n"
+	if folded {
+		sep = " "
+	}
+	return strings.TrimSpace(strings.Join(out, sep))
 }
 
 func parseSkillMeta(md string) (name, description string) {

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -23,6 +23,19 @@ func TestParseSkillMeta(t *testing.T) {
 	}
 }
 
+func TestParseSkillMetaBlockScalar(t *testing.T) {
+	t.Parallel()
+	md := "---\nname: my-skill\ndescription: |\n  line one\n  line two\n\n  line three\nother: x\n---\n# body\n"
+	name, desc := parseSkillMeta(md)
+	if name != "my-skill" {
+		t.Errorf("name = %q", name)
+	}
+	want := "line one\nline two\n\nline three"
+	if desc != want {
+		t.Errorf("block scalar desc = %q, want %q", desc, want)
+	}
+}
+
 func TestList(t *testing.T) {
 	t.Parallel()
 	got, err := List()

--- a/internal/summaryjob/summaryjob.go
+++ b/internal/summaryjob/summaryjob.go
@@ -1,0 +1,817 @@
+// Package summaryjob 实现分片通知总结任务：把一段时间/筛选范围内的通知切成
+// 固定大小的分片，逐片交给模型总结，最后合并为一份 Markdown 结果。
+//
+// 任务态落盘在 <notificationsDir>/.summaries/jobs/<id>/ 下：
+//   - meta.json            任务元数据与分片索引
+//   - chunks/<chunkId>.json 每个分片的 compact 通知
+//   - summaries/<chunkId>.md 每个分片提交的摘要
+//   - result.md            合并后的最终结果
+//
+// 对齐 phone-notifications 的 ntf summary-job 实现。
+package summaryjob
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/YoooClaw/cli/internal/errs"
+	"github.com/YoooClaw/cli/internal/fsutil"
+	"github.com/YoooClaw/cli/internal/notif"
+)
+
+// 默认参数（对齐 TS DEFAULT_*）。
+const (
+	DefaultJobLimit     = 1000
+	DefaultChunkSize    = 150
+	DefaultMaxContent   = 120
+	DefaultRunMaxChunks = 20
+)
+
+const (
+	summaryRoot  = ".summaries"
+	jobsDir      = "jobs"
+	chunksDir    = "chunks"
+	summariesDir = "summaries"
+	resultFile   = "result.md"
+	cmdPrefix    = "yoooclaw notification summary-job"
+)
+
+var attentionKeywords = []string{
+	"待办", "需要", "麻烦", "确认", "回复", "审批", "开会", "会议", "安排",
+	"截止", "紧急", "异常", "失败", "风险",
+	"todo", "deadline", "urgent", "error", "failed",
+}
+
+// QueryMeta 是任务记录的查询条件（原始字符串，用于展示与复现）。
+type QueryMeta struct {
+	From             string `json:"from,omitempty"`
+	To               string `json:"to,omitempty"`
+	App              string `json:"app,omitempty"`
+	Sender           string `json:"sender,omitempty"`
+	ConversationType string `json:"conversationType,omitempty"`
+	Keyword          string `json:"keyword,omitempty"`
+	Limit            int    `json:"limit"`
+}
+
+type rangeInfo struct {
+	Newest *string `json:"newest"`
+	Oldest *string `json:"oldest"`
+}
+
+type scanInfo struct {
+	DaysScanned       int   `json:"daysScanned"`
+	ItemsScanned      int   `json:"itemsScanned"`
+	Matched           int   `json:"matched"`
+	StoppedAfterLimit bool  `json:"stoppedAfterLimit"`
+	ElapsedMs         int64 `json:"elapsedMs"`
+}
+
+type chunk struct {
+	ID          string    `json:"id"`
+	Index       int       `json:"index"`
+	Start       int       `json:"start"`
+	End         int       `json:"end"`
+	Count       int       `json:"count"`
+	Status      string    `json:"status"` // pending | in_progress | done
+	Range       rangeInfo `json:"range"`
+	ClaimedAt   string    `json:"claimedAt,omitempty"`
+	CompletedAt string    `json:"completedAt,omitempty"`
+	SummaryFile string    `json:"summaryFile,omitempty"`
+}
+
+type meta struct {
+	SchemaVersion int       `json:"schemaVersion"`
+	ID            string    `json:"id"`
+	Status        string    `json:"status"` // pending | in_progress | ready | complete | cancelled
+	CreatedAt     string    `json:"createdAt"`
+	UpdatedAt     string    `json:"updatedAt"`
+	Query         QueryMeta `json:"query"`
+	ChunkSize     int       `json:"chunkSize"`
+	MaxContent    int       `json:"maxContent"`
+	Total         int       `json:"total"`
+	Range         rangeInfo `json:"range"`
+	Scan          scanInfo  `json:"scan"`
+	Chunks        []chunk   `json:"chunks"`
+	ResultFile    string    `json:"resultFile,omitempty"`
+}
+
+type compactNotification struct {
+	AppName          string `json:"appName"`
+	AppDisplayName   string `json:"appDisplayName,omitempty"`
+	Title            string `json:"title"`
+	Content          string `json:"content"`
+	Timestamp        string `json:"timestamp"`
+	SenderName       string `json:"senderName,omitempty"`
+	ConversationType string `json:"conversationType,omitempty"`
+	ConversationName string `json:"conversationName,omitempty"`
+}
+
+type chunkFile struct {
+	ID            string                `json:"id"`
+	Index         int                   `json:"index"`
+	Start         int                   `json:"start"`
+	End           int                   `json:"end"`
+	Notifications []compactNotification `json:"notifications"`
+}
+
+// ── 工具函数 ──
+
+func nowIso() string { return time.Now().UTC().Format("2006-01-02T15:04:05.000Z") }
+
+var jobIDRE = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,100}$`)
+
+func createJobID() string {
+	stamp := time.Now().UTC().Format("20060102150405")
+	b := make([]byte, 4)
+	_, _ = rand.Read(b)
+	return stamp + "-" + hex.EncodeToString(b)
+}
+
+func assertJobID(id string) error {
+	if !jobIDRE.MatchString(id) {
+		return errs.New(errs.CodeInvalidArgument, "summary job id 不合法")
+	}
+	return nil
+}
+
+// truncate 按 rune 截断，超长时以 … 收尾（对齐 TS 语义但按字符而非 UTF-16 单元）。
+func truncate(value string, maxLen int) string {
+	r := []rune(value)
+	if len(r) <= maxLen {
+		return value
+	}
+	if maxLen <= 0 {
+		return ""
+	}
+	return string(r[:maxLen-1]) + "…"
+}
+
+func strPtr(s string) *string { return &s }
+
+func compact(item notif.StoredNotification, maxContent int) compactNotification {
+	return compactNotification{
+		AppName:          item.AppName,
+		AppDisplayName:   item.AppDisplayName,
+		Title:            truncate(item.Title, maxContent),
+		Content:          truncate(item.Content, maxContent),
+		Timestamp:        item.Timestamp,
+		SenderName:       item.SenderName,
+		ConversationType: item.ConversationType,
+		ConversationName: item.ConversationName,
+	}
+}
+
+func notificationApp(item compactNotification) string {
+	if v := strings.TrimSpace(item.AppDisplayName); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(item.AppName); v != "" {
+		return v
+	}
+	return "(unknown)"
+}
+
+func notificationSender(item compactNotification) string {
+	if v := strings.TrimSpace(item.SenderName); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(item.ConversationName); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(item.Title); v != "" {
+		return v
+	}
+	return "(unknown)"
+}
+
+// ── 路径 ──
+
+func jobsRootDir(notificationsDir string) string {
+	return filepath.Join(notificationsDir, summaryRoot, jobsDir)
+}
+
+func jobDir(notificationsDir, id string) string {
+	return filepath.Join(jobsRootDir(notificationsDir), id)
+}
+
+func metaPath(dir string) string { return filepath.Join(dir, "meta.json") }
+
+func chunkPath(dir, chunkID string) string {
+	return filepath.Join(dir, chunksDir, chunkID+".json")
+}
+
+// ── 元数据读写 ──
+
+func readMeta(notificationsDir, id string) (*meta, error) {
+	if err := assertJobID(id); err != nil {
+		return nil, err
+	}
+	dir := jobDir(notificationsDir, id)
+	var m meta
+	exists, err := fsutil.ReadJSON(metaPath(dir), &m)
+	if err != nil {
+		return nil, errs.Newf(errs.CodeInvalidArgument, "summary job 元数据损坏: %s", id)
+	}
+	if !exists {
+		return nil, errs.Newf(errs.CodeNotFound, "summary job 不存在: %s", id)
+	}
+	if m.SchemaVersion != 1 || m.ID == "" {
+		return nil, errs.Newf(errs.CodeInvalidArgument, "summary job 元数据损坏: %s", id)
+	}
+	return &m, nil
+}
+
+func saveMeta(notificationsDir string, m *meta) error {
+	m.UpdatedAt = nowIso()
+	return fsutil.WriteJSON(metaPath(jobDir(notificationsDir, m.ID)), m, fsutil.ConfigFileMode)
+}
+
+func readChunkNotifications(dir, chunkID string) ([]compactNotification, error) {
+	var cf chunkFile
+	exists, err := fsutil.ReadJSON(chunkPath(dir, chunkID), &cf)
+	if err != nil || !exists {
+		return nil, errs.Newf(errs.CodeInvalidArgument, "summary job 分片损坏: %s", chunkID)
+	}
+	return cf.Notifications, nil
+}
+
+// ── 状态计算 ──
+
+func refreshStatus(m *meta) string {
+	if m.Status == "cancelled" || m.Status == "complete" {
+		return m.Status
+	}
+	allDone := true
+	anyInProgress := false
+	for _, c := range m.Chunks {
+		if c.Status != "done" {
+			allDone = false
+		}
+		if c.Status == "in_progress" {
+			anyInProgress = true
+		}
+	}
+	if allDone { // 含空分片：对齐 TS .every() 对空数组返回 true 的语义
+		return "ready"
+	}
+	if anyInProgress {
+		return "in_progress"
+	}
+	return "pending"
+}
+
+func progressFor(m *meta) map[string]any {
+	doneChunks := 0
+	doneNotifications := 0
+	for _, c := range m.Chunks {
+		if c.Status == "done" {
+			doneChunks++
+			doneNotifications += c.Count
+		}
+	}
+	return map[string]any{
+		"totalChunks":        len(m.Chunks),
+		"doneChunks":         doneChunks,
+		"totalNotifications": m.Total,
+		"doneNotifications":  doneNotifications,
+		"remainingChunks":    len(m.Chunks) - doneChunks,
+	}
+}
+
+func nilStr(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+func toPublicStatus(m *meta) map[string]any {
+	chunks := make([]any, 0, len(m.Chunks))
+	for _, c := range m.Chunks {
+		chunks = append(chunks, map[string]any{
+			"id":          c.ID,
+			"index":       c.Index,
+			"count":       c.Count,
+			"status":      c.Status,
+			"range":       c.Range,
+			"summaryFile": nilStr(c.SummaryFile),
+		})
+	}
+	return map[string]any{
+		"ok":         true,
+		"id":         m.ID,
+		"status":     m.Status,
+		"createdAt":  m.CreatedAt,
+		"updatedAt":  m.UpdatedAt,
+		"query":      m.Query,
+		"total":      m.Total,
+		"chunkSize":  m.ChunkSize,
+		"range":      m.Range,
+		"scan":       m.Scan,
+		"progress":   progressFor(m),
+		"resultFile": nilStr(m.ResultFile),
+		"chunks":     chunks,
+	}
+}
+
+func nextCommand(id string) string   { return cmdPrefix + " next " + id }
+func resultCommand(id string) string { return cmdPrefix + " result " + id }
+func commitCommand(id, chunkID string) string {
+	return cmdPrefix + " commit " + id + " --chunk-id " + chunkID + " --summary-file <path>"
+}
+
+// ── 命令实现 ──
+
+// CreateParams 是创建任务的入参。Query 用于实际扫描，Meta 用于记录展示。
+type CreateParams struct {
+	Query      notif.QueryOptions
+	Meta       QueryMeta
+	ChunkSize  int
+	MaxContent int
+}
+
+// Create 扫描匹配通知并切片，落盘任务态。
+func Create(notificationsDir string, p CreateParams) (map[string]any, error) {
+	start := time.Now()
+	notifications, stats := notif.QueryWithStats(notificationsDir, p.Query)
+	elapsed := time.Since(start).Milliseconds()
+
+	id := createJobID()
+	dir := jobDir(notificationsDir, id)
+	if err := fsutil.EnsureDir(filepath.Join(dir, chunksDir), fsutil.DirMode); err != nil {
+		return nil, err
+	}
+	if err := fsutil.EnsureDir(filepath.Join(dir, summariesDir), fsutil.DirMode); err != nil {
+		return nil, err
+	}
+
+	chunks := make([]chunk, 0)
+	for s := 0; s < len(notifications); s += p.ChunkSize {
+		e := s + p.ChunkSize
+		if e > len(notifications) {
+			e = len(notifications)
+		}
+		raw := notifications[s:e]
+		compacted := make([]compactNotification, 0, len(raw))
+		for _, item := range raw {
+			compacted = append(compacted, compact(item, p.MaxContent))
+		}
+		index := len(chunks)
+		chunkID := pad4(index + 1)
+		end := s + len(compacted) - 1
+		if err := fsutil.WriteJSON(chunkPath(dir, chunkID), chunkFile{
+			ID: chunkID, Index: index, Start: s, End: end, Notifications: compacted,
+		}, fsutil.ConfigFileMode); err != nil {
+			return nil, err
+		}
+		chunks = append(chunks, chunk{
+			ID: chunkID, Index: index, Start: s, End: end, Count: len(compacted),
+			Status: "pending", Range: rangeFor(compacted),
+		})
+	}
+
+	createdAt := nowIso()
+	status := "pending"
+	if len(chunks) == 0 {
+		status = "ready"
+	}
+	m := &meta{
+		SchemaVersion: 1, ID: id, Status: status, CreatedAt: createdAt, UpdatedAt: createdAt,
+		Query: p.Meta, ChunkSize: p.ChunkSize, MaxContent: p.MaxContent,
+		Total: len(notifications), Range: rangeForStored(notifications),
+		Scan: scanInfo{
+			DaysScanned: stats.DaysScanned, ItemsScanned: stats.ItemsScanned,
+			Matched: stats.Matched, StoppedAfterLimit: stats.StoppedAfterLimit, ElapsedMs: elapsed,
+		},
+		Chunks: chunks,
+	}
+	if err := fsutil.WriteJSON(metaPath(dir), m, fsutil.ConfigFileMode); err != nil {
+		return nil, err
+	}
+
+	out := toPublicStatus(m)
+	out["nextCommand"] = nextCommand(id)
+	out["resultCommand"] = resultCommand(id)
+	return out, nil
+}
+
+// Status 刷新并返回任务状态。
+func Status(notificationsDir, id string) (map[string]any, error) {
+	m, err := readMeta(notificationsDir, id)
+	if err != nil {
+		return nil, err
+	}
+	m.Status = refreshStatus(m)
+	if err := saveMeta(notificationsDir, m); err != nil {
+		return nil, err
+	}
+	return toPublicStatus(m), nil
+}
+
+// Next 领取下一个待总结分片（或重试 in_progress 分片），返回其通知与 commit 命令。
+func Next(notificationsDir, id string) (map[string]any, error) {
+	m, err := readMeta(notificationsDir, id)
+	if err != nil {
+		return nil, err
+	}
+	if m.Status == "cancelled" {
+		return nil, errs.Newf(errs.CodeInvalidArgument, "summary job 已取消: %s", id)
+	}
+	dir := jobDir(notificationsDir, id)
+
+	idx := indexOfStatus(m.Chunks, "in_progress")
+	if idx < 0 {
+		if p := indexOfStatus(m.Chunks, "pending"); p >= 0 {
+			m.Chunks[p].Status = "in_progress"
+			m.Chunks[p].ClaimedAt = nowIso()
+			idx = p
+		}
+	}
+
+	if idx < 0 {
+		m.Status = refreshStatus(m)
+		if err := saveMeta(notificationsDir, m); err != nil {
+			return nil, err
+		}
+		return map[string]any{
+			"ok": true, "id": id, "done": true, "status": m.Status,
+			"progress": progressFor(m), "resultCommand": resultCommand(id),
+		}, nil
+	}
+
+	c := m.Chunks[idx]
+	notifications, err := readChunkNotifications(dir, c.ID)
+	if err != nil {
+		return nil, err
+	}
+	m.Status = refreshStatus(m)
+	if err := saveMeta(notificationsDir, m); err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"ok": true, "id": id, "done": false, "status": m.Status,
+		"chunk": map[string]any{
+			"id": c.ID, "index": c.Index, "start": c.Start, "end": c.End,
+			"count": c.Count, "range": c.Range,
+		},
+		"progress":      progressFor(m),
+		"commitCommand": commitCommand(id, c.ID),
+		"notifications": notifications,
+	}, nil
+}
+
+// Commit 提交某分片的摘要文本并标记完成；全部完成后自动生成结果。
+func Commit(notificationsDir, id, chunkID, summaryText string) (map[string]any, error) {
+	m, err := readMeta(notificationsDir, id)
+	if err != nil {
+		return nil, err
+	}
+	if m.Status == "cancelled" {
+		return nil, errs.Newf(errs.CodeInvalidArgument, "summary job 已取消: %s", id)
+	}
+	idx := indexOfID(m.Chunks, chunkID)
+	if idx < 0 {
+		return nil, errs.Newf(errs.CodeNotFound, "summary job 分片不存在: %s", chunkID)
+	}
+	text := strings.TrimRight(summaryText, "\n") + "\n"
+	if strings.TrimSpace(text) == "" {
+		return nil, errs.New(errs.CodeInvalidArgument, "分片摘要不能为空")
+	}
+	if err := writeChunkSummary(notificationsDir, m, idx, text); err != nil {
+		return nil, err
+	}
+	m.Status = refreshStatus(m)
+	if err := saveMeta(notificationsDir, m); err != nil {
+		return nil, err
+	}
+
+	out := map[string]any{
+		"ok": true, "id": id, "chunkId": chunkID, "status": m.Status, "progress": progressFor(m),
+	}
+	if m.Status == "ready" {
+		out["nextCommand"] = nil
+		out["resultCommand"] = resultCommand(id)
+	} else {
+		out["nextCommand"] = nextCommand(id)
+		out["resultCommand"] = nil
+	}
+	return out, nil
+}
+
+// Run 自动用抽取式摘要处理待总结分片（无需模型），完成后生成结果。
+func Run(notificationsDir, id string, maxChunks int, includeResult bool) (map[string]any, error) {
+	m, err := readMeta(notificationsDir, id)
+	if err != nil {
+		return nil, err
+	}
+	if m.Status == "cancelled" {
+		return nil, errs.Newf(errs.CodeInvalidArgument, "summary job 已取消: %s", id)
+	}
+	dir := jobDir(notificationsDir, id)
+	processed := make([]any, 0)
+	for i := range m.Chunks {
+		if len(processed) >= maxChunks {
+			break
+		}
+		if m.Chunks[i].Status == "done" {
+			continue
+		}
+		m.Chunks[i].Status = "in_progress"
+		m.Chunks[i].ClaimedAt = nowIso()
+		notifications, err := readChunkNotifications(dir, m.Chunks[i].ID)
+		if err != nil {
+			return nil, err
+		}
+		summary := buildExtractiveChunkSummary(m.Chunks[i], notifications)
+		if err := writeChunkSummary(notificationsDir, m, i, summary); err != nil {
+			return nil, err
+		}
+		processed = append(processed, map[string]any{"chunkId": m.Chunks[i].ID, "count": m.Chunks[i].Count})
+	}
+
+	markdown, err := finalizeResultIfReady(notificationsDir, m)
+	if err != nil {
+		return nil, err
+	}
+	if markdown == "" {
+		m.Status = refreshStatus(m)
+	}
+	if err := saveMeta(notificationsDir, m); err != nil {
+		return nil, err
+	}
+
+	out := map[string]any{
+		"ok": true, "id": id, "status": m.Status, "processed": processed,
+		"progress": progressFor(m), "resultFile": nilStr(m.ResultFile),
+	}
+	if m.Status == "complete" {
+		out["nextCommand"] = nil
+		out["resultCommand"] = resultCommand(id)
+	} else {
+		out["nextCommand"] = cmdPrefix + " run " + id
+		out["resultCommand"] = nil
+	}
+	if includeResult && markdown != "" {
+		out["markdown"] = markdown
+	}
+	return out, nil
+}
+
+// Result 合并已提交的分片摘要并返回结果（未就绪时返回 done=false）。
+func Result(notificationsDir, id string) (map[string]any, error) {
+	m, err := readMeta(notificationsDir, id)
+	if err != nil {
+		return nil, err
+	}
+	m.Status = refreshStatus(m)
+	if m.Status != "ready" && m.Status != "complete" {
+		if err := saveMeta(notificationsDir, m); err != nil {
+			return nil, err
+		}
+		return map[string]any{
+			"ok": true, "id": id, "done": false, "status": m.Status,
+			"progress": progressFor(m), "nextCommand": nextCommand(id),
+		}, nil
+	}
+
+	markdown, err := finalizeResultIfReady(notificationsDir, m)
+	if err != nil {
+		return nil, err
+	}
+	if markdown == "" {
+		markdown, err = buildResultMarkdown(notificationsDir, m)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if err := saveMeta(notificationsDir, m); err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"ok": true, "id": id, "done": true, "status": m.Status,
+		"resultFile": resultFile, "markdown": markdown,
+	}, nil
+}
+
+// Cancel 取消任务（保留已落盘的分片与摘要）。
+func Cancel(notificationsDir, id string) (map[string]any, error) {
+	m, err := readMeta(notificationsDir, id)
+	if err != nil {
+		return nil, err
+	}
+	m.Status = "cancelled"
+	if err := saveMeta(notificationsDir, m); err != nil {
+		return nil, err
+	}
+	return map[string]any{"ok": true, "id": id, "status": m.Status, "progress": progressFor(m)}, nil
+}
+
+// ── 内部辅助 ──
+
+func writeChunkSummary(notificationsDir string, m *meta, idx int, text string) error {
+	dir := jobDir(notificationsDir, m.ID)
+	rel := filepath.Join(summariesDir, m.Chunks[idx].ID+".md")
+	if err := fsutil.WriteAtomic(filepath.Join(dir, rel), []byte(text), fsutil.ConfigFileMode); err != nil {
+		return err
+	}
+	m.Chunks[idx].Status = "done"
+	m.Chunks[idx].CompletedAt = nowIso()
+	m.Chunks[idx].SummaryFile = rel
+	return nil
+}
+
+// finalizeResultIfReady 在任务就绪/完成时写出 result.md 并返回内容，否则返回空串。
+func finalizeResultIfReady(notificationsDir string, m *meta) (string, error) {
+	m.Status = refreshStatus(m)
+	if m.Status != "ready" && m.Status != "complete" {
+		return "", nil
+	}
+	markdown, err := buildResultMarkdown(notificationsDir, m)
+	if err != nil {
+		return "", err
+	}
+	if err := fsutil.WriteAtomic(filepath.Join(jobDir(notificationsDir, m.ID), resultFile), []byte(markdown), fsutil.ConfigFileMode); err != nil {
+		return "", err
+	}
+	m.Status = "complete"
+	m.ResultFile = resultFile
+	return markdown, nil
+}
+
+func buildResultMarkdown(notificationsDir string, m *meta) (string, error) {
+	dir := jobDir(notificationsDir, m.ID)
+	var b strings.Builder
+	b.WriteString("# 通知总结任务 " + m.ID + "\n\n")
+	b.WriteString("- 通知数: " + strconv.Itoa(m.Total) + "\n")
+	b.WriteString("- 时间范围: " + dash(m.Range.Oldest) + " 至 " + dash(m.Range.Newest) + "\n")
+	b.WriteString("- 分片数: " + strconv.Itoa(len(m.Chunks)) + "\n\n")
+	b.WriteString("## 分片摘要\n\n")
+	for _, c := range m.Chunks {
+		b.WriteString("### " + c.ID + " · " + strconv.Itoa(c.Count) + " 条 · " + dash(c.Range.Oldest) + " 至 " + dash(c.Range.Newest) + "\n\n")
+		if c.SummaryFile == "" {
+			b.WriteString("(未提交摘要)\n\n")
+			continue
+		}
+		raw, err := readFileTrim(filepath.Join(dir, c.SummaryFile))
+		if err != nil {
+			return "", err
+		}
+		b.WriteString(raw + "\n\n")
+	}
+	return strings.TrimRight(b.String(), "\n") + "\n", nil
+}
+
+func buildExtractiveChunkSummary(c chunk, notifications []compactNotification) string {
+	byApp := map[string]int{}
+	bySender := map[string]int{}
+	for _, item := range notifications {
+		byApp[notificationApp(item)]++
+		bySender[notificationSender(item)]++
+	}
+
+	var latest []string
+	for i, item := range notifications {
+		if i >= 5 {
+			break
+		}
+		latest = append(latest, compactLine(item))
+	}
+	var attention []string
+	for _, item := range notifications {
+		if len(attention) >= 5 {
+			break
+		}
+		if isAttentionCandidate(item) {
+			attention = append(attention, compactLine(item))
+		}
+	}
+
+	var b strings.Builder
+	b.WriteString("## 分片 " + c.ID + "\n\n")
+	b.WriteString("- 数量: " + strconv.Itoa(c.Count) + "\n")
+	b.WriteString("- 时间范围: " + dash(c.Range.Oldest) + " 至 " + dash(c.Range.Newest) + "\n")
+	b.WriteString("- 主要 App: " + formatTopCounts(byApp, 5) + "\n")
+	b.WriteString("- 主要发送人/会话: " + formatTopCounts(bySender, 8) + "\n\n")
+	b.WriteString("### 可能需要关注\n")
+	if len(attention) > 0 {
+		for _, line := range attention {
+			b.WriteString("- " + line + "\n")
+		}
+	} else {
+		b.WriteString("- 无明显待办、风险或异常样例\n")
+	}
+	b.WriteString("\n### 最近样例\n")
+	if len(latest) > 0 {
+		for _, line := range latest {
+			b.WriteString("- " + line + "\n")
+		}
+	} else {
+		b.WriteString("- 无\n")
+	}
+	return strings.TrimRight(b.String(), "\n") + "\n"
+}
+
+func compactLine(item compactNotification) string {
+	return "[" + item.Timestamp + "] " + notificationApp(item) + " · " + notificationSender(item) + ": " + item.Content
+}
+
+func isAttentionCandidate(item compactNotification) bool {
+	text := strings.ToLower(item.Title + "\n" + item.Content)
+	for _, kw := range attentionKeywords {
+		if strings.Contains(text, strings.ToLower(kw)) {
+			return true
+		}
+	}
+	return false
+}
+
+// formatTopCounts 取计数前 limit 名，按「计数降序、键升序」排序后拼成 "k1 c1；k2 c2"。
+func formatTopCounts(counts map[string]int, limit int) string {
+	type kc struct {
+		key   string
+		count int
+	}
+	rows := make([]kc, 0, len(counts))
+	for k, v := range counts {
+		rows = append(rows, kc{k, v})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].count != rows[j].count {
+			return rows[i].count > rows[j].count
+		}
+		return rows[i].key < rows[j].key
+	})
+	if limit < len(rows) {
+		rows = rows[:limit]
+	}
+	if len(rows) == 0 {
+		return "无"
+	}
+	parts := make([]string, 0, len(rows))
+	for _, r := range rows {
+		parts = append(parts, r.key+" "+strconv.Itoa(r.count))
+	}
+	return strings.Join(parts, "；")
+}
+
+func rangeFor(items []compactNotification) rangeInfo {
+	if len(items) == 0 {
+		return rangeInfo{}
+	}
+	return rangeInfo{Newest: strPtr(items[0].Timestamp), Oldest: strPtr(items[len(items)-1].Timestamp)}
+}
+
+func rangeForStored(items []notif.StoredNotification) rangeInfo {
+	if len(items) == 0 {
+		return rangeInfo{}
+	}
+	return rangeInfo{Newest: strPtr(items[0].Timestamp), Oldest: strPtr(items[len(items)-1].Timestamp)}
+}
+
+func indexOfStatus(chunks []chunk, status string) int {
+	for i := range chunks {
+		if chunks[i].Status == status {
+			return i
+		}
+	}
+	return -1
+}
+
+func indexOfID(chunks []chunk, id string) int {
+	for i := range chunks {
+		if chunks[i].ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
+func pad4(n int) string {
+	s := strconv.Itoa(n)
+	for len(s) < 4 {
+		s = "0" + s
+	}
+	return s
+}
+
+func dash(s *string) string {
+	if s == nil || *s == "" {
+		return "-"
+	}
+	return *s
+}
+
+func readFileTrim(path string) (string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", errs.Newf(errs.CodeNotFound, "无法读取分片摘要: %s", path)
+	}
+	return strings.TrimSpace(string(raw)), nil
+}

--- a/internal/summaryjob/summaryjob_test.go
+++ b/internal/summaryjob/summaryjob_test.go
@@ -1,0 +1,223 @@
+package summaryjob
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/YoooClaw/cli/internal/notif"
+)
+
+// writeNotifs 在 dir/<dateKey>.json 写入 n 条通知。
+func writeNotifs(t *testing.T, dir, dateKey string, n int) {
+	t.Helper()
+	items := make([]notif.StoredNotification, n)
+	for i := range items {
+		items[i] = notif.StoredNotification{
+			AppName: "微信", AppDisplayName: "微信",
+			Title: "标题", Content: "需要确认开会", SenderName: "张三",
+			Timestamp: dateKey + "T10:00:00+08:00",
+		}
+	}
+	raw, _ := json.Marshal(items)
+	if err := os.WriteFile(filepath.Join(dir, dateKey+".json"), raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func createJob(t *testing.T, dir string, chunkSize int) string {
+	t.Helper()
+	opts, err := notif.BuildQueryOptions(notif.RawQueryOpts{}, DefaultJobLimit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := Create(dir, CreateParams{Query: opts, Meta: QueryMeta{Limit: opts.Limit}, ChunkSize: chunkSize, MaxContent: DefaultMaxContent})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return res["id"].(string)
+}
+
+func TestCreateChunking(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeNotifs(t, dir, "2026-06-16", 7)
+	res, err := Create(dir, mustOpts(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res["total"].(int) != 7 {
+		t.Errorf("total should be 7: %+v", res["total"])
+	}
+	chunks := res["chunks"].([]any)
+	if len(chunks) != 3 { // 3+3+1
+		t.Errorf("expected 3 chunks: %d", len(chunks))
+	}
+	if res["status"] != "pending" {
+		t.Errorf("status should be pending: %v", res["status"])
+	}
+}
+
+func mustOpts(t *testing.T) CreateParams {
+	t.Helper()
+	opts, err := notif.BuildQueryOptions(notif.RawQueryOpts{}, DefaultJobLimit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return CreateParams{Query: opts, Meta: QueryMeta{Limit: opts.Limit}, ChunkSize: 3, MaxContent: DefaultMaxContent}
+}
+
+func TestCreateEmptyIsReady(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	id := createJob(t, dir, 3)
+	st, err := Status(dir, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st["status"] != "ready" {
+		t.Errorf("empty job should be ready: %v", st["status"])
+	}
+}
+
+func TestLifecycleNextCommitResult(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeNotifs(t, dir, "2026-06-16", 5)
+	id := createJob(t, dir, 2) // 2+2+1 = 3 chunks
+
+	seen := map[string]bool{}
+	for {
+		res, err := Next(dir, id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res["done"].(bool) {
+			break
+		}
+		c := res["chunk"].(map[string]any)
+		chunkID := c["id"].(string)
+		if seen[chunkID] {
+			t.Fatalf("next returned same chunk twice without commit: %s", chunkID)
+		}
+		seen[chunkID] = true
+		if _, err := Commit(dir, id, chunkID, "摘要 "+chunkID); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(seen) != 3 {
+		t.Errorf("should have processed 3 chunks: %d", len(seen))
+	}
+
+	res, err := Result(dir, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res["done"].(bool) || res["status"] != "complete" {
+		t.Errorf("result should be complete: %+v", res)
+	}
+	md := res["markdown"].(string)
+	if !strings.Contains(md, "摘要 0001") || !strings.Contains(md, "通知数: 5") {
+		t.Errorf("markdown missing content: %s", md)
+	}
+	// result.md 已落盘
+	if _, err := os.Stat(filepath.Join(dir, summaryRoot, jobsDir, id, resultFile)); err != nil {
+		t.Errorf("result.md not written: %v", err)
+	}
+}
+
+func TestRunAutoExtractive(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeNotifs(t, dir, "2026-06-16", 5)
+	id := createJob(t, dir, 2)
+
+	res, err := Run(dir, id, DefaultRunMaxChunks, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res["status"] != "complete" {
+		t.Errorf("run should complete: %v", res["status"])
+	}
+	if len(res["processed"].([]any)) != 3 {
+		t.Errorf("should process 3 chunks: %+v", res["processed"])
+	}
+	md := res["markdown"].(string)
+	if !strings.Contains(md, "可能需要关注") {
+		t.Errorf("extractive summary missing attention section: %s", md)
+	}
+}
+
+func TestRunMaxChunks(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeNotifs(t, dir, "2026-06-16", 6)
+	id := createJob(t, dir, 2) // 3 chunks
+
+	res, err := Run(dir, id, 1, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res["status"] == "complete" {
+		t.Errorf("should not complete after 1 of 3 chunks: %v", res["status"])
+	}
+	if len(res["processed"].([]any)) != 1 {
+		t.Errorf("should process exactly 1 chunk: %+v", res["processed"])
+	}
+	// 再跑一次继续处理
+	if _, err := Run(dir, id, DefaultRunMaxChunks, false); err != nil {
+		t.Fatal(err)
+	}
+	st, _ := Status(dir, id)
+	if st["status"] != "complete" {
+		t.Errorf("should complete after second run: %v", st["status"])
+	}
+}
+
+func TestCancel(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeNotifs(t, dir, "2026-06-16", 3)
+	id := createJob(t, dir, 2)
+
+	if _, err := Cancel(dir, id); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Next(dir, id); err == nil {
+		t.Error("next on cancelled job should error")
+	}
+	if _, err := Commit(dir, id, "0001", "x"); err == nil {
+		t.Error("commit on cancelled job should error")
+	}
+}
+
+func TestErrors(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if _, err := Status(dir, "missing"); err == nil {
+		t.Error("missing job should error")
+	}
+	if _, err := Status(dir, "bad id with spaces"); err == nil {
+		t.Error("invalid job id should error")
+	}
+	writeNotifs(t, dir, "2026-06-16", 3)
+	id := createJob(t, dir, 2)
+	if _, err := Commit(dir, id, "9999", "x"); err == nil {
+		t.Error("unknown chunk should error")
+	}
+	if _, err := Commit(dir, id, "0001", "   \n  "); err == nil {
+		t.Error("empty summary should error")
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	t.Parallel()
+	if got := truncate("abc", 10); got != "abc" {
+		t.Errorf("short string unchanged: %q", got)
+	}
+	if got := truncate("你好世界朋友", 3); got != "你好…" {
+		t.Errorf("rune truncate wrong: %q", got)
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.2.4",
+  "version": "0.3.0-beta.0",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {

--- a/skills/yoooclaw-notification-query/SKILL.md
+++ b/skills/yoooclaw-notification-query/SKILL.md
@@ -1,21 +1,58 @@
 ---
 name: yoooclaw-notification-query
-description: 用 yoooclaw CLI 直接、流式地查询手机通知原始数据。当用户说"看看最近的通知""谁找过我""总结今天的消息""某 App 有什么通知""昨天有什么消息"或任何通知查询/筛选/汇总诉求时，激活本 Skill，基于当前磁盘最新数据查询，不要依赖先前轮次或记忆。yoooclaw 是 openclaw 手机通知插件的独立 CLI 形态，数据在 ~/.yoooclaw 下，纯读磁盘、不需要 daemon 在跑。
+description: |
+  查询、汇总、总结手机通知/消息。处理一切"通知 / 消息"的查看、筛选、汇总、总结请求，这是唯一对口的 Skill。
+  最高频触发语（必须命中，不能漏）：
+  - "帮我总结最近的通知，约 {数量} 条。（上次总结时间: {YYYY年M月D日 HH:mm}）"
+  - "帮我总结最近的通知""总结下最近的通知""总结一下我的通知""总结最近收到的消息"
+  其它触发语："查看我的通知""最近收到什么消息""最近有什么通知""谁找过我""某某给我发过什么""昨天/今天有什么通知""看看我的微信消息"。
+  简单判定规则：用户话里出现"通知"或"消息"，且想看 / 查 / 筛 / 总结 / 汇总 / 概览其中之一，就立即激活本 Skill。
+  通知数据持续更新：每次都必须重新激活并从头完整执行本 Skill 流程，基于最新磁盘数据重新查询，禁止复用上一轮结果、禁止从记忆中检索（即使刚更新过记忆）。
 ---
 
-# yoooclaw 通知查询（Agent-Native，流式）
+# yoooclaw 通知查询与总结
 
-`yoooclaw` CLI 自身就是工具表：所有命令都支持 `--format json|pretty|table|ndjson`。
-**Agent 消费首选 `--format ndjson`**——每条通知一行 JSON、无包裹数组，便于流式逐条处理大批量结果。
+`yoooclaw` 是 openclaw 手机通知插件的独立 CLI 形态，数据在 `~/.yoooclaw` 下，纯读磁盘、不需要 daemon 在跑。所有命令支持 `--format json|pretty|table|ndjson`，Agent 消费首选 `json`（总结类）或 `ndjson`（逐条流式）。
 
-> 命令名 `yoooclaw`，短别名 `yc` 完全等价。下文用 `yoooclaw`。
+> 命令名 `yoooclaw`，短别名 `yc` 完全等价。下文用 `yoooclaw`。**只读，不修改任何文件。**
 
-## 何时激活
+## 最常见请求：一步到位（先看这里）
 
-- "最近收到什么消息 / 谁找过我 / 某某给我发过什么"
-- "总结今天 / 昨天 / 最近一小时的通知"
-- "微信 / 飞书 有什么通知"
-- 任何按 时间 / 应用 / 发送人 / 关键词 筛选通知的诉求
+用户说「帮我总结最近的通知，约 X 条」（可能带「上次总结时间」）时，按下面做，不要把上百条通知用 `search` 全文拉进上下文（会导致回复超时卡死）：
+
+1. 取数量 X（用户说「约 X 条 / 最近 X 条」就用 X；没说就用 700）。换算实际 N：X ≤ 3000 时 N=X；X > 3000 时 N=3000，并在回复里说明只覆盖最近 3000 条。
+2. 「未读通知」当前无独立已读/未读字段，按「最近通知」处理，不要因此放大 N。
+3. 如果带「上次总结时间: YYYY年M月D日 HH:mm」，先把它转成 ISO 8601（如 `2026-06-15T14:30:00+08:00`），作为 `--from`。涉及「今天/昨天/最近几天」先跑 `date +%F` 取本机日期，不要用模型内部日期。
+4. 按 N 分流，**整轮只执行一次总结命令**：
+
+   - **N ≤ 700**：一条轻量摘要命令
+
+     ```bash
+     yoooclaw notification summary --limit N --sample 12 --top 8 --format json
+     # 带上次总结时间：再加 --from <ISO_TIME>
+     ```
+
+     返回 `total`（最近 N 条聚合量）、`topApps` / `topSenders`（榜单）、`sample`（最近样例）。基于这些输出总结，**不要**再调 `search`。
+
+   - **N > 700**：分片总结任务，create 后运行一次自动 runner（不要把分片通知粘贴进回复）
+
+     ```bash
+     yoooclaw notification summary-job create --limit N --chunk-size 150 --max-content 120 --format json
+     # 取返回的 id，带上次总结时间则 create 再加 --from <ISO_TIME>
+     yoooclaw notification summary-job run <id> --max-chunks 30 --include-result --format json
+     ```
+
+     基于 `run` 返回的 `markdown`（或 `resultFile`）总结。
+
+5. **输出精简**：先一段整体概览，再按 App / 主要发送人分组，每组最多 3-5 条要点；不逐条罗列、不粘贴原始通知数组。`sample` / `topSenders` 只是代表性样例，不要当成完整列表复述。用户追问具体细节时，再 `yoooclaw notification search --sender "某某" --limit 20` 小范围补查。
+
+## 大批量总结硬性规则
+
+当请求是「总结 / 汇总 / 概览 / 最近通知主要是什么」且数量达 **50 条及以上**（或未指定但上下文暗示通知很多）：**必须**走 `notification summary`（N ≤ 700）或 `notification summary-job`（N > 700），**禁止**用 `search --limit X` 把上百条通知全文拉进上下文做总结。约束：
+
+- 小批量只执行一次 `summary`，不要反复 `summary` 或 `search --limit X`。
+- 大批量用 `summary-job create` 后只跑一次 `summary-job run`，不要再 `search`。
+- 不要用多条 shell 管道反复 grep 完整结果。
 
 ## 先确认存储路径（不要假设目录）
 
@@ -24,48 +61,50 @@ yoooclaw notification storage-path --format json
 # → {"ok":true,"path":"/abs/path/to/profiles/<profile>/notifications"}
 ```
 
-## 查询（按需选参数）
+按日期文件存储：`<path>/2026-06-16.json` 为当天所有通知的 JSON 数组（append-only）。单条字段：`appName / appDisplayName / title / content / timestamp(ISO 8601 含时区) / senderName / conversationType / conversationName`。常见总结请求可直接调 `summary`，无需先查 storage-path。
+
+## 查询（非总结类：查某人 / 某 App / 某天 / 某关键词）
 
 ```bash
-# 今日全部（快捷命令，等价 search --from 今日00:00 --to 今日23:59）
-yoooclaw notification +today --format ndjson
+# 最近 N 条
+yoooclaw notification search --limit 20 --format json
 
-# 最近一小时
-yoooclaw notification +recent --format ndjson
+# 时间范围（ISO 8601 含时区）
+yoooclaw notification search --from 2026-06-01T00:00:00+08:00 --to 2026-06-09T23:59:59+08:00 --format json
 
-# 精确筛选：时间范围 + 应用 + 关键词
-yoooclaw notification search \
-  --from 2026-05-01T00:00:00+08:00 --to 2026-05-21T23:59:59+08:00 \
-  --app 微信 --keyword 开会 --limit 200 --format ndjson
+# 按应用 / 发送人 / 关键词
+yoooclaw notification search --app 微信 --format ndjson
+yoooclaw notification search --sender 张三 --limit 20 --format json
+yoooclaw notification search --keyword 开会 --format ndjson
 
-# 聚合摘要（topApps / topSenders / 最近样例），适合"帮我总结"
-yoooclaw notification summary --top 10 --sample 30 --format json
-
-# 维度统计（date|app|sender|hour|client|all）
-yoooclaw notification stats --from 2026-05-14 --to 2026-05-21 --dim all --format json
-yoooclaw notification stats --from 2026-05-21T00:00:00+08:00 --to 2026-05-21T23:59:59+08:00 --sender 张三 --dim sender --format json
+# 快捷命令
+yoooclaw notification +today --format ndjson      # 今日全部
+yoooclaw notification +recent --format ndjson      # 最近一小时
 ```
 
-- `--app` 支持中英文别名：`微信/wechat`、`飞书/feishu/lark`、`钉钉/dingtalk`、`企业微信/wecom` 等。
-- `search` / `summary` 的 `--from/--to` 用 ISO 8601 含时区（`2026-05-01T09:00:00+08:00`）。`stats` 的 `--from/--to` 支持 `YYYY-MM-DD` 或 ISO 8601。
+- 用户提到期望条数（「最近 20 条 / 约 30 条」）时，必须把该数字传给 `--limit`，不要用默认值。
+- `--app` 支持中英文别名：`微信/wechat`、`飞书/feishu/lark`、`钉钉/dingtalk`、`企业微信/wecom` 等；不要把应用名臆测成不确定的包名。
+- search 返回时间倒序的 `notifications` 数组；展示时只给 appName/title/content/timestamp。
 
-## 流式处理 ndjson 的样板
+## 统计（排行 / 分布 / 趋势）
+
+仅当用户明确要「统计 / 谁发得最多 / 哪个 App 最多 / 按天/应用/发送人/时段分布 / 趋势」时使用；普通总结/概览不要走这里：
 
 ```bash
-yoooclaw notification search --app 微信 --format ndjson | while IFS= read -r line; do
-  # 每行是一条 StoredNotification：{appName,appDisplayName,title,content,timestamp,senderName,conversationType,...}
-  echo "$line" | jq -r '"\(.timestamp) \(.appDisplayName // .appName) | \(.senderName // .title): \(.content)"'
-done
+yoooclaw notification stats --dim all --from 2026-06-09 --to 2026-06-16 --format json
+yoooclaw notification stats --dim sender --sender 张三 --from 2026-06-16T00:00:00+08:00 --to 2026-06-16T23:59:59+08:00 --format json
 ```
+
+`--dim` 可选 `date|app|sender|hour|client|all`；`stats` 的 `--from/--to` 支持 `YYYY-MM-DD` 或 ISO 8601。
 
 ## 错误处理
 
-所有命令失败都输出统一 schema 并以非零退出码结束：
+失败统一输出并以非零退出码结束：
 
 ```json
 { "ok": false, "error": { "code": "YOOOCLAW_...", "message": "...", "hint": "..." } }
 ```
 
-- `YOOOCLAW_INVALID_ARGUMENT`：时间格式 / `--conversation-type`（只能 group|private）/ `--limit` 非正整数 → 按 `message` 修正参数。
-- 通知目录尚不存在或当天无数据：`search` 返回 `[]`、`+today` 返回 `[]`，**不是错误**——直接据此回复"暂无通知"。
+- `YOOOCLAW_INVALID_ARGUMENT`：时间格式 / `--conversation-type`（只能 group|private）/ `--limit` 非正整数 → 按 message 修正参数。
+- 通知目录不存在或当天无数据：`search` / `+today` 返回 `[]`、`summary` 返回 `total:0`，**不是错误**——直接据此回复"暂无通知"。
 - 多 profile：加 `--profile <name>` 查指定 profile 的数据。


### PR DESCRIPTION
## 0.3.0-beta.0

发布分支合回主干。本次预发布包含两块改动：

### recording: `recordings.result.write`（对齐 openclaw 插件）
- 新增 Gateway 方法，App/云端生成的转写与总结写入 `transcript-data/transcripts/summaries`
- 找不到录音时按占位元数据 upsert 新建
- 可选 `ossUrl` 后台下载并覆盖本地音频
- `MarkResultWritten` 直接置 `transcribed`；transcript-data 带 `source.delivery=result-write`
- 状态事件补 `summaryFile`

### notifications: 通知总结任务
- 新增 `cmd_summary_job` / `internal/summaryjob`，带进度上报
- 关联 notif sync/query、`cmd_sync`、notification-query skill 更新

### 发布
- `package.json` 0.2.4 → 0.3.0-beta.0
- tag `cli-v0.3.0-beta.0`，npm dist-tag `beta`，GitHub prerelease

🤖 Generated with [Claude Code](https://claude.com/claude-code)