### PR TITLE
cli-0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {


### PR DESCRIPTION
将 0.4.0 版本 bump 提交合回主干（发布已由 tag `cli-v0.4.0` 触发完成）。

- npm `latest` ← 0.4.0
- npm `beta` ← 0.4.0-beta.0
- 内容：daemon lifecycle 协议（owner/generation/metadata），已在 19b798f 落 master

🤖 Generated with [Claude Code](https://claude.com/claude-code)