### PR TITLE
release/0.5.0 → master：ingress 分层 + yclib 门面（0.5.0-beta.0）

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,32 @@ The lifecycle flags are optional; normal human `daemon start`, `stop`, and
 `restart` usage remains unchanged. When supplied to `daemon stop`, owner and
 generation are checked before the process is terminated.
 
+### Ingress 模式（daemon 连接可选、可代理）
+
+「到手机的连接」分层后可由 `--ingress` 选择**唯一** owner，避免独立 CLI 与宿主插件
+（如 hermes-plugin）同时连 Relay 导致双连接、双 ingest。优先级 `--ingress` flag >
+`YOOOCLAW_INGRESS` 环境变量 > `config.ingress.mode`，默认 `standalone`。
+
+| 模式 | 到手机的连接 owner | Relay 隧道 | ingest 鉴权 | 出站事件 |
+| --- | --- | --- | --- | --- |
+| `standalone`（默认） | Go daemon 自己的隧道 | 启用 | gateway token / 本机 | 经 Relay 推回手机 |
+| `proxied`（嵌入插件） | 宿主插件代理 | **关闭** | **必须 api-key** | POST 回宿主回调 URL |
+| `direct`（LAN / 测试） | 调用方直接 POST | 关闭 | api-key / token | 丢弃（仅落盘） |
+
+`proxied` 下 daemon 不连隧道，只暴露 ingest API（`POST /notifications` `/recordings`
+`/images`，带 `Authorization: Bearer <api-key>`）供宿主把手机数据喂进来；出站事件
+（如 `recording.status`）经 `--egress-callback-url` 回投宿主，再由宿主转发手机。
+
+```bash
+# 嵌入宿主：关掉 Go 自身隧道，让宿主代理连接并接收回投事件
+yoooclaw daemon run-foreground --ingress proxied \
+  --egress-callback-url http://127.0.0.1:8765/yoooclaw/egress \
+  --egress-callback-token <token>
+```
+
+`daemon status` 输出新增 `ingressMode` 字段。完整分层设计见
+[docs/design/ingress-layering.md](docs/design/ingress-layering.md)。
+
 ## 三层命令体系
 
 按粒度从快捷到完全自定义，覆盖日常操作到任意 daemon 端点：

--- a/docs/design/ingress-layering.md
+++ b/docs/design/ingress-layering.md
@@ -1,0 +1,141 @@
+# Ingress 分层设计：让 daemon 连接可选、可代理
+
+状态：yc-cli 侧已实现（standalone / proxied / direct 三模式 + Egress 端口）· hermes-plugin 侧待接入 · 目标读者：yc-cli + hermes-plugin 维护者
+
+## 1. 背景与问题
+
+手机端的数据（通知 / 录音 / 图片）要进入本机，今天有两条独立的「到手机」的连接实现：
+
+- **yc-cli（Go）**：daemon 内置 `relay.Supervisor`，每个 api-key 一条到云端 Relay 的 WebSocket 隧道，收到 frame 后 `Dispatcher` loopback 回 daemon 自己的 HTTP ingest 端点落盘。
+- **hermes-plugin（Python）**：`yoooclaw_app/app_transport/`（`relay.py` + `rpc.py`）是**另一套**完整的 Relay/RPC 客户端，同样直连手机端。同时它又通过 `DaemonSupervisor` spawn `yoooclaw daemon run-foreground` 并 `tunnel reconnect`。
+
+当 cli 内嵌进插件时，这两条连接可能**同时**打开 → 对手机端是双连接、对落盘是双重 ingest、对生命周期是两套重连/心跳。这正是要消除的层次混乱。
+
+## 2. 核心洞察（决定了设计可以很轻）
+
+阅读现有代码得到三个关键事实：
+
+1. **存储是文件化的，读路径不经过 daemon。** `notification list/today/recent`、recording、image 等查询命令直接 `notif.Query(ctx.Paths.Notifications, …)` 读文件。只有 `cmd_auth` / `cmd_daemon` / `cmd_daemon_services` 用 `daemon.Client`。
+2. **daemon 实际只负责三件事**：① ingress（Relay 隧道）② ingest HTTP API ③ 生命周期/状态。它是「传输 + HTTP 包装」，不是数据中枢。
+3. **ingest API 已经支持外部推送。** `isIngestPath` + `http-api-key` 鉴权让任何持有 api-key 的客户端都能 `POST /notifications`；`relay.enabled=false`（server.go）已经能关掉隧道而保留 ingest API。
+
+结论：要的分层**大部分已经存在**。这份设计是把它**显式化**，补齐「出站」与「模式选择」两块，并规定「**每种模式下到手机的连接有且只有一个 owner**」。
+
+## 3. 分层模型
+
+```
+            ┌──────────────────────────────────────────────┐
+  L3 Ingress │  传输层（可插拔，单一 owner）                  │
+   (transport)│  · relay   —— Go daemon 跑隧道（standalone）   │
+            │  · proxy   —— host 代理（embedded / 插件）      │
+            │  · direct  —— LAN/dev 直接 POST                │
+            └───────────────┬──────────────────────────────┘
+                            │  入站：HTTP POST ingest
+                            │  出站：Egress 端口
+            ┌───────────────▼──────────────────────────────┐
+  L2 Edge    │  Ingest / Egress API（稳定契约 = 「cli 暴露的 API」）│
+            │  POST /notifications /recordings /images       │
+            │  + Egress: 把出站事件交给当前传输层            │
+            └───────────────┬──────────────────────────────┘
+            ┌───────────────▼──────────────────────────────┐
+  L1 Core    │  Ingest Core（纯库，无网络）                   │
+            │  notif / recording / image：dedup + 落盘 + 查询 │
+            └───────────────────────────────────────────────┘
+```
+
+两个**端口（port）**把核心和传输解耦：
+
+- **Ingress（入站，host → core）**：就是 L2 的 HTTP ingest 端点。谁来「喂」它由模式决定，core 侧不需要知道。
+- **Egress（出站，core → 手机）**：新增一个接口，替换今天散落的 `s.tunnelSupervisor.PushEvent(...)`。
+  ```go
+  type Egress interface {
+      PushEvent(event string, payload any) error
+  }
+  ```
+  实现：`RelayEgress`（走隧道，= 现状）、`ProxyEgress`（POST 到 host 回调 URL）、`NoopEgress`（落盘即止）。
+
+> 出站今天很轻：只有 `recording.status` 一种事件 + 手机→daemon 的 RPC（查询/灯控）由 dispatcher loopback。所以 Egress 接口落地成本低。
+
+## 4. 三种运行模式
+
+由 `ingress.mode` 选择（config 字段 + `--ingress` 启动 flag + `YOOOCLAW_INGRESS` 环境变量，优先级 flag > env > config）：
+
+| 模式 | 到手机的连接 owner | Go relay.Supervisor | ingest 鉴权 | 出站 Egress |
+|------|------------------|--------------------|------------|------------|
+| `standalone`（默认，= 现状） | Go daemon 的隧道 | 启用 | gateway-token / 本机 | `RelayEgress` |
+| `proxied`（嵌入 hermes-plugin） | **host 插件**的 app_transport | **关闭** | **必须 api-key** | `ProxyEgress` → host 回调 |
+| `direct`（LAN / 测试） | 调用方直接 POST | 关闭 | api-key / token | `NoopEgress` |
+
+`proxied` 在语义上 ≈ 今天的 `relay.enabled=false` + 一个给插件用的 api-key，但显式成一个命名模式后：
+- daemon 启动时**不再**尝试连隧道（消除双连接）；
+- 校验 ingest 必须带 api-key（loopback/本机豁免不再适用于外部 host）；
+- 注册一个 Egress 回调，使出站事件能回到插件。
+
+## 5. 嵌入契约（proxied 模式）
+
+插件与 cli 在同一台机器、localhost 通信。契约是**双向**的：
+
+### 5.1 入站：插件 → cli（喂数据）
+
+插件的 `app_transport` 收到手机 frame 后，按映射 POST 到 cli ingest API（已存在的端点）：
+
+```
+POST http://127.0.0.1:<port>/notifications      Authorization: Bearer <hermes-api-key>
+POST http://127.0.0.1:<port>/recordings         （含 /gateway/recordings.* 分片/异步变体）
+POST http://127.0.0.1:<port>/images
+```
+
+`clientLabel` 由 api-key 映射得到（server.go `labelForAPIKey`），用于多租户区分，无需新协议。
+
+### 5.2 出站：cli → 插件（回事件）
+
+已采用 **回调 webhook**（与入站对称）：daemon 启动时由 `--egress-callback-url` + `--egress-callback-token`（或 `config.ingress.egressCallback`）拿到 host 回调地址；`ProxyEgress.PushEvent` 即 `POST callbackUrl {event, payload}`（带 `Authorization: Bearer <token>`）。插件收到后用自己的 app_transport relay 转发给手机。未配置回调时退化为 `NoopEgress`（出站丢弃，仅告警）。
+
+> 备选未采用：拉取队列 `GET /egress/events`（SSE / long-poll）。无需 host 开端口，但插件要常驻订阅循环；如宿主不便监听端口可再切换。
+
+手机 → cli 的 RPC（如「列通知」「发灯」）在 proxied 模式下由**插件**接收：因为读路径是直读文件，插件可直接调用 cli 查询命令或 L2 只读查询，不必经隧道。
+
+### 5.3 进程模型
+
+保持 **sidecar**：插件仍 spawn `yoooclaw daemon run-foreground --ingress=proxied`（Go/Python 无法同进程链接）。相对现状仅多两个动作：传 `--ingress=proxied`、provision 一个 `hermes` api-key + egress 回调。
+
+> 备选（更激进的简化，列为 future）：**daemon-less one-shot**。因为读直读文件、core 是纯库，插件可对每批数据执行 `yoooclaw ingest --from-file -` 短命令落盘，彻底去掉常驻端口 / gateway-token / daemon 存活监控。代价是出站事件失去常驻端点，需改成插件侧 app_transport 全权负责出站。建议先做 sidecar，验证后再评估。
+
+## 6. 代码改动点（最小化）
+
+L1/L2 几乎不动，主要是把传输从 server 里抽出去：
+
+1. **`internal/daemon/egress.go`（新）**：定义 `Egress` 接口 + `RelayEgress`/`ProxyEgress`/`NoopEgress`。`server` 持有 `egress Egress` 取代直接引用 `tunnelSupervisor.PushEvent`（改 `server_ingest.go`）。
+2. **`internal/config`**：新增 `Ingress.Mode`（`standalone|proxied|direct`，默认 `standalone`）与 `Ingress.EgressCallback{URL,Token}`。
+3. **`internal/daemon/server.go` `RunForeground`**：按 `mode` 装配——
+   - `standalone`：现状（relay.Supervisor + RelayEgress）。
+   - `proxied`：跳过 Supervisor；要求 `credentialSet` 非空否则报错（没有 api-key 插件无法鉴权）；装配 `ProxyEgress`。
+   - `direct`：跳过 Supervisor + `NoopEgress`。
+4. **`cmd_daemon.go`**：`run-foreground` / `start` / `restart` 增加 `--ingress` / `--egress-callback-url` / `--egress-callback-token` flag，透传到 `StartOpts` 并经 `Spawn` 传给 detach 子进程。
+5. **hermes-plugin 侧**：`DaemonSupervisor._spawn_run_foreground` 加 `--ingress=proxied`；启动时 provision `hermes` api-key 并把 app_transport 的入站改成 POST cli ingest（而非自己落盘/双轨）；注册 egress 回调。
+
+## 6.5 实现状态（yc-cli 侧）
+
+已落地：
+
+- `config.IngressSection`（`ingress.mode` + `ingress.egressCallback{url,token}`，默认 `standalone`）。
+- `daemon.Egress` 端口 + `RelayEgress` / `ProxyEgress` / `NoopEgress`（`internal/daemon/egress.go`）。
+- `RunForeground` 按模式装配：`proxied` 跳过 Supervisor 并强制要求 api-key（否则 `YOOOCLAW_UNAUTHORIZED`）、装配 `ProxyEgress`；`direct` 跳过 Supervisor + `NoopEgress`；`standalone` 维持原 Relay 行为。`/daemon/reload` 仅在 `standalone` 重建隧道。
+- `recording.status` 出站改走 `s.egress.PushEvent`（`server_ingest.go`）。
+- `daemon run-foreground|start|restart` 新增 `--ingress` / `--egress-callback-url` / `--egress-callback-token`，经 `Spawn` 透传给 detach 子进程。
+- `/daemon/status` 新增 `ingressMode` 字段。
+- 单测 `internal/daemon/egress_test.go`；三模式手工冒烟通过。
+
+待办（hermes-plugin 侧，见第 6 节第 5 项）：`DaemonSupervisor` spawn 传 `--ingress=proxied` + egress 回调；provision `hermes` api-key；app_transport 入站改为 POST cli ingest API、订阅 egress 回调转发。
+
+> 注意：`config init` 收尾会自动 `Spawn` 一个 **standalone** daemon（`startDaemonForInit`）。嵌入流程里插件应在 init 后先 `daemon stop`，再以 `--ingress=proxied` 拉起，避免起到 standalone 实例。
+
+## 7. 兼容与迁移
+
+- 默认 `standalone` = 完全现状，老用户零感知。
+- `relay.enabled` 保留：`proxied`/`direct` 下强制关闭隧道（模式优先于 `relay.enabled`），不再因 `relay.enabled` 默认 true 而误连隧道。
+- ingest 端点路径、鉴权、frame 格式都不变 → 插件迁移可灰度：先让 app_transport 改走 ingest API，再关 Go 隧道。
+
+## 8. 一句话总结
+
+把 daemon 拆成「**可插拔传输层 + 稳定 ingest/egress 契约 + 文件化核心**」，用 `ingress.mode` 选择**唯一**的传输 owner：独立运行时 Go 自己连隧道，嵌入插件时让插件代理、cli 只暴露 ingest API 收数据——消除双连接、双 ingest，且 90% 复用现有代码。

--- a/internal/cli/cmd_daemon.go
+++ b/internal/cli/cmd_daemon.go
@@ -21,6 +21,7 @@ func newDaemonCmd() *cobra.Command {
 	start.Flags().Bool("no-detach", false, "前台运行（systemd/launchd 用）")
 	start.Flags().String("log-level", "", "error|warn|info|debug|trace")
 	addDaemonLifecycleFlags(start)
+	addIngressFlags(start)
 
 	stop := &cobra.Command{Use: "stop", Short: "停止 daemon（SIGTERM → 10s → SIGKILL）", Args: cobra.NoArgs, RunE: run(daemonStop)}
 	stop.Flags().String("owner", "", "仅停止 owner 匹配的 daemon")
@@ -32,6 +33,7 @@ func newDaemonCmd() *cobra.Command {
 	restart.Flags().Bool("no-detach", false, "前台运行")
 	restart.Flags().String("log-level", "", "日志级别")
 	addDaemonLifecycleFlags(restart)
+	addIngressFlags(restart)
 	reload := &cobra.Command{Use: "reload", Short: "重读凭据并增量刷新 Relay 隧道", Args: cobra.NoArgs, RunE: run(daemonReload)}
 	status := &cobra.Command{Use: "status", Short: "打印 daemon 状态（PID/端口/relay/规则数...）", Args: cobra.NoArgs, RunE: run(daemonStatus)}
 
@@ -45,6 +47,7 @@ func newDaemonCmd() *cobra.Command {
 	runFg.Flags().String("port", "", "监听端口")
 	runFg.Flags().String("log-level", "", "日志级别")
 	addDaemonLifecycleFlags(runFg)
+	addIngressFlags(runFg)
 
 	c.AddCommand(start, stop, restart, reload, status, logs, runFg)
 	return c
@@ -58,12 +61,21 @@ func startOptsFromCmd(cmd *cobra.Command) daemon.StartOpts {
 	return daemon.StartOpts{
 		Bind: flagStr(cmd, "bind"), Port: port, LogLevel: flagStr(cmd, "log-level"),
 		Owner: flagStr(cmd, "owner"), Generation: flagStr(cmd, "generation"),
+		IngressMode:         flagStr(cmd, "ingress"),
+		EgressCallbackURL:   flagStr(cmd, "egress-callback-url"),
+		EgressCallbackToken: flagStr(cmd, "egress-callback-token"),
 	}
 }
 
 func addDaemonLifecycleFlags(cmd *cobra.Command) {
 	cmd.Flags().String("owner", "", "生命周期 owner（例如 hermes-plugin）")
 	cmd.Flags().String("generation", "", "生命周期 generation，用于识别同一批启动的进程")
+}
+
+func addIngressFlags(cmd *cobra.Command) {
+	cmd.Flags().String("ingress", "", "传输模式 standalone|proxied|direct（默认 config.ingress.mode）")
+	cmd.Flags().String("egress-callback-url", "", "proxied 模式出站事件回投宿主的 URL")
+	cmd.Flags().String("egress-callback-token", "", "proxied 模式出站回调的 Bearer token")
 }
 
 func stopOptsFromCmd(cmd *cobra.Command) daemon.StopOpts {

--- a/internal/cli/cmd_notification.go
+++ b/internal/cli/cmd_notification.go
@@ -2,8 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"regexp"
-	"sort"
 	"strconv"
 	"time"
 
@@ -98,57 +96,13 @@ func notificationSummary(ctx *clictx.Context, cmd *cobra.Command, _ []string) (a
 	}
 	items := notif.Query(ctx.Paths.Notifications, opts)
 	return map[string]any{
-		"ok":    true,
-		"total": len(items),
-		"range": map[string]any{"from": nilIfEmpty(raw.From), "to": nilIfEmpty(raw.To)},
-		"topApps": topCounts(items, func(n notif.StoredNotification) string {
-			return firstNonEmpty(n.AppDisplayName, n.AppName)
-		}, top),
-		"topSenders": topCounts(items, func(n notif.StoredNotification) string {
-			return firstNonEmpty(n.SenderName, n.Title)
-		}, top),
-		"sample": toAnySlice(sliceN(items, sample)),
+		"ok":         true,
+		"total":      len(items),
+		"range":      map[string]any{"from": nilIfEmpty(raw.From), "to": nilIfEmpty(raw.To)},
+		"topApps":    notif.TopCounts(items, notif.AppLabel, top),
+		"topSenders": notif.TopCounts(items, notif.SenderLabel, top),
+		"sample":     toAnySlice(sliceN(items, sample)),
 	}, nil
-}
-
-var dateOnlyRE = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
-var isoTimeRE = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(\.\d{1,3})?)?(Z|[+-]\d{2}:\d{2})$`)
-
-type statsBoundary struct {
-	raw        string
-	exactTs    *time.Time
-	startTs    time.Time
-	endTs      time.Time
-	minDateKey string
-	maxDateKey string
-}
-
-func parseStatsBoundary(value, optionName string) (statsBoundary, error) {
-	if dateOnlyRE.MatchString(value) {
-		t, err := time.ParseInLocation("2006-01-02", value, time.Local)
-		if err != nil {
-			return statsBoundary{}, errs.Newf(errs.CodeInvalidArgument, "%s 必须是合法日期 YYYY-MM-DD", optionName)
-		}
-		start := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.Local)
-		end := time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 999000000, time.Local)
-		return statsBoundary{raw: value, startTs: start, endTs: end, minDateKey: value, maxDateKey: value}, nil
-	}
-	if !isoTimeRE.MatchString(value) {
-		return statsBoundary{}, errs.Newf(errs.CodeInvalidArgument,
-			"%s 必须是 YYYY-MM-DD 或 ISO 8601 时间，例如 2026-06-02 或 2026-06-02T09:00:00+08:00", optionName)
-	}
-	exact, ok := notif.ParseTime(value)
-	if !ok {
-		return statsBoundary{}, errs.Newf(errs.CodeInvalidArgument, "%s 不是合法时间", optionName)
-	}
-	declaredKey := value[:10]
-	localKey := exact.In(time.Local).Format("2006-01-02")
-	lo, hi := declaredKey, localKey
-	if lo > hi {
-		lo, hi = hi, lo
-	}
-	e := exact
-	return statsBoundary{raw: value, exactTs: &e, startTs: exact, endTs: exact, minDateKey: lo, maxDateKey: hi}, nil
 }
 
 func notificationStats(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error) {
@@ -160,15 +114,15 @@ func notificationStats(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any
 	if toRaw == "" {
 		toRaw = localToday()
 	}
-	from, err := parseStatsBoundary(fromRaw, "--from")
+	from, err := notif.ParseStatsBoundary(fromRaw, "--from")
 	if err != nil {
 		return nil, err
 	}
-	to, err := parseStatsBoundary(toRaw, "--to")
+	to, err := notif.ParseStatsBoundary(toRaw, "--to")
 	if err != nil {
 		return nil, err
 	}
-	if from.startTs.After(to.endTs) {
+	if from.StartTs.After(to.EndTs) {
 		return nil, errs.New(errs.CodeInvalidArgument, "--from 不能晚于 --to")
 	}
 	dim := flagStr(cmd, "dim")
@@ -181,21 +135,21 @@ func notificationStats(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any
 	}
 	opts := notif.QueryOptions{
 		App: flagStr(cmd, "app"), Sender: flagStr(cmd, "sender"), Client: flagStr(cmd, "client"),
-		Limit: maxLimit, FromTs: from.exactTs, ToTs: to.exactTs,
-		FromDateKey: from.minDateKey, ToDateKey: to.maxDateKey,
+		Limit: maxLimit, FromTs: from.ExactTs, ToTs: to.ExactTs,
+		FromDateKey: from.MinDateKey, ToDateKey: to.MaxDateKey,
 	}
 	items := notif.Query(ctx.Paths.Notifications, opts)
 
 	dims := map[string]any{
-		"date":   topCounts(items, func(n notif.StoredNotification) string { return tsLocalDate(n.Timestamp) }, maxLimit),
-		"app":    topCounts(items, func(n notif.StoredNotification) string { return firstNonEmpty(n.AppDisplayName, n.AppName) }, maxLimit),
-		"sender": topCounts(items, func(n notif.StoredNotification) string { return firstNonEmpty(n.SenderName, n.Title) }, maxLimit),
-		"hour":   topCounts(items, func(n notif.StoredNotification) string { return tsLocalHour(n.Timestamp) }, maxLimit),
-		"client": topCounts(items, func(n notif.StoredNotification) string { return firstNonEmpty(n.ClientLabel, "legacy") }, maxLimit),
+		"date":   notif.TopCounts(items, func(n notif.StoredNotification) string { return notif.TsLocalDate(n.Timestamp) }, maxLimit),
+		"app":    notif.TopCounts(items, notif.AppLabel, maxLimit),
+		"sender": notif.TopCounts(items, notif.SenderLabel, maxLimit),
+		"hour":   notif.TopCounts(items, func(n notif.StoredNotification) string { return notif.TsLocalHour(n.Timestamp) }, maxLimit),
+		"client": notif.TopCounts(items, notif.ClientLabelOf, maxLimit),
 	}
 	out := map[string]any{
 		"ok": true, "total": len(items),
-		"range": map[string]any{"from": from.raw, "to": to.raw}, "dim": dim,
+		"range": map[string]any{"from": from.Raw, "to": to.Raw}, "dim": dim,
 	}
 	if dim == "all" {
 		for k, v := range dims {
@@ -236,37 +190,9 @@ func notificationUnread(_ *clictx.Context, _ *cobra.Command, _ []string) (any, e
 }
 
 // ── helpers ──
-
-func topCounts(items []notif.StoredNotification, pick func(notif.StoredNotification) string, topN int) []any {
-	counts := map[string]int{}
-	for _, item := range items {
-		if k := pick(item); k != "" {
-			counts[k]++
-		}
-	}
-	type kc struct {
-		key   string
-		count int
-	}
-	rows := make([]kc, 0, len(counts))
-	for k, v := range counts {
-		rows = append(rows, kc{k, v})
-	}
-	sort.Slice(rows, func(i, j int) bool {
-		if rows[i].count != rows[j].count {
-			return rows[i].count > rows[j].count
-		}
-		return rows[i].key < rows[j].key
-	})
-	if topN < len(rows) {
-		rows = rows[:topN]
-	}
-	out := make([]any, 0, len(rows))
-	for _, r := range rows {
-		out = append(out, map[string]any{"key": r.key, "count": r.count})
-	}
-	return out
-}
+// 注：聚合原语 TopCounts / AppLabel / SenderLabel / ClientLabelOf / TsLocalDate /
+// TsLocalHour / ParseStatsBoundary 已下沉到 internal/notif（CLI 与 yclib 共用，
+// 见 arc-cli-library-integration §6 单一真相源）。
 
 func toAnySlice(items []notif.StoredNotification) []any {
 	out := make([]any, 0, len(items))
@@ -312,20 +238,6 @@ func atoiDefault(s string, def int) int {
 
 func localToday() string        { return time.Now().Format("2006-01-02") }
 func localDaysAgo(n int) string { return time.Now().AddDate(0, 0, -n).Format("2006-01-02") }
-func tsLocalDate(ts string) string {
-	t, ok := notif.ParseTime(ts)
-	if !ok {
-		return ""
-	}
-	return t.In(time.Local).Format("2006-01-02")
-}
-func tsLocalHour(ts string) string {
-	t, ok := notif.ParseTime(ts)
-	if !ok {
-		return ""
-	}
-	return t.In(time.Local).Format("15")
-}
 
 func localTZOffset() string {
 	_, offset := time.Now().Zone()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,6 +78,41 @@ type RelaySection struct {
 	Enabled            bool   `json:"enabled"`
 }
 
+// Ingress 运行模式（见 docs/design/ingress-layering.md）。
+const (
+	// IngressStandalone：daemon 自连 Relay 隧道接收数据（默认）。
+	IngressStandalone = "standalone"
+	// IngressProxied：宿主（如 hermes-plugin）代理到手机的连接，daemon 关闭隧道、
+	// 仅暴露 ingest API 收数据，出站事件回投宿主 egress 回调。
+	IngressProxied = "proxied"
+	// IngressDirect：不连隧道、不回投，仅供 LAN / 测试直接 POST。
+	IngressDirect = "direct"
+)
+
+// IngressSection 选择数据入站的传输 owner（L3 传输层）。
+type IngressSection struct {
+	Mode           string                `json:"mode"`
+	EgressCallback EgressCallbackSection `json:"egressCallback"`
+}
+
+// EgressCallbackSection 是 proxied 模式下 daemon 把出站事件回投给宿主的地址。
+type EgressCallbackSection struct {
+	URL   string `json:"url"`
+	Token string `json:"token"`
+}
+
+// NormalizeIngressMode 归一化 ingress 模式，未知/空值回退到 standalone。
+func NormalizeIngressMode(mode string) string {
+	switch strings.TrimSpace(mode) {
+	case IngressProxied:
+		return IngressProxied
+	case IngressDirect:
+		return IngressDirect
+	default:
+		return IngressStandalone
+	}
+}
+
 // NotificationSection 通知存储配置。RetentionDays 为 nil 表示永久保存。
 type NotificationSection struct {
 	RetentionDays *int     `json:"retentionDays"`
@@ -121,6 +156,7 @@ type Config struct {
 	Daemon       DaemonSection       `json:"daemon"`
 	Auth         AuthSection         `json:"auth"`
 	Relay        RelaySection        `json:"relay"`
+	Ingress      IngressSection      `json:"ingress"`
 	Notification NotificationSection `json:"notification"`
 	LightRules   LightRulesSection   `json:"lightRules"`
 	AutoUpdate   AutoUpdateSection   `json:"autoUpdate"`
@@ -148,6 +184,7 @@ func Default(credentialsPath string) Config {
 			ReconnectBackoffMs: 2000,
 			Enabled:            true,
 		},
+		Ingress: IngressSection{Mode: IngressStandalone},
 		Notification: NotificationSection{
 			RetentionDays: nil,
 			IgnoredApps:   []string{},

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -23,8 +23,21 @@ type Client struct {
 	timeout time.Duration
 }
 
-// NewClient 按 lock / config 推导 base URL 与 gateway token。
+// NewClient 按 lock / config 推导 base URL，并从 config/keychain 隐式解析 gateway token。
 func NewClient(p paths.Paths) *Client {
+	cfg, _ := config.Load(p)
+	tokenRef, _ := creds.ResolveGatewayToken(cfg)
+	return newClient(p, tokenRef.Value)
+}
+
+// NewClientWithToken 同 NewClient，但使用**显式传入**的 gateway token，不读 keychain/config。
+// 供 library（yclib）按 CredentialSource 注入凭证时使用。token 为空则后续请求不带鉴权头。
+func NewClientWithToken(p paths.Paths, token string) *Client {
+	return newClient(p, token)
+}
+
+// newClient 按 lock / config 推导 base URL，token 由调用方决定。
+func newClient(p paths.Paths, token string) *Client {
 	cfg, _ := config.Load(p)
 	state := State(p)
 	bind := cfg.Daemon.Bind
@@ -37,10 +50,9 @@ func NewClient(p paths.Paths) *Client {
 	if host == "0.0.0.0" {
 		host = "127.0.0.1"
 	}
-	tokenRef, _ := creds.ResolveGatewayToken(cfg)
 	return &Client{
 		BaseURL: "http://" + host + ":" + strconv.Itoa(port),
-		token:   tokenRef.Value,
+		token:   token,
 		timeout: 10 * time.Second,
 	}
 }

--- a/internal/daemon/egress.go
+++ b/internal/daemon/egress.go
@@ -1,0 +1,93 @@
+package daemon
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/YoooClaw/cli/internal/relay"
+)
+
+// Egress 是 daemon 出站事件端口（core → 手机）。不同传输模式有不同实现：
+// standalone 走 Relay 隧道；proxied 回投宿主 HTTP 回调；direct 丢弃。
+// 见 docs/design/ingress-layering.md。
+type Egress interface {
+	PushEvent(event string, payload any) error
+}
+
+// RelayEgress 把事件经 Relay 隧道广播给手机端（standalone 模式）。
+type RelayEgress struct {
+	sup *relay.Supervisor
+}
+
+// NewRelayEgress 构造基于隧道 supervisor 的出站端口。
+func NewRelayEgress(sup *relay.Supervisor) *RelayEgress {
+	return &RelayEgress{sup: sup}
+}
+
+// PushEvent 经隧道广播事件。
+func (e *RelayEgress) PushEvent(event string, payload any) error {
+	if e.sup == nil {
+		return nil
+	}
+	e.sup.PushEvent(event, payload)
+	return nil
+}
+
+// ProxyEgress 把事件 POST 给宿主 egress 回调（proxied 模式），由宿主再转发给手机端。
+type ProxyEgress struct {
+	url    string
+	token  string
+	client *http.Client
+	logger *Logger
+}
+
+// NewProxyEgress 构造回投宿主回调的出站端口。
+func NewProxyEgress(url, token string, logger *Logger) *ProxyEgress {
+	return &ProxyEgress{
+		url:    url,
+		token:  token,
+		client: &http.Client{Timeout: 10 * time.Second},
+		logger: logger,
+	}
+}
+
+// PushEvent 把 {event, payload} POST 给宿主回调。
+func (e *ProxyEgress) PushEvent(event string, payload any) error {
+	body, err := json.Marshal(map[string]any{"event": event, "payload": payload})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodPost, e.url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if e.token != "" {
+		req.Header.Set("Authorization", "Bearer "+e.token)
+	}
+	resp, err := e.client.Do(req)
+	if err != nil {
+		if e.logger != nil {
+			e.logger.Warn("egress 回投失败 event=" + event + ": " + err.Error())
+		}
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		msg := fmt.Sprintf("egress 回调返回 %d event=%s", resp.StatusCode, event)
+		if e.logger != nil {
+			e.logger.Warn(msg)
+		}
+		return fmt.Errorf("%s", msg)
+	}
+	return nil
+}
+
+// NoopEgress 丢弃出站事件（direct 模式，或 proxied 未配置回调时）。
+type NoopEgress struct{}
+
+// PushEvent 丢弃事件。
+func (NoopEgress) PushEvent(string, any) error { return nil }

--- a/internal/daemon/egress_test.go
+++ b/internal/daemon/egress_test.go
@@ -1,0 +1,95 @@
+package daemon
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/YoooClaw/cli/internal/config"
+)
+
+func TestResolveIngressMode(t *testing.T) {
+	cfg := config.Default("/tmp/creds.json") // ingress.mode = standalone
+	cases := []struct {
+		name    string
+		optMode string
+		env     string
+		cfgMode string
+		want    string
+	}{
+		{"default standalone", "", "", config.IngressStandalone, config.IngressStandalone},
+		{"flag wins over env+config", config.IngressDirect, config.IngressProxied, config.IngressProxied, config.IngressDirect},
+		{"env wins over config", "", config.IngressProxied, config.IngressStandalone, config.IngressProxied},
+		{"config used when no flag/env", "", "", config.IngressProxied, config.IngressProxied},
+		{"unknown falls back to standalone", "bogus", "", config.IngressStandalone, config.IngressStandalone},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.env != "" {
+				t.Setenv("YOOOCLAW_INGRESS", tc.env)
+			} else {
+				t.Setenv("YOOOCLAW_INGRESS", "")
+			}
+			cfg.Ingress.Mode = tc.cfgMode
+			got := resolveIngressMode(StartOpts{IngressMode: tc.optMode}, cfg)
+			if got != tc.want {
+				t.Fatalf("resolveIngressMode = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveProxyEgress(t *testing.T) {
+	logger := NewLogger(filepath.Join(t.TempDir(), "d.log"), "info", false)
+	cfg := config.Default("/tmp/creds.json")
+
+	// 未配置回调 → NoopEgress（出站丢弃）。
+	if e := resolveProxyEgress(StartOpts{}, cfg, logger); e != (NoopEgress{}) {
+		t.Fatalf("无回调时应为 NoopEgress，得到 %T", e)
+	}
+
+	// flag 提供回调 → ProxyEgress。
+	e := resolveProxyEgress(StartOpts{EgressCallbackURL: "http://x/cb", EgressCallbackToken: "tok"}, cfg, logger)
+	if _, ok := e.(*ProxyEgress); !ok {
+		t.Fatalf("有回调时应为 *ProxyEgress，得到 %T", e)
+	}
+}
+
+func TestProxyEgressPushEvent(t *testing.T) {
+	var gotAuth, gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+	logger := NewLogger(filepath.Join(t.TempDir(), "d.log"), "info", false)
+
+	eg := NewProxyEgress(srv.URL, "cbtok", logger)
+	if err := eg.PushEvent("recording.status", map[string]any{"id": "r1"}); err != nil {
+		t.Fatalf("PushEvent error: %v", err)
+	}
+	if gotAuth != "Bearer cbtok" {
+		t.Fatalf("Authorization = %q, want Bearer cbtok", gotAuth)
+	}
+	var payload struct {
+		Event   string         `json:"event"`
+		Payload map[string]any `json:"payload"`
+	}
+	if err := json.Unmarshal([]byte(gotBody), &payload); err != nil {
+		t.Fatalf("回调 body 非法 JSON: %v (%s)", err, gotBody)
+	}
+	if payload.Event != "recording.status" || payload.Payload["id"] != "r1" {
+		t.Fatalf("回调 payload 不符: %+v", payload)
+	}
+}
+
+func TestNoopEgressDropsEvents(t *testing.T) {
+	if err := (NoopEgress{}).PushEvent("recording.status", nil); err != nil {
+		t.Fatalf("NoopEgress 不应报错: %v", err)
+	}
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -38,6 +38,11 @@ type StartOpts struct {
 	LogLevel   string
 	Owner      string
 	Generation string
+	// IngressMode 覆盖 config.ingress.mode（standalone|proxied|direct）；空则回退 env/config。
+	IngressMode string
+	// EgressCallbackURL/Token 覆盖 config.ingress.egressCallback（proxied 模式出站回投）。
+	EgressCallbackURL   string
+	EgressCallbackToken string
 }
 
 type runtimeState struct {
@@ -117,21 +122,38 @@ func RunForeground(ctx *clictx.Context, opts StartOpts) error {
 		return err
 	}
 	logger.Info(fmt.Sprintf("yoooclaw daemon 启动：%s:%d（profile=%s, pid=%d）", bind, actualPort, ctx.Profile, os.Getpid()))
-	if cfg.Relay.Enabled {
+	mode := resolveIngressMode(opts, cfg)
+	srv.ingressMode = mode
+	srv.egress = NoopEgress{}
+	switch mode {
+	case config.IngressProxied:
+		// 宿主代理到手机的连接：daemon 不连隧道，只暴露 ingest API。要求 api-key 供宿主推送鉴权。
 		if len(credentialSet.Entries) == 0 {
-			logger.Warn("Relay 已启用但未设置 api-key；当前仅直连 HTTP")
-		} else {
-			srv.tunnelSupervisor = relay.NewSupervisor(relay.SupervisorOptions{
-				TunnelURL:          config.ResolveRelayURL(cfg),
-				HTTPBaseURL:        "http://127.0.0.1:" + fmt.Sprint(actualPort),
-				HTTPToken:          token,
-				HeartbeatSec:       cfg.Relay.HeartbeatSec,
-				ReconnectBackoffMs: cfg.Relay.ReconnectBackoffMs,
-				StateDir:           ctx.Paths.Dir,
-				Logger:             logger,
-			})
-			result := srv.tunnelSupervisor.Apply(credentialSet)
-			logger.Info(fmt.Sprintf("Relay tunnels applied: started=%v unchanged=%v", result.Started, result.Unchanged))
+			return errs.New(errs.CodeUnauthorized, "proxied 模式需要至少一个 api-key 供宿主推送鉴权").
+				WithHint("先设置 api-key，或改用 --ingress=standalone")
+		}
+		srv.egress = resolveProxyEgress(opts, cfg, logger)
+		logger.Info("ingress=proxied：Relay 隧道关闭，等待宿主推送 ingest")
+	case config.IngressDirect:
+		logger.Info("ingress=direct：Relay 隧道关闭，仅接受直接 POST")
+	default: // standalone
+		if cfg.Relay.Enabled {
+			if len(credentialSet.Entries) == 0 {
+				logger.Warn("Relay 已启用但未设置 api-key；当前仅直连 HTTP")
+			} else {
+				srv.tunnelSupervisor = relay.NewSupervisor(relay.SupervisorOptions{
+					TunnelURL:          config.ResolveRelayURL(cfg),
+					HTTPBaseURL:        "http://127.0.0.1:" + fmt.Sprint(actualPort),
+					HTTPToken:          token,
+					HeartbeatSec:       cfg.Relay.HeartbeatSec,
+					ReconnectBackoffMs: cfg.Relay.ReconnectBackoffMs,
+					StateDir:           ctx.Paths.Dir,
+					Logger:             logger,
+				})
+				result := srv.tunnelSupervisor.Apply(credentialSet)
+				srv.egress = NewRelayEgress(srv.tunnelSupervisor)
+				logger.Info(fmt.Sprintf("Relay tunnels applied: started=%v unchanged=%v", result.Started, result.Unchanged))
+			}
 		}
 	}
 
@@ -171,6 +193,8 @@ type server struct {
 	recordingMu       sync.Mutex
 	recordingInFlight map[string]time.Time
 	tunnelSupervisor  *relay.Supervisor
+	egress            Egress
+	ingressMode       string
 	token             string
 	credentialSet     creds.CredentialSet
 	ignored           map[string]bool
@@ -212,7 +236,7 @@ func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case path == "/daemon/reload" && r.Method == http.MethodPost:
 		s.credentialSet = creds.ResolveAPIKeyEntries()
 		relayResult := relay.ApplyResult{}
-		if s.cfg.Relay.Enabled {
+		if s.ingressMode == config.IngressStandalone && s.cfg.Relay.Enabled {
 			if s.tunnelSupervisor == nil && len(s.credentialSet.Entries) > 0 {
 				s.tunnelSupervisor = relay.NewSupervisor(relay.SupervisorOptions{
 					TunnelURL:          config.ResolveRelayURL(s.cfg),
@@ -373,6 +397,7 @@ func (s *server) handleStatus(w http.ResponseWriter) {
 			"startedAt":  s.st.startedAt,
 		},
 		"lastIngestAt": nilIfEmptyStr(lastIngest), "ingestCount": ingestCount,
+		"ingressMode":    s.ingressMode,
 		"relay":          relayStatus,
 		"tunnels":        relayStatus["tunnels"],
 		"credentialMode": s.credentialSet.Mode, "defaultLabel": defaultLabel,
@@ -405,8 +430,15 @@ func (s *server) relayStatusPayload() map[string]any {
 		}
 	}
 	note := "Relay 未启用，走直连 HTTP"
-	if s.cfg.Relay.Enabled {
-		note = "Relay 已启用但当前 CredentialSet 没有可用 api-key"
+	switch s.ingressMode {
+	case config.IngressProxied:
+		note = "ingress=proxied：隧道由宿主代理，daemon 仅收 ingest"
+	case config.IngressDirect:
+		note = "ingress=direct：隧道关闭，仅接受直接 POST"
+	default:
+		if s.cfg.Relay.Enabled {
+			note = "Relay 已启用但当前 CredentialSet 没有可用 api-key"
+		}
 	}
 	return map[string]any{
 		"mode": "standalone-http", "connected": false, "env": envhost.Name(), "url": config.ResolveRelayURL(s.cfg), "enabled": s.cfg.Relay.Enabled,
@@ -472,6 +504,24 @@ func writeJSON(w http.ResponseWriter, status int, body any) {
 
 func errBody(code, msg string) map[string]any {
 	return map[string]any{"ok": false, "error": map[string]any{"code": code, "message": msg}}
+}
+
+// resolveIngressMode 解析 ingress 模式，优先级：flag > env(YOOOCLAW_INGRESS) > config > standalone。
+func resolveIngressMode(opts StartOpts, cfg config.Config) string {
+	raw := firstNonEmptyStr(opts.IngressMode, os.Getenv("YOOOCLAW_INGRESS"), cfg.Ingress.Mode)
+	return config.NormalizeIngressMode(raw)
+}
+
+// resolveProxyEgress 装配 proxied 模式出站端口；未配置回调则丢弃并告警。
+func resolveProxyEgress(opts StartOpts, cfg config.Config, logger *Logger) Egress {
+	url := firstNonEmptyStr(opts.EgressCallbackURL, cfg.Ingress.EgressCallback.URL)
+	token := firstNonEmptyStr(opts.EgressCallbackToken, cfg.Ingress.EgressCallback.Token)
+	if url == "" {
+		logger.Warn("proxied 模式未配置 egress 回调，出站事件将被丢弃")
+		return NoopEgress{}
+	}
+	logger.Info("ingress=proxied：出站事件回投 " + url)
+	return NewProxyEgress(url, token, logger)
 }
 
 func firstNonEmptyStr(values ...string) string {

--- a/internal/daemon/server_ingest.go
+++ b/internal/daemon/server_ingest.go
@@ -329,8 +329,10 @@ func (s *server) notifyRecordingStatus(event recording.StatusEvent) {
 			s.logger.Warn("[recording-status] 事件落盘失败: " + err.Error())
 		}
 	}
-	if s.tunnelSupervisor != nil {
-		s.tunnelSupervisor.PushEvent("recording.status", event)
+	if s.egress != nil {
+		if err := s.egress.PushEvent("recording.status", event); err != nil {
+			s.logger.Warn("[recording-status] 出站事件投递失败: " + err.Error())
+		}
 	}
 	if terminalRecordingStatuses[event.TransferStatus] {
 		s.releaseRecordingInFlight(event.RecordingID)

--- a/internal/daemon/spawn.go
+++ b/internal/daemon/spawn.go
@@ -34,6 +34,15 @@ func Spawn(ctx *clictx.Context, opts StartOpts) (*Lock, error) {
 	if opts.Generation != "" {
 		args = append(args, "--generation", opts.Generation)
 	}
+	if opts.IngressMode != "" {
+		args = append(args, "--ingress", opts.IngressMode)
+	}
+	if opts.EgressCallbackURL != "" {
+		args = append(args, "--egress-callback-url", opts.EgressCallbackURL)
+	}
+	if opts.EgressCallbackToken != "" {
+		args = append(args, "--egress-callback-token", opts.EgressCallbackToken)
+	}
 	cmd := exec.Command(exe, args...)
 	cmd.SysProcAttr = detachSysProcAttr()
 	if null, err := os.OpenFile(os.DevNull, os.O_RDWR, 0); err == nil {

--- a/internal/daemon/spawn.go
+++ b/internal/daemon/spawn.go
@@ -14,11 +14,17 @@ import (
 
 // Spawn fork 一个脱离会话的子进程跑 `daemon run-foreground`，轮询 lock 确认起来（最多 ~3s）。
 func Spawn(ctx *clictx.Context, opts StartOpts) (*Lock, error) {
+	return SpawnFor(ctx.Paths, ctx.Profile, opts)
+}
+
+// SpawnFor 同 Spawn，但以**显式 paths + profile** 入参，不依赖 clictx。
+// 供 library（yclib）显式起 daemon 时使用。
+func SpawnFor(p paths.Paths, profile string, opts StartOpts) (*Lock, error) {
 	exe, err := os.Executable()
 	if err != nil {
 		return nil, errs.New(errs.CodeUnknown, "无法定位可执行文件："+err.Error())
 	}
-	args := []string{"daemon", "run-foreground", "--profile", ctx.Profile}
+	args := []string{"daemon", "run-foreground", "--profile", profile}
 	if opts.Bind != "" {
 		args = append(args, "--bind", opts.Bind)
 	}
@@ -56,7 +62,7 @@ func Spawn(ctx *clictx.Context, opts StartOpts) (*Lock, error) {
 
 	for i := 0; i < 30; i++ {
 		time.Sleep(100 * time.Millisecond)
-		if st := State(ctx.Paths); st.Running {
+		if st := State(p); st.Running {
 			return st.Lock, nil
 		}
 	}

--- a/internal/notif/aggregate.go
+++ b/internal/notif/aggregate.go
@@ -1,0 +1,120 @@
+package notif
+
+import (
+	"regexp"
+	"sort"
+	"time"
+
+	"github.com/YoooClaw/cli/internal/errs"
+)
+
+// Count 是一个聚合计数项（维度取值 + 出现次数）。其 JSON 形态 {key,count}
+// 与历史 CLI 输出逐字节一致，作为 CLI / library 共享的聚合原语。
+type Count struct {
+	Key   string `json:"key"`
+	Count int    `json:"count"`
+}
+
+// TopCounts 按 pick 维度聚合计数，按 (count 降序, key 升序) 排序后取前 topN。
+// 空 key 不计入。CLI 的 summary/stats 与 library 共用本函数，确保口径一致。
+func TopCounts(items []StoredNotification, pick func(StoredNotification) string, topN int) []Count {
+	counts := map[string]int{}
+	for _, item := range items {
+		if k := pick(item); k != "" {
+			counts[k]++
+		}
+	}
+	rows := make([]Count, 0, len(counts))
+	for k, v := range counts {
+		rows = append(rows, Count{Key: k, Count: v})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Count != rows[j].Count {
+			return rows[i].Count > rows[j].Count
+		}
+		return rows[i].Key < rows[j].Key
+	})
+	if topN < len(rows) {
+		rows = rows[:topN]
+	}
+	return rows
+}
+
+// AppLabel 取应用展示名（显示名优先，回退包名）。
+func AppLabel(n StoredNotification) string { return firstNonEmpty(n.AppDisplayName, n.AppName) }
+
+// SenderLabel 取发送人展示名（结构化发送人优先，回退标题）。
+func SenderLabel(n StoredNotification) string { return firstNonEmpty(n.SenderName, n.Title) }
+
+// ClientLabelOf 取来源客户端 label，旧数据回退 "legacy"。
+func ClientLabelOf(n StoredNotification) string { return firstNonEmpty(n.ClientLabel, "legacy") }
+
+// TsLocalDate 把 ISO 时间戳转本地日期 key（YYYY-MM-DD）；非法返回空串。
+func TsLocalDate(ts string) string {
+	t, ok := ParseTime(ts)
+	if !ok {
+		return ""
+	}
+	return t.In(time.Local).Format("2006-01-02")
+}
+
+// TsLocalHour 把 ISO 时间戳转本地小时（00-23）；非法返回空串。
+func TsLocalHour(ts string) string {
+	t, ok := ParseTime(ts)
+	if !ok {
+		return ""
+	}
+	return t.In(time.Local).Format("15")
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+var dateOnlyRE = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
+var isoTimeRE = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(\.\d{1,3})?)?(Z|[+-]\d{2}:\d{2})$`)
+
+// StatsBoundary 是 stats 查询的一端边界，支持「仅日期」或「ISO 时间」两种输入，
+// 同时给出精确时间戳与覆盖的日期 key 区间（用于按天文件早停过滤）。
+type StatsBoundary struct {
+	Raw        string
+	ExactTs    *time.Time
+	StartTs    time.Time
+	EndTs      time.Time
+	MinDateKey string
+	MaxDateKey string
+}
+
+// ParseStatsBoundary 解析 stats 的 --from/--to 边界值。optionName 仅用于错误提示。
+func ParseStatsBoundary(value, optionName string) (StatsBoundary, error) {
+	if dateOnlyRE.MatchString(value) {
+		t, err := time.ParseInLocation("2006-01-02", value, time.Local)
+		if err != nil {
+			return StatsBoundary{}, errs.Newf(errs.CodeInvalidArgument, "%s 必须是合法日期 YYYY-MM-DD", optionName)
+		}
+		start := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.Local)
+		end := time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 999000000, time.Local)
+		return StatsBoundary{Raw: value, StartTs: start, EndTs: end, MinDateKey: value, MaxDateKey: value}, nil
+	}
+	if !isoTimeRE.MatchString(value) {
+		return StatsBoundary{}, errs.Newf(errs.CodeInvalidArgument,
+			"%s 必须是 YYYY-MM-DD 或 ISO 8601 时间，例如 2026-06-02 或 2026-06-02T09:00:00+08:00", optionName)
+	}
+	exact, ok := ParseTime(value)
+	if !ok {
+		return StatsBoundary{}, errs.Newf(errs.CodeInvalidArgument, "%s 不是合法时间", optionName)
+	}
+	declaredKey := value[:10]
+	localKey := exact.In(time.Local).Format("2006-01-02")
+	lo, hi := declaredKey, localKey
+	if lo > hi {
+		lo, hi = hi, lo
+	}
+	e := exact
+	return StatsBoundary{Raw: value, ExactTs: &e, StartTs: exact, EndTs: exact, MinDateKey: lo, MaxDateKey: hi}, nil
+}

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -21,13 +21,20 @@ import (
 // DefaultProfile 是缺省 profile 名。
 const DefaultProfile = "default"
 
+// DefaultRoot 返回**不读环境变量**的缺省根数据目录（~/.yoooclaw）。
+// 供 library（yclib）等需要显式、可预测根目录的调用方使用，避免隐式 env 决策。
+func DefaultRoot() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".yoooclaw")
+}
+
 // RootDir 返回 CLI 根数据目录。可用 YOOOCLAW_HOME 覆盖（测试 / 多实例隔离）。
+// 注意：本函数会读环境变量，仅供 CLI 外壳使用；library 路径请用 DefaultRoot / ForRoot。
 func RootDir() string {
 	if h := strings.TrimSpace(os.Getenv("YOOOCLAW_HOME")); h != "" {
 		return h
 	}
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".yoooclaw")
+	return DefaultRoot()
 }
 
 // SharedCredentialsPath 返回 account 级共享凭据文件（顶层，跨 profile + 插件共享）。
@@ -66,9 +73,15 @@ type Paths struct {
 	State         string
 }
 
-// For 解析某个 profile 下的全部关键路径。
+// For 解析某个 profile 下的全部关键路径（根目录走 RootDir，含 env 覆盖）。
 func For(profile string) Paths {
-	dir := ProfileDir(profile)
+	return ForRoot(RootDir(), profile)
+}
+
+// ForRoot 在**显式根目录**下解析某个 profile 的全部关键路径，不读任何环境变量。
+// 供 library（yclib）注入 Config.RootDir 时使用，保证路径可预测、无隐式 env 决策。
+func ForRoot(root, profile string) Paths {
+	dir := filepath.Join(root, "profiles", profile)
 	return Paths{
 		Profile:       profile,
 		Dir:           dir,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.4.0",
+  "version": "0.5.0-beta.0",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {

--- a/yclib/README.md
+++ b/yclib/README.md
@@ -1,0 +1,107 @@
+# yclib — yc-cli 进程内 Go Library
+
+`yclib` 是 `@yoooclaw/cli` 的**进程内公开 API 门面**，让 Go Agent 进程直接 `import` 调用 CLI 的能力，无需 fork 子进程、无 IPC、类型安全。
+
+> 设计约束见 software 仓库 `architecture/arc-cli-library-integration.md`（路径 C）。
+
+## 安装
+
+```bash
+go get github.com/YoooClaw/cli/yclib
+```
+
+## 快速开始
+
+```go
+import "github.com/YoooClaw/cli/yclib"
+
+c, err := yclib.New(yclib.Config{Profile: "default"})
+if err != nil { /* ... */ }
+
+ctx := context.Background()
+res, err := c.Notifications().Search(ctx, yclib.RawQueryOpts{Keyword: "会议", Limit: "50"})
+for _, n := range res.Notifications {
+    fmt.Printf("[%s] %s: %s\n", n.AppDisplayName, n.Title, n.Content)
+}
+```
+
+消费方**只 import `yclib`**：入参/出参类型（`RawQueryOpts`、`StoredNotification`、`Count`、`ScanStats` …）都由 yclib re-export，不必触碰 `internal/...`。
+
+## 配置（显式注入，无隐式 env）
+
+```go
+type Config struct {
+    Profile string // 空 → "default"。不回退 $YOOOCLAW_PROFILE / active-profile 文件
+    RootDir string // 空 → ~/.yoooclaw（不读 YOOOCLAW_HOME）。可用于多租户 / 测试隔离
+    Logger  Logger // 可选；nil 静默。library 自身不向 stdout/stderr 打印
+
+    // daemon 依赖能力（Light 等）所需凭证：
+    Credentials              CredentialSource // 显式注入 gateway token；nil 表示不提供
+    AllowImplicitCredentials bool             // 为真时允许回退读 profile 的 config/keychain（默认 false）
+}
+```
+
+`New` 无任何 IO 副作用（不建目录、不写文件、不读环境变量）。`Client` 可并发只读使用。
+
+## 已实现能力
+
+所有公开方法首参均为 `context.Context`；返回具体导出 struct（非 `any`）；失败返回 `*yclib.Error`。
+
+### 纯本地（不经 daemon）
+
+| 方法 | 说明 | 对应 CLI |
+|------|------|----------|
+| `Notifications().Search/Summary/Stats(ctx, …)` | 查询 / 聚合摘要 / 维度统计 | `notification search/summary/stats` |
+| `Images().List(ctx, ImageListOpts)` / `Get(ctx, id)` | 列出 / 取单张图片 | `image list` / `image status` |
+| `Recordings().List(ctx, RecordingListOpts)` / `Get(ctx, id)` | 列出 / 取单条录音 | `recording list` / `recording status` |
+
+### daemon 依赖
+
+| 方法 | 说明 | 对应 CLI |
+|------|------|----------|
+| `Daemon().Status(ctx)` | 读取 daemon 运行态（lock + 探活，无网络） | `daemon status` |
+| `Daemon().Start(ctx, DaemonStartOpts)` | **显式**启动 daemon（幂等） | `daemon start` |
+| `Daemon().Stop(ctx)` | 停止 daemon（未运行为 no-op） | `daemon stop` |
+| `Light().Send(ctx, LightSendOpts)` / `Blink(ctx)` | 下发灯效 / 连通性测试 | `light send` / `light +blink` |
+| `LightRules().List/Get/Create/Update/Delete/SetEnabled(ctx, …)` | 灯效规则增删改查与启停 | `lightrule …` |
+| `Tunnel().Status/Reconnect/Test(ctx, client)` | Relay 隧道状态 / 重连 / 回环自检 | `tunnel …` |
+
+> **daemon 生命周期（arc §5 硬约束）**：library **绝不隐式 fork daemon**。`Light()` 等
+> daemon 依赖方法在 daemon 未运行时只返回 `CodeDaemonNotRunning`，由调用方决定是否
+> `Daemon().Start(...)`。
+
+```go
+c, _ := yclib.New(yclib.Config{
+    Credentials: yclib.StaticCredentials{Token: gatewayToken}, // 连 daemon 的鉴权
+})
+if st, _ := c.Daemon().Status(ctx); !st.Running {
+    c.Daemon().Start(ctx, yclib.DaemonStartOpts{}) // 显式拉起
+}
+res, err := c.Light().Send(ctx, yclib.LightSendOpts{Preset: "red-strobe-3"})
+```
+
+## 错误处理
+
+错误是结构化的，按错误码分支而非解析字符串：
+
+```go
+res, err := c.Notifications().Search(ctx, opts)
+if err != nil {
+    switch yclib.ErrorCode(err) {
+    case yclib.CodeInvalidArgument:
+        // 参数非法
+    case yclib.CodeStorageUnavailable:
+        // 存储不可用
+    }
+}
+```
+
+通知目录不存在（无 daemon / 尚无数据）视为正常态，返回空结果而非错误。
+
+## 尚未覆盖（路线图）
+
+- **录音/图片的写侧 ingestion 与录音 ASR 工作流**：当前只覆盖读侧（List/Get）；写入（App 推送）属插件侧职责。
+- **Phase 4**：统一对外错误、`context.Context` 透传至底层 IO。
+- **暂不纳入**：`sync` 系列（底层返回 `map[string]any`，违反类型化约束，且属插件侧 ingestion 游标协议）。
+
+详见 `arc-cli-library-integration.md` §5（daemon 边界裁决）与 §7（落地阶段）。

--- a/yclib/capabilities_test.go
+++ b/yclib/capabilities_test.go
@@ -1,0 +1,114 @@
+package yclib_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/YoooClaw/cli/yclib"
+)
+
+func writeJSONFile(t *testing.T, path string, v any) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	raw, _ := json.Marshal(v)
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func TestImages_ListGet(t *testing.T) {
+	root := t.TempDir()
+	idx := filepath.Join(root, "profiles", "default", "images", "index.json")
+	writeJSONFile(t, idx, map[string]any{"images": []map[string]any{
+		{"imageId": "img1", "status": "synced", "metadata": map[string]any{"created_at": "2026-06-22T10:00:00+08:00", "source_app": "com.feishu"}},
+		{"imageId": "img2", "status": "pending", "metadata": map[string]any{"created_at": "2026-06-22T12:00:00+08:00", "source_app": "com.wechat"}},
+	}})
+	c, _ := yclib.New(yclib.Config{RootDir: root})
+	ctx := context.Background()
+
+	all, err := c.Images().List(ctx, yclib.ImageListOpts{})
+	if err != nil || len(all) != 2 {
+		t.Fatalf("List = %d (%v), want 2", len(all), err)
+	}
+	// 倒序：img2(12:00) 在前。
+	if all[0].ImageID != "img2" {
+		t.Errorf("first = %s, want img2 (desc)", all[0].ImageID)
+	}
+	// 状态过滤。
+	synced, _ := c.Images().List(ctx, yclib.ImageListOpts{Status: "synced"})
+	if len(synced) != 1 || synced[0].ImageID != "img1" {
+		t.Fatalf("status filter = %+v, want single img1", synced)
+	}
+	// Get + NotFound。
+	if _, err := c.Images().Get(ctx, "img1"); err != nil {
+		t.Fatalf("Get img1: %v", err)
+	}
+	if _, err := c.Images().Get(ctx, "nope"); yclib.ErrorCode(err) != yclib.CodeNotFound {
+		t.Fatalf("Get missing ErrorCode = %q, want %q", yclib.ErrorCode(err), yclib.CodeNotFound)
+	}
+}
+
+func TestRecordings_ListGet(t *testing.T) {
+	root := t.TempDir()
+	idx := filepath.Join(root, "profiles", "default", "recordings", "index.json")
+	writeJSONFile(t, idx, map[string]any{"recordings": []map[string]any{
+		{"id": "rec1", "status": "done", "metadata": map[string]any{}, "ingestedAt": "2026-06-22T10:00:00+08:00", "updatedAt": "2026-06-22T10:05:00+08:00"},
+		{"id": "rec2", "status": "transcribing", "metadata": map[string]any{}, "ingestedAt": "2026-06-22T11:00:00+08:00", "updatedAt": "2026-06-22T11:00:00+08:00"},
+	}})
+	c, _ := yclib.New(yclib.Config{RootDir: root})
+	ctx := context.Background()
+
+	all, err := c.Recordings().List(ctx, yclib.RecordingListOpts{})
+	if err != nil || len(all) != 2 {
+		t.Fatalf("List = %d (%v), want 2", len(all), err)
+	}
+	done, _ := c.Recordings().List(ctx, yclib.RecordingListOpts{Status: "done"})
+	if len(done) != 1 || done[0].ID != "rec1" {
+		t.Fatalf("status filter = %+v, want single rec1", done)
+	}
+	if _, err := c.Recordings().Get(ctx, "rec2"); err != nil {
+		t.Fatalf("Get rec2: %v", err)
+	}
+	if _, err := c.Recordings().Get(ctx, "nope"); yclib.ErrorCode(err) != yclib.CodeNotFound {
+		t.Fatalf("Get missing ErrorCode = %q, want %q", yclib.ErrorCode(err), yclib.CodeNotFound)
+	}
+}
+
+func TestLightRules_RequireDaemon(t *testing.T) {
+	c, _ := yclib.New(yclib.Config{RootDir: t.TempDir()})
+	ctx := context.Background()
+	if _, err := c.LightRules().List(ctx); yclib.ErrorCode(err) != yclib.CodeDaemonNotRunning {
+		t.Fatalf("List ErrorCode = %q, want %q", yclib.ErrorCode(err), yclib.CodeDaemonNotRunning)
+	}
+	if err := c.LightRules().Delete(ctx, "x"); yclib.ErrorCode(err) != yclib.CodeDaemonNotRunning {
+		t.Fatalf("Delete ErrorCode = %q, want %q", yclib.ErrorCode(err), yclib.CodeDaemonNotRunning)
+	}
+}
+
+func TestTunnel_RequireDaemon(t *testing.T) {
+	c, _ := yclib.New(yclib.Config{RootDir: t.TempDir()})
+	ctx := context.Background()
+	if _, err := c.Tunnel().Status(ctx, ""); yclib.ErrorCode(err) != yclib.CodeDaemonNotRunning {
+		t.Fatalf("Status ErrorCode = %q, want %q", yclib.ErrorCode(err), yclib.CodeDaemonNotRunning)
+	}
+}
+
+func TestNewCapabilities_ContextCancelled(t *testing.T) {
+	c, _ := yclib.New(yclib.Config{RootDir: t.TempDir()})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := c.Images().List(ctx, yclib.ImageListOpts{}); err == nil {
+		t.Error("Images().List should honor cancelled ctx")
+	}
+	if _, err := c.Recordings().List(ctx, yclib.RecordingListOpts{}); err == nil {
+		t.Error("Recordings().List should honor cancelled ctx")
+	}
+	if _, err := c.LightRules().List(ctx); err == nil {
+		t.Error("LightRules().List should honor cancelled ctx")
+	}
+}

--- a/yclib/client.go
+++ b/yclib/client.go
@@ -1,0 +1,110 @@
+// Package yclib 是 yc-cli 的进程内公开 API 门面（路径 C / library 化）。
+//
+// 设计约束见 software 仓库 architecture/arc-cli-library-integration.md：
+//   - 唯一对外入口；internal/ 实现保持私有（本包位于 module 根下，故可合法 import internal）。
+//   - 显式 Config 注入，不读隐式 env / active-profile 文件 / 全局 flag。
+//   - 不 os.Exit、不写 os.Stdout/Stderr；以返回值 + error 表达结果。
+//   - 公开方法首参 context.Context；返回具体导出 struct，不返回 any。
+//
+// 本文件提供入口 New(Config) 与 Client 装配。能力按子 client 分组（见各 *.go）。
+package yclib
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/YoooClaw/cli/internal/errs"
+	"github.com/YoooClaw/cli/internal/paths"
+)
+
+// Logger 是可选的 library 日志出口。library 自身**不**向 stdout/stderr 打印，
+// 调用方若想观测内部进度可注入实现；nil 表示静默。
+type Logger interface {
+	Logf(format string, args ...any)
+}
+
+// Config 是 library 的唯一配置注入点。
+//
+// 缺省值产出可预测行为：Profile 空 → "default"；RootDir 空 → ~/.yoooclaw（不读
+// YOOOCLAW_HOME 等环境变量）。library 路径严禁隐式读 env / 文件做行为决策。
+type Config struct {
+	// Profile 显式 profile 名。空 → "default"。不回退到 $YOOOCLAW_PROFILE 或 active-profile 文件。
+	Profile string
+	// RootDir 覆盖数据根目录（多租户 / 测试隔离）。空 → paths.DefaultRoot()（~/.yoooclaw）。
+	RootDir string
+	// Logger 可选；nil 表示静默。
+	Logger Logger
+
+	// Credentials 显式注入 daemon 依赖能力所需的凭证（如 gateway token）。
+	// nil 表示不提供；是否回退到隐式来源由 AllowImplicitCredentials 决定。
+	Credentials CredentialSource
+
+	// AllowImplicitCredentials 为真时，在 Credentials 未提供 token 的情况下，
+	// 允许回退到当前 profile 的 config/keychain 解析（迁移便利的 opt-in 开关）。
+	// 默认 false：严格显式，符合 arc §4「不隐式读凭证」。
+	AllowImplicitCredentials bool
+}
+
+// Client 是 library 的根句柄，按能力分组暴露子 client。构造无进程级副作用
+// （不建目录、不写文件、不读环境变量）。Client 可并发只读使用。
+type Client struct {
+	profile            string
+	paths              paths.Paths
+	logger             Logger
+	creds              CredentialSource
+	allowImplicitCreds bool
+}
+
+// New 按显式 Config 装配 Client。不产生任何 IO 副作用。
+func New(cfg Config) (*Client, error) {
+	profile := strings.TrimSpace(cfg.Profile)
+	if profile == "" {
+		profile = paths.DefaultProfile
+	}
+	root := strings.TrimSpace(cfg.RootDir)
+	if root == "" {
+		root = paths.DefaultRoot()
+	}
+	return &Client{
+		profile:            profile,
+		paths:              paths.ForRoot(root, profile),
+		logger:             cfg.Logger,
+		creds:              cfg.Credentials,
+		allowImplicitCreds: cfg.AllowImplicitCredentials,
+	}, nil
+}
+
+// Profile 返回当前 Client 绑定的 profile 名。
+func (c *Client) Profile() string { return c.profile }
+
+// logf 经可选 Logger 输出；未注入时静默。
+func (c *Client) logf(format string, args ...any) {
+	if c.logger != nil {
+		c.logger.Logf(format, args...)
+	}
+}
+
+// Error 是 library 对外暴露的结构化错误类型（与内部错误同源）。
+// 调用方可用 errors.As(err, &yclib.Error{}) 判别，或用 ErrorCode(err) 取错误码。
+type Error = errs.Error
+
+// 常用错误码（与 internal/errs 同值，进入对外半正式契约）。
+const (
+	CodeUnknown            = errs.CodeUnknown
+	CodeInvalidArgument    = errs.CodeInvalidArgument
+	CodeNotFound           = errs.CodeNotFound
+	CodeStorageUnavailable = errs.CodeStorageUnavailable
+	CodeDaemonNotRunning   = errs.CodeDaemonNotRunning
+	CodeUnauthorized       = errs.CodeUnauthorized
+	CodeNetworkError       = errs.CodeNetworkError
+)
+
+// ErrorCode 提取错误码；非结构化错误返回空串。便于调用方做类型安全分支，
+// 而非解析错误字符串。
+func ErrorCode(err error) string {
+	var e *Error
+	if errors.As(err, &e) {
+		return e.Code
+	}
+	return ""
+}

--- a/yclib/credentials.go
+++ b/yclib/credentials.go
@@ -1,0 +1,40 @@
+package yclib
+
+import (
+	"github.com/YoooClaw/cli/internal/config"
+	"github.com/YoooClaw/cli/internal/creds"
+)
+
+// CredentialSource 是 library 的显式凭证注入点。daemon 依赖能力需要 gateway token
+// 才能向本地 daemon 鉴权；library 不隐式读 keychain/config，除非 Config.AllowImplicitCredentials。
+type CredentialSource interface {
+	// GatewayToken 返回连接本地 daemon 的 token；返回空串表示“未提供”。
+	GatewayToken() string
+}
+
+// StaticCredentials 是最简单的显式凭证实现：直接持有 token 字面量。
+type StaticCredentials struct {
+	Token string
+}
+
+// GatewayToken 实现 CredentialSource。
+func (s StaticCredentials) GatewayToken() string { return s.Token }
+
+// gatewayToken 解析当前 Client 应使用的 daemon token：
+//  1. 显式 Config.Credentials 优先；
+//  2. 否则，仅当 Config.AllowImplicitCredentials 为真时，回退到 profile 的 config/keychain；
+//  3. 否则返回空串（daemon 调用将因缺鉴权被拒，报 CodeUnauthorized）。
+func (c *Client) gatewayToken() string {
+	if c.creds != nil {
+		if t := c.creds.GatewayToken(); t != "" {
+			return t
+		}
+	}
+	if c.allowImplicitCreds {
+		cfg, _ := config.Load(c.paths)
+		if ref, err := creds.ResolveGatewayToken(cfg); err == nil {
+			return ref.Value
+		}
+	}
+	return ""
+}

--- a/yclib/daemon.go
+++ b/yclib/daemon.go
@@ -1,0 +1,87 @@
+package yclib
+
+import (
+	"context"
+
+	"github.com/YoooClaw/cli/internal/daemon"
+)
+
+// DaemonClient 暴露 daemon 生命周期管理。经 Client.Daemon() 获取。
+//
+// arc §5 硬约束：library **绝不隐式 fork daemon**。Start/Stop 必须由调用方显式触发；
+// 其它 daemon 依赖能力在 daemon 未运行时只报 CodeDaemonNotRunning，不自动拉起。
+type DaemonClient struct {
+	c *Client
+}
+
+// Daemon 返回 daemon 生命周期子 client。
+func (c *Client) Daemon() *DaemonClient { return &DaemonClient{c: c} }
+
+// DaemonStatus 是 daemon 的运行态快照。
+type DaemonStatus struct {
+	Running bool   `json:"running"`
+	Stale   bool   `json:"stale"` // 锁存在但进程已死
+	PID     int    `json:"pid,omitempty"`
+	Bind    string `json:"bind,omitempty"`
+	Port    int    `json:"port,omitempty"`
+	Version string `json:"version,omitempty"`
+	Profile string `json:"profile,omitempty"`
+}
+
+// Status 读取 daemon 运行态（基于 lock 文件 + 进程探活），不发起网络请求。
+func (d *DaemonClient) Status(ctx context.Context) (DaemonStatus, error) {
+	if err := ctx.Err(); err != nil {
+		return DaemonStatus{}, err
+	}
+	return statusFrom(daemon.State(d.c.paths)), nil
+}
+
+// DaemonStartOpts 控制显式启动 daemon 的绑定参数（均可选）。
+type DaemonStartOpts struct {
+	Bind     string
+	Port     int
+	LogLevel string
+}
+
+// Start 显式 fork 并等待 daemon 起来（最多 ~3s）。已在运行则直接返回当前状态（幂等）。
+// 这是 library 中**唯一**会创建 daemon 进程的入口，且必须由调用方主动调用。
+func (d *DaemonClient) Start(ctx context.Context, opts DaemonStartOpts) (DaemonStatus, error) {
+	if err := ctx.Err(); err != nil {
+		return DaemonStatus{}, err
+	}
+	if st := daemon.State(d.c.paths); st.Running {
+		return statusFrom(st), nil
+	}
+	lock, err := daemon.SpawnFor(d.c.paths, d.c.profile, daemon.StartOpts{
+		Bind: opts.Bind, Port: opts.Port, LogLevel: opts.LogLevel,
+	})
+	if err != nil {
+		return DaemonStatus{}, err
+	}
+	d.c.logf("yclib daemon started pid=%d port=%d", lock.PID, lock.Port)
+	return statusFrom(daemon.State(d.c.paths)), nil
+}
+
+// Stop 停止 daemon（未运行则为 no-op，返回 nil）。
+func (d *DaemonClient) Stop(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if st := daemon.State(d.c.paths); !st.Running {
+		return nil
+	}
+	_, err := daemon.Stop(d.c.paths)
+	return err
+}
+
+func statusFrom(st daemon.RunningState) DaemonStatus {
+	out := DaemonStatus{Running: st.Running, Stale: st.Stale}
+	if st.Lock != nil {
+		out.PID = st.Lock.PID
+		out.Bind = st.Lock.Bind
+		out.Port = st.Lock.Port
+		out.Version = st.Lock.Version
+		out.Profile = st.Lock.Profile
+	}
+	return out
+}

--- a/yclib/daemon_rpc.go
+++ b/yclib/daemon_rpc.go
@@ -1,0 +1,99 @@
+package yclib
+
+import (
+	"encoding/json"
+
+	"github.com/YoooClaw/cli/internal/daemon"
+	"github.com/YoooClaw/cli/internal/errs"
+)
+
+// daemonClient 用解析出的 gateway token 构造 daemon RPC client（不读隐式凭证，
+// token 解析逻辑见 Client.gatewayToken）。
+func (c *Client) daemonClient() *daemon.Client {
+	return daemon.NewClientWithToken(c.paths, c.gatewayToken())
+}
+
+// assertDaemon 确保 daemon 在运行，否则返回 CodeDaemonNotRunning。
+// arc §5：library 不隐式 fork daemon —— 未运行时报错，由调用方决定是否 Daemon().Start()。
+func (c *Client) assertDaemon() error {
+	return daemon.AssertRunning(c.paths)
+}
+
+// daemonRequest 发起一次 daemon RPC：先确保运行 → 调用 → 把响应体解码进 out（typed），
+// 非 2xx 统一转成结构化 *yclib.Error。out 可为 nil（不关心响应体）。
+func (c *Client) daemonRequest(method, path string, body, out any) error {
+	if err := c.assertDaemon(); err != nil {
+		return err
+	}
+	status, resBody, err := c.daemonClient().Request(method, path, body)
+	if err != nil {
+		return err
+	}
+	if status >= 400 {
+		return errorFromEnvelope(status, resBody)
+	}
+	if out != nil {
+		return decodeInto(resBody, out)
+	}
+	return nil
+}
+
+// gatewayRequest 处理 gateway 风格端点（响应封装 {ok, data, error}）：
+// 先确保 daemon 运行 → 调用 → ok:false 或非 2xx 转 *yclib.Error；否则把 data 解进 dataOut。
+func (c *Client) gatewayRequest(method, path string, body, dataOut any) error {
+	if err := c.assertDaemon(); err != nil {
+		return err
+	}
+	status, resBody, err := c.daemonClient().Request(method, path, body)
+	if err != nil {
+		return err
+	}
+	if status >= 400 {
+		return errorFromEnvelope(status, resBody)
+	}
+	if m, ok := resBody.(map[string]any); ok {
+		if okVal, exists := m["ok"]; exists && okVal == false {
+			return errorFromEnvelope(status, m)
+		}
+		if dataOut != nil {
+			if data, has := m["data"]; has {
+				return decodeInto(data, dataOut)
+			}
+		}
+	}
+	if dataOut != nil {
+		return decodeInto(resBody, dataOut)
+	}
+	return nil
+}
+
+// decodeInto 把 daemon 返回的无类型 JSON 值（any）重编码后解进具体 struct。
+func decodeInto(v, out any) error {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return errs.New(errs.CodeUnknown, "daemon 响应序列化失败："+err.Error())
+	}
+	if err := json.Unmarshal(raw, out); err != nil {
+		return errs.New(errs.CodeUnknown, "daemon 响应解码失败："+err.Error())
+	}
+	return nil
+}
+
+// errorFromEnvelope 从 daemon 错误体 {ok:false,error:{code,message}} 提取结构化错误；
+// 提取不到则回落到带状态码的通用错误。
+func errorFromEnvelope(status int, body any) error {
+	if m, ok := body.(map[string]any); ok {
+		if e, ok := m["error"].(map[string]any); ok {
+			code, _ := e["code"].(string)
+			msg, _ := e["message"].(string)
+			if code == "" {
+				code = errs.CodeUnknown
+			}
+			if msg == "" {
+				msg = "daemon 返回错误"
+			}
+			return errs.New(code, msg, map[string]any{"status": status})
+		}
+	}
+	return errs.New(errs.CodeUnknown, "daemon 返回非 2xx", map[string]any{"status": status})
+}

--- a/yclib/daemon_rpc_internal_test.go
+++ b/yclib/daemon_rpc_internal_test.go
@@ -1,0 +1,48 @@
+package yclib
+
+import "testing"
+
+func TestErrorFromEnvelope_Extracts(t *testing.T) {
+	body := map[string]any{
+		"ok":    false,
+		"error": map[string]any{"code": "YOOOCLAW_NOT_FOUND", "message": "未知预设"},
+	}
+	err := errorFromEnvelope(404, body)
+	if ErrorCode(err) != "YOOOCLAW_NOT_FOUND" {
+		t.Fatalf("code = %q, want YOOOCLAW_NOT_FOUND", ErrorCode(err))
+	}
+	if err.Error() != "未知预设" {
+		t.Fatalf("message = %q, want 未知预设", err.Error())
+	}
+}
+
+func TestErrorFromEnvelope_Fallback(t *testing.T) {
+	err := errorFromEnvelope(500, "plain text body")
+	if ErrorCode(err) != CodeUnknown {
+		t.Fatalf("code = %q, want %q", ErrorCode(err), CodeUnknown)
+	}
+}
+
+func TestDecodeInto(t *testing.T) {
+	src := map[string]any{"ok": true, "bizUniqueId": "abc", "status": float64(200)}
+	var out LightSendResult
+	if err := decodeInto(src, &out); err != nil {
+		t.Fatalf("decodeInto: %v", err)
+	}
+	if !out.OK || out.BizUniqueID != "abc" || out.Status != 200 {
+		t.Fatalf("decoded = %+v, want ok/abc/200", out)
+	}
+}
+
+func TestGatewayToken_Resolution(t *testing.T) {
+	// 显式 Credentials 优先。
+	c, _ := New(Config{RootDir: t.TempDir(), Credentials: StaticCredentials{Token: "explicit"}})
+	if got := c.gatewayToken(); got != "explicit" {
+		t.Fatalf("explicit token = %q, want explicit", got)
+	}
+	// 无 Credentials 且未允许隐式 → 空。
+	c2, _ := New(Config{RootDir: t.TempDir()})
+	if got := c2.gatewayToken(); got != "" {
+		t.Fatalf("no-creds token = %q, want empty", got)
+	}
+}

--- a/yclib/daemon_test.go
+++ b/yclib/daemon_test.go
@@ -1,0 +1,66 @@
+package yclib_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/YoooClaw/cli/yclib"
+)
+
+func TestDaemonStatus_NotRunning(t *testing.T) {
+	c, _ := yclib.New(yclib.Config{RootDir: t.TempDir()})
+	st, err := c.Daemon().Status(context.Background())
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if st.Running || st.Stale {
+		t.Fatalf("fresh root should be not-running & not-stale, got %+v", st)
+	}
+}
+
+func TestDaemonStop_NoopWhenNotRunning(t *testing.T) {
+	c, _ := yclib.New(yclib.Config{RootDir: t.TempDir()})
+	if err := c.Daemon().Stop(context.Background()); err != nil {
+		t.Fatalf("Stop on not-running should be no-op, got %v", err)
+	}
+}
+
+func TestLightSend_RequiresDaemon(t *testing.T) {
+	c, _ := yclib.New(yclib.Config{RootDir: t.TempDir()})
+	// daemon 未运行：即便参数合法也应报 CodeDaemonNotRunning（arc §5：不自动拉起）。
+	_, err := c.Light().Send(context.Background(), yclib.LightSendOpts{Preset: "red-strobe-3"})
+	if code := yclib.ErrorCode(err); code != yclib.CodeDaemonNotRunning {
+		t.Fatalf("ErrorCode = %q, want %q", code, yclib.CodeDaemonNotRunning)
+	}
+}
+
+func TestLightSend_InvalidArgBeforeDaemon(t *testing.T) {
+	c, _ := yclib.New(yclib.Config{RootDir: t.TempDir()})
+	// 三选一校验在本地，先于 daemon 检查：给 0 个 → CodeInvalidArgument。
+	if _, err := c.Light().Send(context.Background(), yclib.LightSendOpts{}); yclib.ErrorCode(err) != yclib.CodeInvalidArgument {
+		t.Fatalf("empty opts ErrorCode = %q, want %q", yclib.ErrorCode(err), yclib.CodeInvalidArgument)
+	}
+	// 给 2 个 → 同样 CodeInvalidArgument。
+	two := yclib.LightSendOpts{Preset: "x", Rule: "y"}
+	if _, err := c.Light().Send(context.Background(), two); yclib.ErrorCode(err) != yclib.CodeInvalidArgument {
+		t.Fatalf("two-source ErrorCode = %q, want %q", yclib.ErrorCode(err), yclib.CodeInvalidArgument)
+	}
+}
+
+func TestStaticCredentials(t *testing.T) {
+	if (yclib.StaticCredentials{Token: "abc"}).GatewayToken() != "abc" {
+		t.Fatal("StaticCredentials.GatewayToken mismatch")
+	}
+}
+
+func TestContextCancelled_DaemonAndLight(t *testing.T) {
+	c, _ := yclib.New(yclib.Config{RootDir: t.TempDir()})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := c.Daemon().Status(ctx); err == nil {
+		t.Error("Daemon().Status should honor cancelled ctx")
+	}
+	if _, err := c.Light().Send(ctx, yclib.LightSendOpts{Preset: "x"}); err == nil {
+		t.Error("Light().Send should honor cancelled ctx")
+	}
+}

--- a/yclib/example_test.go
+++ b/yclib/example_test.go
@@ -1,0 +1,44 @@
+package yclib_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/YoooClaw/cli/yclib"
+)
+
+// Example 展示 Go Agent 进程内集成 yclib 的最小用法：构造 Client → 查询通知。
+// 消费方只 import yclib，无需触碰 internal/...（入参/出参类型均由 yclib re-export）。
+func Example() {
+	// 显式注入配置：profile 空 → "default"；RootDir 空 → ~/.yoooclaw。
+	c, err := yclib.New(yclib.Config{Profile: "default"})
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+
+	// 1) 搜索：按关键字 + 上限过滤，时间倒序。
+	res, err := c.Notifications().Search(ctx, yclib.RawQueryOpts{
+		Keyword: "会议",
+		Limit:   "50",
+	})
+	if err != nil {
+		// 结构化错误：可按错误码分支，而非解析字符串。
+		if yclib.ErrorCode(err) == yclib.CodeInvalidArgument {
+			fmt.Println("参数非法:", err)
+		}
+		return
+	}
+	for _, n := range res.Notifications {
+		fmt.Printf("[%s] %s: %s\n", n.AppDisplayName, n.Title, n.Content)
+	}
+
+	// 2) 聚合摘要：供 Agent 总结“最近通知概览”。
+	sum, _ := c.Notifications().Summary(ctx, yclib.SummaryOpts{Top: 5, Sample: 20})
+	fmt.Printf("共 %d 条；Top 应用：%v\n", sum.Total, sum.TopApps)
+
+	// 3) 维度统计：近 7 天按应用聚合。
+	stats, _ := c.Notifications().Stats(ctx, yclib.StatsOpts{Dim: "app"})
+	fmt.Printf("近 7 天按应用：%v\n", stats.App)
+}

--- a/yclib/helpers.go
+++ b/yclib/helpers.go
@@ -1,0 +1,33 @@
+package yclib
+
+import (
+	"time"
+
+	"github.com/YoooClaw/cli/internal/errs"
+	"github.com/YoooClaw/cli/internal/notif"
+)
+
+// newInvalidArg 构造一个 CodeInvalidArgument 的结构化错误。
+func newInvalidArg(msg string) error { return errs.New(errs.CodeInvalidArgument, msg) }
+
+// newNotFound 构造一个 CodeNotFound 的结构化错误。
+func newNotFound(msg string) error { return errs.New(errs.CodeNotFound, msg) }
+
+// labelOrLegacy 把空 clientLabel 归一为 "legacy"（对齐 CLI 的过滤语义）。
+func labelOrLegacy(label string) string {
+	if label == "" {
+		return "legacy"
+	}
+	return label
+}
+
+// sliceN 取前 n 条（n 越界则原样返回）。
+func sliceN(items []notif.StoredNotification, n int) []notif.StoredNotification {
+	if n < len(items) {
+		return items[:n]
+	}
+	return items
+}
+
+func localToday() string        { return time.Now().Format("2006-01-02") }
+func localDaysAgo(n int) string { return time.Now().AddDate(0, 0, -n).Format("2006-01-02") }

--- a/yclib/images.go
+++ b/yclib/images.go
@@ -1,0 +1,75 @@
+package yclib
+
+import (
+	"context"
+
+	"github.com/YoooClaw/cli/internal/image"
+	"github.com/YoooClaw/cli/internal/notif"
+)
+
+// ImagesClient 暴露图片查询能力（纯本地：直接读 profile 的 images 索引，不经 daemon）。
+type ImagesClient struct {
+	c *Client
+}
+
+// Images 返回图片能力子 client。
+func (c *Client) Images() *ImagesClient { return &ImagesClient{c: c} }
+
+// ImageListOpts 是 List 的可选过滤；Limit <= 0 时默认 100。
+type ImageListOpts struct {
+	Status string // 按同步状态过滤
+	Client string // 按 clientLabel 过滤；"all" 或空为全部
+	App    string // 按来源应用过滤（支持别名）
+	From   string // createdAt 下界（字符串字典序比较）
+	To     string // createdAt 上界
+	Limit  int
+}
+
+// List 列出图片（按创建时间倒序）。等价于 CLI `image list`，返回 typed 结果。
+func (i *ImagesClient) List(ctx context.Context, opts ImageListOpts) ([]ImageEntry, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	out := make([]ImageEntry, 0)
+	for _, it := range image.ReadIndex(i.c.paths.Images) {
+		if opts.Status != "" && it.Status != opts.Status {
+			continue
+		}
+		if opts.Client != "" && opts.Client != "all" && labelOrLegacy(it.ClientLabel) != opts.Client {
+			continue
+		}
+		if opts.App != "" && !notif.MatchesAppFilter(notif.StoredNotification{AppName: it.Metadata.SourceApp}, opts.App) {
+			continue
+		}
+		if opts.From != "" && it.Metadata.CreatedAt < opts.From {
+			continue
+		}
+		if opts.To != "" && it.Metadata.CreatedAt > opts.To {
+			continue
+		}
+		out = append(out, it)
+	}
+	image.SortByCreatedDesc(out)
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	i.c.logf("yclib images.list total=%d", len(out))
+	return out, nil
+}
+
+// Get 按 imageId 取单张图片详情；不存在返回 CodeNotFound。
+func (i *ImagesClient) Get(ctx context.Context, imageID string) (ImageEntry, error) {
+	if err := ctx.Err(); err != nil {
+		return ImageEntry{}, err
+	}
+	for _, it := range image.ReadIndex(i.c.paths.Images) {
+		if it.ImageID == imageID {
+			return it, nil
+		}
+	}
+	return ImageEntry{}, newNotFound("图片不存在：" + imageID)
+}

--- a/yclib/light.go
+++ b/yclib/light.go
@@ -1,0 +1,85 @@
+package yclib
+
+import (
+	"context"
+
+	"github.com/YoooClaw/cli/internal/light"
+)
+
+// LightClient 暴露灯效硬件控制能力。经 Client.Light() 获取。
+//
+// 注意：灯效下发**经 daemon 代理**（daemon 持有灯效云 API key 并实际发送），属 daemon
+// 依赖能力 —— daemon 未运行时返回 CodeDaemonNotRunning（不自动拉起，见 arc §5）。
+type LightClient struct {
+	c *Client
+}
+
+// Light 返回灯效子 client。
+func (c *Client) Light() *LightClient { return &LightClient{c: c} }
+
+// LightSendResult 是灯效下发结果（re-export 自底层，typed DTO）。
+type LightSendResult = light.SendResult
+
+// LightSendOpts 是 Send 的入参：Segments / Preset / Rule 三选一。
+//   - Segments：直接给出灯效段（结构见灯效协议），服务端校验。
+//   - Preset：内置预设 id（如 "red-strobe-3"）。
+//   - Rule：已保存的灯效规则 id。
+//
+// Repeat/RepeatTimes 控制重复；Reason/Title 为可选元信息（透传到下发记录）。
+type LightSendOpts struct {
+	Segments    []map[string]any
+	Preset      string
+	Rule        string
+	Repeat      bool
+	RepeatTimes *float64
+	Reason      string
+	Title       string
+}
+
+// Send 下发灯效到硬件。等价于 CLI `light send`，返回 typed 结果。
+// Segments/Preset/Rule 必须恰好提供一个；否则返回 CodeInvalidArgument。
+func (l *LightClient) Send(ctx context.Context, opts LightSendOpts) (LightSendResult, error) {
+	if err := ctx.Err(); err != nil {
+		return LightSendResult{}, err
+	}
+	n := 0
+	body := map[string]any{}
+	if len(opts.Segments) > 0 {
+		body["segments"] = opts.Segments
+		n++
+	}
+	if opts.Preset != "" {
+		body["preset"] = opts.Preset
+		n++
+	}
+	if opts.Rule != "" {
+		body["rule"] = opts.Rule
+		n++
+	}
+	if n != 1 {
+		return LightSendResult{}, newInvalidArg("需要 Segments / Preset / Rule 之一（且只能一个）")
+	}
+	if opts.Repeat {
+		body["repeat"] = true
+	}
+	if opts.RepeatTimes != nil {
+		body["repeat_times"] = *opts.RepeatTimes
+	}
+	if opts.Reason != "" {
+		body["reason"] = opts.Reason
+	}
+	if opts.Title != "" {
+		body["title"] = opts.Title
+	}
+	var res LightSendResult
+	if err := l.c.daemonRequest("POST", "/light/send", body, &res); err != nil {
+		return LightSendResult{}, err
+	}
+	l.c.logf("yclib light.send ok=%v status=%d", res.OK, res.Status)
+	return res, nil
+}
+
+// Blink 发送内置连通性测试灯效（red-strobe-3）。等价于 CLI `light +blink`。
+func (l *LightClient) Blink(ctx context.Context) (LightSendResult, error) {
+	return l.Send(ctx, LightSendOpts{Preset: "red-strobe-3"})
+}

--- a/yclib/lightrules.go
+++ b/yclib/lightrules.go
@@ -1,0 +1,93 @@
+package yclib
+
+import (
+	"context"
+)
+
+// LightRulesClient 暴露灯效规则管理（经 daemon 的 gateway/lightrules.* 端点代理）。
+// daemon 未运行时返回 CodeDaemonNotRunning（不自动拉起，见 arc §5）。
+type LightRulesClient struct {
+	c *Client
+}
+
+// LightRules 返回灯效规则子 client。
+func (c *Client) LightRules() *LightRulesClient { return &LightRulesClient{c: c} }
+
+// lightrulesListEnvelope 对应 gateway lightrules.list 的 data 部分。
+type lightrulesListEnvelope struct {
+	Rules []LightRule `json:"rules"`
+}
+
+// List 列出全部灯效规则。等价于 CLI `lightrule list`。
+func (lr *LightRulesClient) List(ctx context.Context) ([]LightRule, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	var data lightrulesListEnvelope
+	if err := lr.c.gatewayRequest("POST", "/gateway/lightrules.list", map[string]any{}, &data); err != nil {
+		return nil, err
+	}
+	if data.Rules == nil {
+		data.Rules = []LightRule{}
+	}
+	return data.Rules, nil
+}
+
+// Get 按 name 取单条规则；不存在返回 CodeNotFound。
+func (lr *LightRulesClient) Get(ctx context.Context, name string) (LightRule, error) {
+	rules, err := lr.List(ctx)
+	if err != nil {
+		return LightRule{}, err
+	}
+	for _, r := range rules {
+		if r.Name == name {
+			return r, nil
+		}
+	}
+	return LightRule{}, newNotFound("规则不存在：" + name)
+}
+
+// Create 创建规则。params 为规则字段（name / description / segments / matchRules 等，
+// 与 CLI `lightrule create --from-file` 的 JSON 同构）。
+func (lr *LightRulesClient) Create(ctx context.Context, params map[string]any) (LightRule, error) {
+	if err := ctx.Err(); err != nil {
+		return LightRule{}, err
+	}
+	var out LightRule
+	if err := lr.c.gatewayRequest("POST", "/gateway/lightrules.create", params, &out); err != nil {
+		return LightRule{}, err
+	}
+	return out, nil
+}
+
+// Update 更新规则（按 name）。params 为要变更的字段。
+func (lr *LightRulesClient) Update(ctx context.Context, name string, params map[string]any) (LightRule, error) {
+	if err := ctx.Err(); err != nil {
+		return LightRule{}, err
+	}
+	if params == nil {
+		params = map[string]any{}
+	}
+	params["name"] = name
+	var out LightRule
+	if err := lr.c.gatewayRequest("POST", "/gateway/lightrules.update", params, &out); err != nil {
+		return LightRule{}, err
+	}
+	return out, nil
+}
+
+// Delete 删除规则（按 name）。
+func (lr *LightRulesClient) Delete(ctx context.Context, name string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return lr.c.gatewayRequest("POST", "/gateway/lightrules.delete", map[string]any{"name": name}, nil)
+}
+
+// SetEnabled 启用/停用单条规则（按 name）。
+func (lr *LightRulesClient) SetEnabled(ctx context.Context, name string, enabled bool) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return lr.c.gatewayRequest("POST", "/gateway/lightrules.update", map[string]any{"name": name, "enabled": enabled}, nil)
+}

--- a/yclib/notifications.go
+++ b/yclib/notifications.go
@@ -1,0 +1,48 @@
+package yclib
+
+import (
+	"context"
+
+	"github.com/YoooClaw/cli/internal/notif"
+)
+
+// defaultSearchLimit 对齐 CLI `notification search` 的默认上限（100）。
+const defaultSearchLimit = 100
+
+// NotificationsClient 暴露通知查询能力（纯本地：直接读 profile 的 notifications 目录，
+// 不经 daemon）。经 Client.Notifications() 获取。
+type NotificationsClient struct {
+	c *Client
+}
+
+// Notifications 返回通知能力子 client。
+func (c *Client) Notifications() *NotificationsClient {
+	return &NotificationsClient{c: c}
+}
+
+// SearchResult 是 Search 的类型化结果。Notifications 按时间倒序，Stats 给出本次
+// 扫描的统计（扫描天数 / 条数 / 命中数 / 是否因 limit 早停）。
+type SearchResult struct {
+	Notifications []StoredNotification `json:"notifications"`
+	Stats         ScanStats            `json:"stats"`
+}
+
+// Search 按筛选条件查询通知。等价于 CLI `notification search`，但返回类型化结果、
+// 不写 stdout、不 os.Exit。opts 复用底层 notif.RawQueryOpts（字符串原始参数，
+// 与 CLI flag 同语义）。
+//
+// 校验失败（如 conversation-type 非法、from 晚于 to）返回 *yclib.Error，
+// 可用 ErrorCode(err) == CodeInvalidArgument 判别。notifications 目录不存在
+// （无 daemon / 尚无数据）视为正常态，返回空结果而非错误。
+func (n *NotificationsClient) Search(ctx context.Context, opts RawQueryOpts) (SearchResult, error) {
+	if err := ctx.Err(); err != nil {
+		return SearchResult{}, err
+	}
+	qo, err := notif.BuildQueryOptions(opts, defaultSearchLimit)
+	if err != nil {
+		return SearchResult{}, err
+	}
+	items, stats := notif.QueryWithStats(n.c.paths.Notifications, qo)
+	n.c.logf("yclib notifications.search matched=%d scanned=%d", stats.Matched, stats.ItemsScanned)
+	return SearchResult{Notifications: items, Stats: stats}, nil
+}

--- a/yclib/notifications_aggregate.go
+++ b/yclib/notifications_aggregate.go
@@ -1,0 +1,145 @@
+package yclib
+
+import (
+	"context"
+
+	"github.com/YoooClaw/cli/internal/notif"
+)
+
+// maxAggLimit 充当聚合的“全部”上限（对齐 CLI 的 maxLimit 语义）。
+const maxAggLimit = 1 << 60
+
+// SummaryOpts 是 Summary 的输入。Query 复用 search 的原始过滤参数；Sample/Top
+// 控制返回的样例条数与聚合榜单长度（<=0 时取默认 30 / 10）。
+type SummaryOpts struct {
+	Query  RawQueryOpts
+	Sample int
+	Top    int
+}
+
+// SummaryResult 是 Summary 的类型化结果：范围内通知总数 + 应用/发送人 Top 榜 + 最近样例。
+type SummaryResult struct {
+	Total      int                  `json:"total"`
+	From       string               `json:"from,omitempty"`
+	To         string               `json:"to,omitempty"`
+	TopApps    []Count              `json:"topApps"`
+	TopSenders []Count              `json:"topSenders"`
+	Sample     []StoredNotification `json:"sample"`
+}
+
+// Summary 聚合统计 + 样例摘要，供 Agent 总结。等价于 CLI `notification summary`，
+// 返回类型化结果。纯本地、不经 daemon。
+func (n *NotificationsClient) Summary(ctx context.Context, opts SummaryOpts) (SummaryResult, error) {
+	if err := ctx.Err(); err != nil {
+		return SummaryResult{}, err
+	}
+	sample, top := opts.Sample, opts.Top
+	if sample <= 0 {
+		sample = 30
+	}
+	if top <= 0 {
+		top = 10
+	}
+	raw := opts.Query
+	// 聚合范围内全部通知（Query.Limit 为空时 BuildQueryOptions 取 maxAggLimit 默认；
+	// 调用方显式给了正数 Limit 则尊重之）。
+	qo, err := notif.BuildQueryOptions(raw, maxAggLimit)
+	if err != nil {
+		return SummaryResult{}, err
+	}
+	items := notif.Query(n.c.paths.Notifications, qo)
+	n.c.logf("yclib notifications.summary total=%d", len(items))
+	return SummaryResult{
+		Total:      len(items),
+		From:       raw.From,
+		To:         raw.To,
+		TopApps:    notif.TopCounts(items, notif.AppLabel, top),
+		TopSenders: notif.TopCounts(items, notif.SenderLabel, top),
+		Sample:     sliceN(items, sample),
+	}, nil
+}
+
+// StatsOpts 是 Stats 的输入。From/To 接受 "YYYY-MM-DD" 或 ISO 8601（空 → 默认近 7 天）；
+// Dim 取 date|app|sender|hour|client|all（空 → all）；App/Sender/Client 为可选过滤。
+type StatsOpts struct {
+	From   string
+	To     string
+	Dim    string
+	App    string
+	Sender string
+	Client string
+}
+
+// StatsResult 是 Stats 的类型化结果。各维度切片仅在被请求（dim=all 或匹配 Dim）时填充。
+type StatsResult struct {
+	Total  int     `json:"total"`
+	From   string  `json:"from"`
+	To     string  `json:"to"`
+	Dim    string  `json:"dim"`
+	Date   []Count `json:"date,omitempty"`
+	App    []Count `json:"app,omitempty"`
+	Sender []Count `json:"sender,omitempty"`
+	Hour   []Count `json:"hour,omitempty"`
+	Client []Count `json:"client,omitempty"`
+}
+
+var statsDims = map[string]bool{"date": true, "app": true, "sender": true, "hour": true, "client": true, "all": true}
+
+// Stats 按维度聚合统计。等价于 CLI `notification stats`，返回类型化结果。纯本地、不经 daemon。
+// 非法 Dim / 时间边界返回 *yclib.Error（CodeInvalidArgument）。
+func (n *NotificationsClient) Stats(ctx context.Context, opts StatsOpts) (StatsResult, error) {
+	if err := ctx.Err(); err != nil {
+		return StatsResult{}, err
+	}
+	fromRaw, toRaw := opts.From, opts.To
+	if fromRaw == "" {
+		fromRaw = localDaysAgo(7)
+	}
+	if toRaw == "" {
+		toRaw = localToday()
+	}
+	from, err := notif.ParseStatsBoundary(fromRaw, "from")
+	if err != nil {
+		return StatsResult{}, err
+	}
+	to, err := notif.ParseStatsBoundary(toRaw, "to")
+	if err != nil {
+		return StatsResult{}, err
+	}
+	if from.StartTs.After(to.EndTs) {
+		return StatsResult{}, newInvalidArg("from 不能晚于 to")
+	}
+	dim := opts.Dim
+	if dim == "" {
+		dim = "all"
+	}
+	if !statsDims[dim] {
+		return StatsResult{}, newInvalidArg("dim 只能是 date|app|sender|hour|client|all")
+	}
+	qo := notif.QueryOptions{
+		App: opts.App, Sender: opts.Sender, Client: opts.Client,
+		Limit: maxAggLimit, FromTs: from.ExactTs, ToTs: to.ExactTs,
+		FromDateKey: from.MinDateKey, ToDateKey: to.MaxDateKey,
+	}
+	items := notif.Query(n.c.paths.Notifications, qo)
+	n.c.logf("yclib notifications.stats total=%d dim=%s", len(items), dim)
+
+	res := StatsResult{Total: len(items), From: from.Raw, To: to.Raw, Dim: dim}
+	want := func(d string) bool { return dim == "all" || dim == d }
+	if want("date") {
+		res.Date = notif.TopCounts(items, func(s notif.StoredNotification) string { return notif.TsLocalDate(s.Timestamp) }, maxAggLimit)
+	}
+	if want("app") {
+		res.App = notif.TopCounts(items, notif.AppLabel, maxAggLimit)
+	}
+	if want("sender") {
+		res.Sender = notif.TopCounts(items, notif.SenderLabel, maxAggLimit)
+	}
+	if want("hour") {
+		res.Hour = notif.TopCounts(items, func(s notif.StoredNotification) string { return notif.TsLocalHour(s.Timestamp) }, maxAggLimit)
+	}
+	if want("client") {
+		res.Client = notif.TopCounts(items, notif.ClientLabelOf, maxAggLimit)
+	}
+	return res, nil
+}

--- a/yclib/notifications_test.go
+++ b/yclib/notifications_test.go
@@ -1,0 +1,166 @@
+package yclib_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/YoooClaw/cli/internal/notif"
+	"github.com/YoooClaw/cli/yclib"
+)
+
+// seedNotifications 在显式 RootDir 下按 profile 写入一个日期文件，返回该 root。
+func seedNotifications(t *testing.T, profile string, items []notif.StoredNotification, dateKey string) string {
+	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, "profiles", profile, "notifications")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	raw, err := json.Marshal(items)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, dateKey+".json"), raw, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return root
+}
+
+func TestNotificationsSearch_EndToEnd(t *testing.T) {
+	items := []notif.StoredNotification{
+		{AppName: "com.feishu", AppDisplayName: "飞书", Title: "周会", Content: "下午三点开会", Timestamp: "2026-06-22T15:00:00+08:00"},
+		{AppName: "com.wechat", AppDisplayName: "微信", Title: "午饭", Content: "一起吃饭吗", Timestamp: "2026-06-22T11:30:00+08:00"},
+	}
+	root := seedNotifications(t, "default", items, "2026-06-22")
+
+	c, err := yclib.New(yclib.Config{RootDir: root})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if c.Profile() != "default" {
+		t.Fatalf("profile = %q, want default", c.Profile())
+	}
+
+	// 全量查询：两条都命中，时间倒序（周会 15:00 在前）。
+	res, err := c.Notifications().Search(context.Background(), notif.RawQueryOpts{})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(res.Notifications) != 2 {
+		t.Fatalf("got %d notifications, want 2", len(res.Notifications))
+	}
+	if res.Notifications[0].Title != "周会" {
+		t.Errorf("first title = %q, want 周会 (desc by time)", res.Notifications[0].Title)
+	}
+	if res.Stats.Matched != 2 {
+		t.Errorf("stats.Matched = %d, want 2", res.Stats.Matched)
+	}
+
+	// 关键字过滤：只命中含“开会”的一条。
+	res, err = c.Notifications().Search(context.Background(), notif.RawQueryOpts{Keyword: "开会"})
+	if err != nil {
+		t.Fatalf("Search keyword: %v", err)
+	}
+	if len(res.Notifications) != 1 || res.Notifications[0].Title != "周会" {
+		t.Fatalf("keyword filter got %+v, want single 周会", res.Notifications)
+	}
+}
+
+func TestNotificationsSearch_EmptyIsNotError(t *testing.T) {
+	// RootDir 指向空目录：notifications 目录不存在 → 正常返回空，非错误。
+	c, err := yclib.New(yclib.Config{RootDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	res, err := c.Notifications().Search(context.Background(), notif.RawQueryOpts{})
+	if err != nil {
+		t.Fatalf("Search on empty: %v", err)
+	}
+	if len(res.Notifications) != 0 {
+		t.Fatalf("got %d, want 0", len(res.Notifications))
+	}
+}
+
+func TestNotificationsSearch_InvalidArgIsTypedError(t *testing.T) {
+	c, _ := yclib.New(yclib.Config{RootDir: t.TempDir()})
+	_, err := c.Notifications().Search(context.Background(), notif.RawQueryOpts{ConversationType: "bogus"})
+	if err == nil {
+		t.Fatal("want error for invalid conversation-type, got nil")
+	}
+	if code := yclib.ErrorCode(err); code != yclib.CodeInvalidArgument {
+		t.Fatalf("ErrorCode = %q, want %q", code, yclib.CodeInvalidArgument)
+	}
+}
+
+func TestNotificationsSearch_ContextCancelled(t *testing.T) {
+	c, _ := yclib.New(yclib.Config{RootDir: t.TempDir()})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := c.Notifications().Search(ctx, yclib.RawQueryOpts{}); err == nil {
+		t.Fatal("want context.Canceled, got nil")
+	}
+}
+
+func TestNotificationsSummary_EndToEnd(t *testing.T) {
+	items := []notif.StoredNotification{
+		{AppName: "com.feishu", AppDisplayName: "飞书", Title: "周会", SenderName: "Alice", Timestamp: "2026-06-22T15:00:00+08:00"},
+		{AppName: "com.feishu", AppDisplayName: "飞书", Title: "日报", SenderName: "Alice", Timestamp: "2026-06-22T18:00:00+08:00"},
+		{AppName: "com.wechat", AppDisplayName: "微信", Title: "午饭", SenderName: "Bob", Timestamp: "2026-06-22T11:30:00+08:00"},
+	}
+	root := seedNotifications(t, "default", items, "2026-06-22")
+	c, _ := yclib.New(yclib.Config{RootDir: root})
+
+	res, err := c.Notifications().Summary(context.Background(), yclib.SummaryOpts{})
+	if err != nil {
+		t.Fatalf("Summary: %v", err)
+	}
+	if res.Total != 3 {
+		t.Fatalf("Total = %d, want 3", res.Total)
+	}
+	// 飞书 2 条排第一，微信 1 条第二。
+	if len(res.TopApps) != 2 || res.TopApps[0].Key != "飞书" || res.TopApps[0].Count != 2 {
+		t.Fatalf("TopApps = %+v, want 飞书=2 first", res.TopApps)
+	}
+	if len(res.Sample) != 3 {
+		t.Errorf("Sample len = %d, want 3", len(res.Sample))
+	}
+}
+
+func TestNotificationsStats_DimFiltering(t *testing.T) {
+	items := []notif.StoredNotification{
+		{AppName: "com.feishu", AppDisplayName: "飞书", Title: "周会", Timestamp: "2026-06-22T15:00:00+08:00"},
+		{AppName: "com.wechat", AppDisplayName: "微信", Title: "午饭", Timestamp: "2026-06-22T11:30:00+08:00"},
+	}
+	root := seedNotifications(t, "default", items, "2026-06-22")
+	c, _ := yclib.New(yclib.Config{RootDir: root})
+	ctx := context.Background()
+
+	// dim=app：只填充 App 维度，其余为 nil。
+	res, err := c.Notifications().Stats(ctx, yclib.StatsOpts{From: "2026-06-22", To: "2026-06-22", Dim: "app"})
+	if err != nil {
+		t.Fatalf("Stats app: %v", err)
+	}
+	if res.Total != 2 || len(res.App) != 2 {
+		t.Fatalf("App dim = %+v (total %d), want 2 apps", res.App, res.Total)
+	}
+	if res.Date != nil || res.Hour != nil {
+		t.Errorf("non-requested dims should be nil, got Date=%v Hour=%v", res.Date, res.Hour)
+	}
+
+	// dim=all：五个维度都填充。
+	res, err = c.Notifications().Stats(ctx, yclib.StatsOpts{From: "2026-06-22", To: "2026-06-22", Dim: "all"})
+	if err != nil {
+		t.Fatalf("Stats all: %v", err)
+	}
+	if res.Date == nil || res.App == nil || res.Sender == nil || res.Hour == nil || res.Client == nil {
+		t.Fatalf("dim=all should fill every dimension, got %+v", res)
+	}
+
+	// 非法 dim → typed invalid-arg。
+	if _, err := c.Notifications().Stats(ctx, yclib.StatsOpts{Dim: "bogus"}); yclib.ErrorCode(err) != yclib.CodeInvalidArgument {
+		t.Fatalf("bogus dim ErrorCode = %q, want %q", yclib.ErrorCode(err), yclib.CodeInvalidArgument)
+	}
+}

--- a/yclib/recordings.go
+++ b/yclib/recordings.go
@@ -1,0 +1,53 @@
+package yclib
+
+import (
+	"context"
+
+	"github.com/YoooClaw/cli/internal/recording"
+)
+
+// RecordingsClient 暴露录音查询能力（纯本地：直接读 profile 的 recordings 索引，不经 daemon）。
+type RecordingsClient struct {
+	c *Client
+}
+
+// Recordings 返回录音能力子 client。
+func (c *Client) Recordings() *RecordingsClient { return &RecordingsClient{c: c} }
+
+// RecordingListOpts 是 List 的可选过滤。
+type RecordingListOpts struct {
+	Status string // 按转写/传输状态过滤
+	Client string // 按 clientLabel 过滤；"all" 或空为全部
+}
+
+// List 列出录音。等价于 CLI `recording list`，返回 typed 结果（完整 Entry，含各产物文件名）。
+func (r *RecordingsClient) List(ctx context.Context, opts RecordingListOpts) ([]RecordingEntry, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	out := make([]RecordingEntry, 0)
+	for _, rec := range recording.ReadIndex(r.c.paths.Recordings) {
+		if opts.Status != "" && rec.Status != opts.Status {
+			continue
+		}
+		if opts.Client != "" && opts.Client != "all" && labelOrLegacy(rec.ClientLabel) != opts.Client {
+			continue
+		}
+		out = append(out, rec)
+	}
+	r.c.logf("yclib recordings.list total=%d", len(out))
+	return out, nil
+}
+
+// Get 按 id 取单条录音详情；不存在返回 CodeNotFound。
+func (r *RecordingsClient) Get(ctx context.Context, id string) (RecordingEntry, error) {
+	if err := ctx.Err(); err != nil {
+		return RecordingEntry{}, err
+	}
+	for _, rec := range recording.ReadIndex(r.c.paths.Recordings) {
+		if rec.ID == id {
+			return rec, nil
+		}
+	}
+	return RecordingEntry{}, newNotFound("录音不存在：" + id)
+}

--- a/yclib/tunnel.go
+++ b/yclib/tunnel.go
@@ -1,0 +1,97 @@
+package yclib
+
+import (
+	"context"
+	"net/url"
+)
+
+// TunnelClient 暴露 Relay 隧道运维（经 daemon 的 /tunnel/* 端点代理）。
+// daemon 未运行时返回 CodeDaemonNotRunning（不自动拉起，见 arc §5）。
+type TunnelClient struct {
+	c *Client
+}
+
+// Tunnel 返回 Relay 隧道子 client。
+func (c *Client) Tunnel() *TunnelClient { return &TunnelClient{c: c} }
+
+// TunnelStatusResult 是 Relay 隧道整体状态。
+type TunnelStatusResult struct {
+	Mode                 string       `json:"mode"`
+	CredentialMode       string       `json:"credentialMode"`
+	DefaultLabel         string       `json:"defaultLabel"`
+	Connected            bool         `json:"connected"`
+	RelayURL             string       `json:"relayUrl"`
+	Enabled              bool         `json:"enabled"`
+	ReconnectAttempt     int          `json:"reconnectAttempt"`
+	LastDisconnectReason string       `json:"lastDisconnectReason"`
+	Note                 string       `json:"note"`
+	Tunnels              []TunnelInfo `json:"tunnels"`
+}
+
+// Status 查询隧道状态。client 为空查全部，非空只看指定 clientLabel。
+// 等价于 CLI `tunnel status`。
+func (t *TunnelClient) Status(ctx context.Context, client string) (TunnelStatusResult, error) {
+	if err := ctx.Err(); err != nil {
+		return TunnelStatusResult{}, err
+	}
+	path := "/tunnel/status"
+	if client != "" {
+		path += "?client=" + url.QueryEscape(client)
+	}
+	var out TunnelStatusResult
+	if err := t.c.daemonRequest("GET", path, nil, &out); err != nil {
+		return TunnelStatusResult{}, err
+	}
+	return out, nil
+}
+
+// TunnelReconnectResult 是强制重连的结果。
+type TunnelReconnectResult struct {
+	Reconnected bool     `json:"reconnected"`
+	Mode        string   `json:"mode"`
+	Labels      []string `json:"labels"`
+	Note        string   `json:"note"`
+}
+
+// Reconnect 强制重连隧道。client 为空重连全部，非空只重连指定 clientLabel。
+// 等价于 CLI `tunnel reconnect`。
+func (t *TunnelClient) Reconnect(ctx context.Context, client string) (TunnelReconnectResult, error) {
+	if err := ctx.Err(); err != nil {
+		return TunnelReconnectResult{}, err
+	}
+	var body any
+	if client != "" {
+		body = map[string]any{"client": client}
+	}
+	var out TunnelReconnectResult
+	if err := t.c.daemonRequest("POST", "/tunnel/reconnect", body, &out); err != nil {
+		return TunnelReconnectResult{}, err
+	}
+	return out, nil
+}
+
+// TunnelTestResult 是 ingest + 鉴权 echo 回环自检结果。
+type TunnelTestResult struct {
+	OK          bool   `json:"ok"`
+	Mode        string `json:"mode"`
+	ClientLabel string `json:"clientLabel"`
+	Loopback    struct {
+		OK bool `json:"ok"`
+	} `json:"loopback"`
+}
+
+// Test 触发 daemon 本地 ingest + 鉴权 echo 回环自检。等价于 CLI `tunnel +test`。
+func (t *TunnelClient) Test(ctx context.Context, client string) (TunnelTestResult, error) {
+	if err := ctx.Err(); err != nil {
+		return TunnelTestResult{}, err
+	}
+	var body any
+	if client != "" {
+		body = map[string]any{"client": client}
+	}
+	var out TunnelTestResult
+	if err := t.c.daemonRequest("POST", "/tunnel/test", body, &out); err != nil {
+		return TunnelTestResult{}, err
+	}
+	return out, nil
+}

--- a/yclib/types.go
+++ b/yclib/types.go
@@ -1,0 +1,31 @@
+package yclib
+
+import (
+	"github.com/YoooClaw/cli/internal/image"
+	"github.com/YoooClaw/cli/internal/lightrule"
+	"github.com/YoooClaw/cli/internal/notif"
+	"github.com/YoooClaw/cli/internal/recording"
+	"github.com/YoooClaw/cli/internal/relay"
+)
+
+// 类型 re-export：让消费方完全经 yclib 包消费入参/出参，无需 import internal/...
+// 这些是类型别名（identical types），与底层类型可互换传递。
+type (
+	// RawQueryOpts 是通知查询的原始字符串过滤参数（与 CLI flag 同语义）。
+	RawQueryOpts = notif.RawQueryOpts
+	// StoredNotification 是一条落盘通知记录。
+	StoredNotification = notif.StoredNotification
+	// ScanStats 是一次查询扫描的统计。
+	ScanStats = notif.ScanStats
+	// Count 是一个聚合计数项（维度取值 + 次数）。
+	Count = notif.Count
+
+	// ImageEntry 是一条落盘图片记录。
+	ImageEntry = image.Entry
+	// RecordingEntry 是一条落盘录音记录。
+	RecordingEntry = recording.Entry
+	// LightRule 是单条灯效规则元数据。
+	LightRule = lightrule.Meta
+	// TunnelInfo 是单条 Relay 隧道状态。
+	TunnelInfo = relay.TunnelStatus
+)


### PR DESCRIPTION
把 `release/0.5.0` 合回 master 同步主干（发包由 tag `cli-v0.5.0-beta.0` 触发，与本 PR 无关）。

## 包含
- **feat(daemon)**: ingress 分层，daemon 连接可选、可被代理（standalone / proxied / direct 三模式 + Egress 端口）。`proxied` 让宿主插件代理「到手机的连接」，CLI 只暴露 ingest API。设计见 `docs/design/ingress-layering.md`。
- **feat(yclib)**: 进程内 Go library 门面（路径 C，Phase 1–3）。
- **docs**: README 补充 ingress 模式说明；版本 bump 0.4.0 → 0.5.0-beta.0。

## 验证
- `go vet ./...` 干净；`go test ./...` 全绿（含 yclib）。
- 文档站 yc-docs 已同步「Ingress 模式」章节并部署。

🤖 Generated with [Claude Code](https://claude.com/claude-code)