### PR TITLE
cli-0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.3.0-beta.1",
+  "version": "0.3.0",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {


### PR DESCRIPTION
将 release/0.3.0 的版本号 bump（0.3.0-beta.1 → 0.3.0）合回 master，保持主干与已发布版本一致。

发布已完成：npm `latest` = 0.3.0，GitHub Release cli-v0.3.0（Latest）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)