### PR TITLE
cli-0.5.2-beta.0

### DIFF
--- a/internal/light/env.go
+++ b/internal/light/env.go
@@ -3,6 +3,8 @@ package light
 import "github.com/YoooClaw/cli/internal/envhost"
 
 // LightAPIURL 返回灯效云 API 端点（主机随 PHONE_NOTIFICATIONS_ENV 切换，见 internal/envhost）。
+// 一次性亮灯走 Notification Intelligence Service 的插件侧 Facade，
+// 由服务端负责 LightSegment 校验、线协议编码与 message-service 调用。
 func LightAPIURL() string {
-	return "https://" + envhost.Host() + "/api/message/tob/sendMessage"
+	return "https://" + envhost.Host() + "/api/plugin/notification-intelligence/light-effects/send"
 }

--- a/internal/light/env_test.go
+++ b/internal/light/env_test.go
@@ -9,7 +9,7 @@ func TestLightAPIURL(t *testing.T) {
 	t.Setenv("PHONE_NOTIFICATIONS_ENV", "production")
 	t.Setenv("OPENCLAW_HOST_PRODUCTION", "")
 	url := LightAPIURL()
-	if !strings.HasPrefix(url, "https://") || !strings.HasSuffix(url, "/api/message/tob/sendMessage") {
+	if !strings.HasPrefix(url, "https://") || !strings.HasSuffix(url, "/api/plugin/notification-intelligence/light-effects/send") {
 		t.Errorf("LightAPIURL = %q", url)
 	}
 }

--- a/internal/light/sender.go
+++ b/internal/light/sender.go
@@ -11,12 +11,6 @@ import (
 	"time"
 )
 
-// 后端要求 appKey / templateId 写死在代码里（不再从 env 注入）。
-const (
-	lightAppKey     = "phone-notifications"
-	lightTemplateID = "1990771146010017800"
-)
-
 // Logger 是 sender 依赖的最小日志接口。
 type Logger interface {
 	Info(string)
@@ -32,36 +26,45 @@ type SendResult struct {
 	Error       string `json:"error,omitempty"`
 }
 
-// SendLightEffect 把 segments 编码成线协议负载并 POST 到灯效云 API。
+// SendLightEffect 把结构化 segments POST 到 Notification Intelligence Service 的
+// 插件侧一次性亮灯 Facade（线协议编码与 message-service 调用由服务端完成）。
 func SendLightEffect(apiKey string, segments []map[string]any, repeatInput RepeatInput, reason, title string, logger Logger) SendResult {
 	apiURL := LightAPIURL()
 	resolvedTitle := resolveLightTitle(title, reason, segments)
 
 	if logger != nil {
-		logger.Info(fmt.Sprintf("Light sender: apiUrl=%s, appKey=%s…, templateId=%s, apiKey=%s, title=%s, reason=%s",
-			apiURL, truncate(lightAppKey, 8), lightTemplateID, maskKey(apiKey), resolvedTitle, reason))
+		logger.Info(fmt.Sprintf("Light sender: apiUrl=%s, apiKey=%s, title=%s, reason=%s",
+			apiURL, maskKey(apiKey), resolvedTitle, reason))
 	}
 	if apiURL == "" {
 		return SendResult{OK: false, Error: "灯效 API 未配置，请确认构建时已封装 OPENCLAW_HOST_*"}
 	}
 
-	bizContent, err := BuildLightEffectApnsBody(segments, repeatInput, reason)
+	if len(segments) == 0 {
+		return SendResult{OK: false, Error: "segments 不能为空"}
+	}
+	repeatTimes, err := NormalizeRepeatTimes(repeatInput)
 	if err != nil {
+		return SendResult{OK: false, Error: err.Error()}
+	}
+	if err := AssertAncsRepeatTimes(repeatTimes); err != nil {
 		return SendResult{OK: false, Error: err.Error()}
 	}
 	bizUniqueID := newUUID()
 
 	requestBody := map[string]any{
-		"appKey":      lightAppKey,
-		"bizMap":      map[string]any{"noticeType": "APP_NOTIFICATION_IMPORTANT", "title": resolvedTitle, "reason": reason},
-		"bizUniqueId": bizUniqueID,
-		"paramsMap":   map[string]any{"bizContent": bizContent},
-		"pushType":    "SPECIFY_PUSH",
-		"templateId":  lightTemplateID,
+		"title":        resolvedTitle,
+		"bizUniqueId":  bizUniqueID,
+		"repeat_times": repeatTimes,
+		"segments":     segments,
+	}
+	if strings.TrimSpace(reason) != "" {
+		requestBody["reason"] = reason
 	}
 	payload, _ := json.Marshal(requestBody)
 	if logger != nil {
-		logger.Info(fmt.Sprintf("Light sender: POST %s, bizUniqueId=%s, body=%s", apiURL, bizUniqueID, truncate(string(payload), 500)))
+		logger.Info(fmt.Sprintf("Light sender: POST %s, bizUniqueId=%s, segments_count=%d, repeat_times=%d",
+			apiURL, bizUniqueID, len(segments), repeatTimes))
 	}
 
 	req, err := http.NewRequest(http.MethodPost, apiURL, bytes.NewReader(payload))
@@ -84,6 +87,18 @@ func SendLightEffect(apiKey string, segments []map[string]any, repeatInput Repea
 			logger.Warn(fmt.Sprintf("Light sender: FAILED %d, url=%s, resBody=%s", res.StatusCode, apiURL, truncate(string(resBody), 500)))
 		}
 		return SendResult{OK: false, Status: res.StatusCode, Error: string(resBody)}
+	}
+
+	// 响应外壳：{code, msg, date, data:{success, requestId, bizUniqueId, message}}，code=000000 为成功。
+	var envelope struct {
+		Code string `json:"code"`
+		Msg  string `json:"msg"`
+	}
+	if json.Unmarshal(resBody, &envelope) == nil && envelope.Code != "" && envelope.Code != "000000" {
+		if logger != nil {
+			logger.Warn(fmt.Sprintf("Light sender: FAILED code=%s, msg=%s, bizUniqueId=%s", envelope.Code, envelope.Msg, bizUniqueID))
+		}
+		return SendResult{OK: false, Status: res.StatusCode, BizUniqueID: bizUniqueID, Error: envelope.Code + ": " + envelope.Msg}
 	}
 	if logger != nil {
 		logger.Info(fmt.Sprintf("Light sender: OK bizUniqueId=%s, resBody=%s", bizUniqueID, truncate(string(resBody), 200)))

--- a/internal/light/sender_test.go
+++ b/internal/light/sender_test.go
@@ -97,9 +97,9 @@ func TestSendLightEffectConnectionError(t *testing.T) {
 func TestSendLightEffectBadBody(t *testing.T) {
 	t.Setenv("PHONE_NOTIFICATIONS_ENV", "production")
 	t.Setenv("OPENCLAW_HOST_PRODUCTION", "127.0.0.1:1")
-	// 空 segments 会让 BuildLightEffectApnsBody 报错（编码前置校验）。
+	// 空 segments 在发送前被本地校验拦下，不发起请求。
 	res := SendLightEffect("k", nil, RepeatInput{}, "r", "t", nil)
 	if res.OK {
-		t.Error("empty segments should fail body build or send")
+		t.Error("empty segments should fail before send")
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.5.1",
+  "version": "0.5.2-beta.0",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {


### PR DESCRIPTION
将 0.5.2-beta.0 发版分支合回主干。

## 内容
- **refactor(light)**: 一次性灯效发送切到 notification-intelligence Facade 端点 `/api/plugin/notification-intelligence/light-effects/send`；线协议编码与 message-service 调用交给服务端，客户端只发结构化 segments。移除写死的 appKey/templateId，新增 segments 非空 / ANCS repeat 校验，并按响应外壳 code(000000 成功) 判定失败。
- **cli-0.5.2-beta.0**: package.json 版本 bump。

## 验证
- `go test ./internal/light/...` 通过。
- tag `cli-v0.5.2-beta.0` 已推送并触发 release-cli.yml。

🤖 Generated with [Claude Code](https://claude.com/claude-code)