### PR TITLE
cli-0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.5.2-beta.0",
+  "version": "0.5.2",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {


### PR DESCRIPTION
Release 0.5.2 正式版。

- bump `package.json` version: `0.5.2-beta.0` → `0.5.2`
- tag `cli-v0.5.2` 已推送，发布 workflow 已触发

合回 master 仅为同步主干（发布触发器是 tag 推送，非 PR 合并）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)