### PR TITLE
cli-0.5.1

### DIFF
--- a/internal/daemon/egress.go
+++ b/internal/daemon/egress.go
@@ -54,6 +54,10 @@ func NewProxyEgress(url, token string, logger *Logger) *ProxyEgress {
 	}
 }
 
+// proxyEgressRetryDelays 是回投失败后的重试间隔。宿主插件可能正在整组重启
+// （回调服务短暂不可达），带退避多试几次能把重启窗口内的事件送达而不是丢掉。
+var proxyEgressRetryDelays = []time.Duration{time.Second, 3 * time.Second, 9 * time.Second}
+
 // PushEvent 异步把 {event, payload} POST 给宿主回调。请求会保留自身的 10s
 // 超时，但调用方只负责排队，不会被宿主回调的延迟阻塞 ingest 响应。
 func (e *ProxyEgress) PushEvent(event string, payload any) error {
@@ -61,34 +65,50 @@ func (e *ProxyEgress) PushEvent(event string, payload any) error {
 	if err != nil {
 		return err
 	}
+	go e.deliver(event, body)
+	return nil
+}
+
+// deliver 投递事件，网络错误与 5xx 按 proxyEgressRetryDelays 重试；4xx 属
+// 配置性失败（token 不符、路径不对），重试无意义，立即放弃。
+func (e *ProxyEgress) deliver(event string, body []byte) {
+	for attempt := 0; ; attempt++ {
+		retryable, err := e.post(body)
+		if err == nil {
+			return
+		}
+		if !retryable || attempt >= len(proxyEgressRetryDelays) {
+			if e.logger != nil {
+				e.logger.Warn(fmt.Sprintf("egress 回投失败（放弃）event=%s attempts=%d: %v", event, attempt+1, err))
+			}
+			return
+		}
+		delay := proxyEgressRetryDelays[attempt]
+		if e.logger != nil {
+			e.logger.Warn(fmt.Sprintf("egress 回投失败 event=%s attempt=%d，%s 后重试: %v", event, attempt+1, delay, err))
+		}
+		time.Sleep(delay)
+	}
+}
+
+func (e *ProxyEgress) post(body []byte) (retryable bool, err error) {
 	req, err := http.NewRequest(http.MethodPost, e.url, bytes.NewReader(body))
 	if err != nil {
-		return err
+		return false, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if e.token != "" {
 		req.Header.Set("Authorization", "Bearer "+e.token)
 	}
-	go e.deliver(event, req)
-	return nil
-}
-
-func (e *ProxyEgress) deliver(event string, req *http.Request) {
 	resp, err := e.client.Do(req)
 	if err != nil {
-		if e.logger != nil {
-			e.logger.Warn("egress 回投失败 event=" + event + ": " + err.Error())
-		}
-		return
+		return true, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		msg := fmt.Sprintf("egress 回调返回 %d event=%s", resp.StatusCode, event)
-		if e.logger != nil {
-			e.logger.Warn(msg)
-		}
-		return
+		return resp.StatusCode >= 500, fmt.Errorf("egress 回调返回 %d", resp.StatusCode)
 	}
+	return false, nil
 }
 
 // NoopEgress 丢弃出站事件（direct 模式，或 proxied 未配置回调时）。

--- a/internal/daemon/egress_test.go
+++ b/internal/daemon/egress_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -131,6 +132,81 @@ func TestProxyEgressDoesNotWaitForSlowCallback(t *testing.T) {
 		t.Fatal("异步回调未开始")
 	}
 	close(releaseCallback)
+}
+
+func TestProxyEgressRetriesOnServerError(t *testing.T) {
+	oldDelays := proxyEgressRetryDelays
+	proxyEgressRetryDelays = []time.Duration{5 * time.Millisecond, 5 * time.Millisecond, 5 * time.Millisecond}
+	defer func() { proxyEgressRetryDelays = oldDelays }()
+
+	var mu sync.Mutex
+	calls := 0
+	success := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		calls++
+		n := calls
+		mu.Unlock()
+		if n < 3 {
+			w.WriteHeader(http.StatusBadGateway) // 宿主整组重启窗口内的瞬时失败
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		success <- struct{}{}
+	}))
+	defer srv.Close()
+
+	eg := NewProxyEgress(srv.URL, "", nil)
+	if err := eg.PushEvent("recording.status", map[string]any{"id": "r1"}); err != nil {
+		t.Fatalf("PushEvent error: %v", err)
+	}
+	select {
+	case <-success:
+	case <-time.After(2 * time.Second):
+		t.Fatal("重试后仍未成功投递")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 3 {
+		t.Fatalf("calls = %d, want 3", calls)
+	}
+}
+
+func TestProxyEgressDoesNotRetryClientError(t *testing.T) {
+	oldDelays := proxyEgressRetryDelays
+	proxyEgressRetryDelays = []time.Duration{time.Millisecond}
+	defer func() { proxyEgressRetryDelays = oldDelays }()
+
+	var mu sync.Mutex
+	calls := 0
+	first := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		select {
+		case first <- struct{}{}:
+		default:
+		}
+		w.WriteHeader(http.StatusUnauthorized) // token 不符属配置错误，重试无意义
+	}))
+	defer srv.Close()
+
+	eg := NewProxyEgress(srv.URL, "", nil)
+	if err := eg.PushEvent("recording.status", nil); err != nil {
+		t.Fatalf("PushEvent error: %v", err)
+	}
+	select {
+	case <-first:
+	case <-time.After(time.Second):
+		t.Fatal("未收到回调请求")
+	}
+	time.Sleep(50 * time.Millisecond) // 留出误重试的观察窗口
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("4xx 不应重试，calls = %d", calls)
+	}
 }
 
 func TestNoopEgressDropsEvents(t *testing.T) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {


### PR DESCRIPTION
将 0.5.1 发布分支合回主干,同步以下内容:

- **fix(daemon): retry egress delivery on transient failures** — 回投失败后按 1s/3s/9s 退避重试,覆盖宿主插件整组重启的短暂不可达窗口;网络错误与 5xx 视为可重试,4xx(token/路径等配置错误)立即放弃。
- 版本 bump `0.5.0 → 0.5.1`

发布已由 tag `cli-v0.5.1` 触发,本 PR 仅为同步主干。

🤖 Generated with [Claude Code](https://claude.com/claude-code)