### PR TITLE
cli-0.5.3

### DIFF
--- a/internal/cli/cmd_daemon.go
+++ b/internal/cli/cmd_daemon.go
@@ -120,7 +120,8 @@ func daemonStop(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error
 }
 
 func daemonRestart(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error) {
-	lock := daemon.ReadLock(ctx.Paths)
+	state := daemon.State(ctx.Paths)
+	lock := state.Lock
 	opts := startOptsFromCmd(cmd)
 	if lock != nil {
 		if opts.Bind == "" {
@@ -132,7 +133,7 @@ func daemonRestart(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, er
 		if opts.LogLevel == "" {
 			opts.LogLevel = lock.LogLevel
 		}
-		if daemon.IsProcessAlive(lock.PID) {
+		if state.Running {
 			if _, err := daemon.Stop(ctx.Paths); err != nil {
 				return nil, err
 			}

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/YoooClaw/cli/internal/config"
@@ -46,18 +46,15 @@ func newClient(p paths.Paths, token string) *Client {
 		bind = state.Lock.Bind
 		port = state.Lock.Port
 	}
-	host := bind
-	if host == "0.0.0.0" {
-		host = "127.0.0.1"
-	}
 	return &Client{
-		BaseURL: "http://" + host + ":" + strconv.Itoa(port),
+		BaseURL: daemonBaseURL(bind, port),
 		token:   token,
 		timeout: 10 * time.Second,
 	}
 }
 
-// Request 调 daemon；连接被拒/超时统一报 DAEMON_NOT_RUNNING。
+// Request 调 daemon；localhost 连接失败（包括 reset/EOF/超时）统一报
+// DAEMON_NOT_RUNNING，让生命周期监管可以清理陈旧 lock 并重启 daemon。
 func (c *Client) Request(method, path string, body any) (int, any, error) {
 	var reader io.Reader
 	if body != nil {
@@ -78,11 +75,8 @@ func (c *Client) Request(method, path string, body any) (int, any, error) {
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		if strings.Contains(err.Error(), "connection refused") || ctx.Err() != nil {
-			return 0, nil, errs.New(errs.CodeDaemonNotRunning, "daemon 未启动或无响应",
-				map[string]any{"hint": "先执行 yoooclaw daemon start", "baseUrl": c.BaseURL})
-		}
-		return 0, nil, errs.New(errs.CodeNetworkError, "调用 daemon 失败："+err.Error())
+		return 0, nil, errs.New(errs.CodeDaemonNotRunning, "daemon 未启动或无响应",
+			map[string]any{"hint": "先执行 yoooclaw daemon start", "baseUrl": c.BaseURL, "cause": err.Error()})
 	}
 	defer resp.Body.Close()
 	text, _ := io.ReadAll(resp.Body)
@@ -97,6 +91,14 @@ func (c *Client) Request(method, path string, body any) (int, any, error) {
 			map[string]any{"status": resp.StatusCode})
 	}
 	return resp.StatusCode, parsed, nil
+}
+
+func daemonBaseURL(bind string, port int) string {
+	host := bind
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		host = "127.0.0.1"
+	}
+	return "http://" + net.JoinHostPort(host, strconv.Itoa(port))
 }
 
 // AssertRunning 确保 daemon 在运行，否则报 DAEMON_NOT_RUNNING（🟡 命令前置检查）。

--- a/internal/daemon/client_test.go
+++ b/internal/daemon/client_test.go
@@ -1,10 +1,12 @@
 package daemon
 
 import (
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/YoooClaw/cli/internal/errs"
 )
@@ -19,11 +21,46 @@ func TestNewClientBuildsURL(t *testing.T) {
 	}
 }
 
+func TestDaemonBaseURLNormalizesWildcardAndIPv6(t *testing.T) {
+	if got := daemonBaseURL("0.0.0.0", 12345); got != "http://127.0.0.1:12345" {
+		t.Fatalf("wildcard base URL = %q", got)
+	}
+	if got := daemonBaseURL("::1", 12345); got != "http://[::1]:12345" {
+		t.Fatalf("IPv6 base URL = %q", got)
+	}
+}
+
 func TestClientRequestDaemonNotRunning(t *testing.T) {
 	c := &Client{BaseURL: "http://127.0.0.1:1", timeout: 1e9}
 	_, _, err := c.Request("GET", "/health", nil)
 	if e, ok := err.(*errs.Error); !ok || e.Code != errs.CodeDaemonNotRunning {
 		t.Errorf("connection refused should map to DAEMON_NOT_RUNNING, got %v", err)
+	}
+}
+
+func TestClientRequestConnectionResetIsDaemonNotRunning(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	accepted := make(chan struct{})
+	go func() {
+		conn, acceptErr := ln.Accept()
+		if acceptErr == nil {
+			if tcp, ok := conn.(*net.TCPConn); ok {
+				_ = tcp.SetLinger(0) // close with RST, matching the WSL report.
+			}
+			_ = conn.Close()
+		}
+		close(accepted)
+	}()
+
+	c := &Client{BaseURL: "http://" + ln.Addr().String(), timeout: time.Second}
+	_, _, err = c.Request("GET", "/daemon/status", nil)
+	<-accepted
+	if e, ok := err.(*errs.Error); !ok || e.Code != errs.CodeDaemonNotRunning {
+		t.Fatalf("connection reset should map to DAEMON_NOT_RUNNING, got %v", err)
 	}
 }
 

--- a/internal/daemon/lock.go
+++ b/internal/daemon/lock.go
@@ -42,13 +42,17 @@ func ReadLock(p paths.Paths) *Lock {
 	return &lock
 }
 
-// State 返回 daemon 运行态（通过 signal 0 探活；陈旧锁视为未运行）。
+// State 返回 daemon 运行态（signal 0 + Linux/WSL /proc 身份校验；陈旧锁视为未运行）。
 func State(p paths.Paths) RunningState {
 	lock := ReadLock(p)
 	if lock == nil {
 		return RunningState{}
 	}
-	alive := isProcessAlive(lock.PID)
+	// signal 0 alone is not enough on Linux/WSL: it also succeeds for zombies,
+	// and a persisted lock can point at an unrelated process after PID reuse.
+	// When /proc metadata is available, verify that the PID still belongs to the
+	// daemon executable and command line recorded by the lock.
+	alive := isProcessAlive(lock.PID) && isExpectedDaemonProcess(lock)
 	return RunningState{Running: alive, Lock: lock, Stale: !alive}
 }
 

--- a/internal/daemon/lock_test.go
+++ b/internal/daemon/lock_test.go
@@ -39,7 +39,11 @@ func TestLockRoundTrip(t *testing.T) {
 	if got.Owner != "hermes-plugin" || got.Generation != "gen-1" || got.Executable != "/tmp/yoooclaw" || got.Version != "1.2.3" || got.Profile != "default" {
 		t.Fatalf("lock lifecycle fields not preserved: %+v", got)
 	}
-	// 自己的 pid 必然存活 -> Running
+	// 当前 test binary 不是 daemon，不能拿上面的伪 executable/cmdline 做身份
+	// 校验；另写一个 legacy lock 单独验证基础 PID 判活。
+	if err := WriteLock(p, Lock{PID: os.Getpid(), Bind: "127.0.0.1", Port: 18789}); err != nil {
+		t.Fatal(err)
+	}
 	st := State(p)
 	if !st.Running || st.Stale {
 		t.Errorf("self pid should be running: %+v", st)

--- a/internal/daemon/process_identity.go
+++ b/internal/daemon/process_identity.go
@@ -1,0 +1,43 @@
+package daemon
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+)
+
+func linuxProcessState(stat []byte) byte {
+	// /proc/<pid>/stat starts with "pid (comm) state". comm may contain spaces
+	// or ')', so find the final closing parenthesis instead of splitting fields.
+	end := bytes.LastIndexByte(stat, ')')
+	if end < 0 || end+2 >= len(stat) {
+		return 0
+	}
+	return stat[end+2]
+}
+
+func isDaemonCommandLine(cmdline []byte) bool {
+	args := bytes.Split(bytes.TrimRight(cmdline, "\x00"), []byte{0})
+	for i, arg := range args {
+		if string(arg) == "--yclib-daemon-bootstrap" {
+			return true
+		}
+		if string(arg) == "daemon" && i+1 < len(args) && string(args[i+1]) == "run-foreground" {
+			return true
+		}
+	}
+	return false
+}
+
+func sameExecutable(expected, actual string) bool {
+	actual = strings.TrimSuffix(actual, " (deleted)")
+	return canonicalExecutable(expected) == canonicalExecutable(actual)
+}
+
+func canonicalExecutable(path string) string {
+	path = filepath.Clean(path)
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved
+	}
+	return path
+}

--- a/internal/daemon/process_identity_linux.go
+++ b/internal/daemon/process_identity_linux.go
@@ -1,0 +1,38 @@
+//go:build linux
+
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// isExpectedDaemonProcess rejects stale daemon locks that happen to reference
+// a live PID. This matters especially in WSL, where the lock survives a distro
+// restart while the Linux PID namespace starts over and quickly reuses PIDs.
+func isExpectedDaemonProcess(lock *Lock) bool {
+	procRoot := fmt.Sprintf("/proc/%d", lock.PID)
+	stat, err := os.ReadFile(filepath.Join(procRoot, "stat"))
+	if err != nil {
+		// /proc can be hidden by container policy. Preserve the historical
+		// signal-0 behavior when identity metadata is unavailable.
+		return true
+	}
+	if linuxProcessState(stat) == 'Z' || linuxProcessState(stat) == 'X' {
+		return false
+	}
+	if lock.Executable == "" {
+		return true // legacy locks did not record enough identity to verify.
+	}
+
+	actualExecutable, err := os.Readlink(filepath.Join(procRoot, "exe"))
+	if err == nil && !sameExecutable(lock.Executable, actualExecutable) {
+		return false
+	}
+	cmdline, err := os.ReadFile(filepath.Join(procRoot, "cmdline"))
+	if err == nil && len(cmdline) > 0 && !isDaemonCommandLine(cmdline) {
+		return false
+	}
+	return true
+}

--- a/internal/daemon/process_identity_linux_test.go
+++ b/internal/daemon/process_identity_linux_test.go
@@ -1,0 +1,19 @@
+//go:build linux
+
+package daemon
+
+import (
+	"os"
+	"testing"
+)
+
+func TestStateRejectsReusedLinuxPID(t *testing.T) {
+	p := sandboxPaths(t)
+	if err := WriteLock(p, Lock{PID: os.Getpid(), Executable: "/definitely/not/the/test-binary"}); err != nil {
+		t.Fatal(err)
+	}
+	st := State(p)
+	if st.Running || !st.Stale {
+		t.Fatalf("reused PID should be stale: %+v", st)
+	}
+}

--- a/internal/daemon/process_identity_other.go
+++ b/internal/daemon/process_identity_other.go
@@ -1,0 +1,8 @@
+//go:build !linux
+
+package daemon
+
+// Non-Linux platforms do not expose the /proc identity data used to reject PID
+// reuse. Their existing platform-specific process liveness check remains the
+// best available signal.
+func isExpectedDaemonProcess(_ *Lock) bool { return true }

--- a/internal/daemon/process_identity_test.go
+++ b/internal/daemon/process_identity_test.go
@@ -1,0 +1,18 @@
+package daemon
+
+import "testing"
+
+func TestLinuxProcessIdentityParsing(t *testing.T) {
+	if got := linuxProcessState([]byte("123 (daemon worker) Z 1 2 3")); got != 'Z' {
+		t.Fatalf("state = %q", got)
+	}
+	if !isDaemonCommandLine([]byte("/usr/bin/yc\x00daemon\x00run-foreground\x00--profile\x00default\x00")) {
+		t.Fatal("daemon run-foreground command line was not recognized")
+	}
+	if !isDaemonCommandLine([]byte("/tmp/host\x00--yclib-daemon-bootstrap\x00")) {
+		t.Fatal("yclib bootstrap command line was not recognized")
+	}
+	if isDaemonCommandLine([]byte("/usr/bin/yc\x00daemon\x00status\x00")) {
+		t.Fatal("normal CLI process must not satisfy daemon identity")
+	}
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -71,6 +71,7 @@ func RunForeground(ctx *clictx.Context, opts StartOpts) error {
 	token := tokenRef.Value
 	credentialSet := creds.ResolveAPIKeyEntries()
 	executable, _ := os.Executable()
+	mode := resolveIngressMode(opts, cfg)
 
 	loopback := bind == "127.0.0.1" || bind == "::1" || bind == "localhost"
 	if !loopback && token == "" {
@@ -82,6 +83,13 @@ func RunForeground(ctx *clictx.Context, opts StartOpts) error {
 	ctx.Paths.MigrateLogs()
 	logger := NewLogger(ctx.Paths.DaemonLog, logLevel, false)
 	st := &runtimeState{startedAt: time.Now().UTC().Format(time.RFC3339)}
+	// Validate all prerequisites before publishing daemon.lock. Previously a
+	// proxied start without an api-key wrote the lock and then exited, leaving
+	// callers (especially after WSL restarts) talking to a dead or reused PID.
+	if mode == config.IngressProxied && len(credentialSet.Entries) == 0 {
+		return errs.New(errs.CodeUnauthorized, "proxied 模式需要至少一个 api-key 供宿主推送鉴权").
+			WithHint("先设置 api-key，或改用 --ingress=standalone")
+	}
 
 	storage := notif.NewStorage(ctx.Paths.Notifications, notif.PluginConfig{
 		RetentionDays: cfg.Notification.RetentionDays, IgnoredApps: cfg.Notification.IgnoredApps,
@@ -102,8 +110,12 @@ func RunForeground(ctx *clictx.Context, opts StartOpts) error {
 	srv := &server{
 		ctx: ctx, cfg: cfg, logger: logger, st: st, storage: storage,
 		recordingStorage: recordingStorage, recordingEventLog: recordingEventLog,
-		token:         token, credentialSet: credentialSet, ignored: ignored, bind: bind,
+		token: token, credentialSet: credentialSet, ignored: ignored, bind: bind,
 		owner: opts.Owner, generation: opts.Generation, executable: executable,
+		ingressMode: mode, egress: NoopEgress{},
+	}
+	if mode == config.IngressProxied {
+		srv.egress = resolveProxyEgress(opts, cfg, logger)
 	}
 
 	// 监听；端口被占自动 +1（最多 64 次）。
@@ -111,6 +123,7 @@ func RunForeground(ctx *clictx.Context, opts StartOpts) error {
 	if err != nil {
 		return err
 	}
+	defer ln.Close()
 	srv.port = actualPort
 
 	httpSrv := &http.Server{Handler: srv}
@@ -120,18 +133,13 @@ func RunForeground(ctx *clictx.Context, opts StartOpts) error {
 	}); err != nil {
 		return err
 	}
+	// Every non-os.Exit return path must retire the lock. This includes startup
+	// failures and unexpected http.Server termination.
+	defer RemoveLock(ctx.Paths)
 	logger.Info(fmt.Sprintf("yoooclaw daemon 启动：%s:%d（profile=%s, pid=%d）", bind, actualPort, ctx.Profile, os.Getpid()))
-	mode := resolveIngressMode(opts, cfg)
-	srv.ingressMode = mode
-	srv.egress = NoopEgress{}
 	switch mode {
 	case config.IngressProxied:
-		// 宿主代理到手机的连接：daemon 不连隧道，只暴露 ingest API。要求 api-key 供宿主推送鉴权。
-		if len(credentialSet.Entries) == 0 {
-			return errs.New(errs.CodeUnauthorized, "proxied 模式需要至少一个 api-key 供宿主推送鉴权").
-				WithHint("先设置 api-key，或改用 --ingress=standalone")
-		}
-		srv.egress = resolveProxyEgress(opts, cfg, logger)
+		// 宿主代理到手机的连接：daemon 不连隧道，只暴露 ingest API。
 		logger.Info("ingress=proxied：Relay 隧道关闭，等待宿主推送 ingest")
 	case config.IngressDirect:
 		logger.Info("ingress=direct：Relay 隧道关闭，仅接受直接 POST")

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -26,18 +26,18 @@ func newTestServer(t *testing.T, token string) (*server, *httptest.Server) {
 		t.Fatal(err)
 	}
 	srv := &server{
-		ctx:               &clictx.Context{Profile: "default", Paths: p},
-		cfg:               config.Default(p.Credentials),
-		logger:            logger,
-		st:                &runtimeState{startedAt: "2026-06-07T10:00:00Z"},
-		storage:           storage,
-		token:             token,
-		ignored:           map[string]bool{"com.spam.app": true},
-		bind:              "127.0.0.1",
-		port:              18789,
-		owner:             "hermes-plugin",
-		generation:        "gen-1",
-		executable:        "/tmp/yoooclaw",
+		ctx:        &clictx.Context{Profile: "default", Paths: p},
+		cfg:        config.Default(p.Credentials),
+		logger:     logger,
+		st:         &runtimeState{startedAt: "2026-06-07T10:00:00Z"},
+		storage:    storage,
+		token:      token,
+		ignored:    map[string]bool{"com.spam.app": true},
+		bind:       "127.0.0.1",
+		port:       18789,
+		owner:      "hermes-plugin",
+		generation: "gen-1",
+		executable: "/tmp/yoooclaw",
 	}
 	ts := httptest.NewServer(srv)
 	t.Cleanup(ts.Close)
@@ -160,6 +160,24 @@ func TestListenWithFallbackPortZeroReturnsActualPort(t *testing.T) {
 	}
 	if port != addr.Port {
 		t.Fatalf("returned port = %d, listener port = %d", port, addr.Port)
+	}
+}
+
+func TestRunForegroundProxiedValidationDoesNotPublishLock(t *testing.T) {
+	p := sandboxPaths(t)
+	cfg := config.Default(p.Credentials)
+	cfg.Relay.Enabled = false
+	if err := config.Save(p, cfg); err != nil {
+		t.Fatal(err)
+	}
+	ctx := &clictx.Context{Profile: p.Profile, Paths: p}
+
+	err := RunForeground(ctx, StartOpts{IngressMode: config.IngressProxied})
+	if err == nil {
+		t.Fatal("proxied start without api-key should fail")
+	}
+	if lock := ReadLock(p); lock != nil {
+		t.Fatalf("failed startup published stale lock: %+v", lock)
 	}
 }
 

--- a/internal/daemon/spawn.go
+++ b/internal/daemon/spawn.go
@@ -2,6 +2,8 @@ package daemon
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"runtime"
@@ -89,22 +91,77 @@ func spawn(p paths.Paths, executable string, args, env []string, release bool) (
 	if null != nil {
 		_ = null.Close()
 	}
-	if release {
-		_ = cmd.Process.Release()
-	} else {
+	if !release {
 		// An embedding host is long-lived, unlike the short-lived yc CLI parent.
 		// Keep a waiter so a stopped daemon cannot remain a zombie until the host exits.
 		go func() { _ = cmd.Wait() }()
 	}
 
-	for i := 0; i < 30; i++ {
+	lock, readyErr := waitForDaemonReady(p, cmd.Process.Pid)
+	if readyErr == nil {
+		if release {
+			_ = cmd.Process.Release()
+		}
+		return lock, nil
+	}
+
+	// Do not leave a failed child, zombie, or lock behind for the next retry.
+	_ = cmd.Process.Kill()
+	if release {
+		_ = cmd.Wait()
+	}
+	if current := ReadLock(p); current != nil && current.PID == cmd.Process.Pid {
+		RemoveLock(p)
+	}
+	return nil, errs.New(errs.CodeUnknown, "daemon 启动失败（3s 内 HTTP 未就绪）："+readyErr.Error()).
+		WithHint("查看 yoooclaw daemon logs 排查")
+}
+
+func waitForDaemonReady(p paths.Paths, pid int) (*Lock, error) {
+	var lastErr error = fmt.Errorf("尚未写出 lock")
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
 		time.Sleep(100 * time.Millisecond)
-		if st := State(p); st.Running {
-			return st.Lock, nil
+		lock := ReadLock(p)
+		if lock == nil || lock.PID != pid {
+			if !isProcessAlive(pid) || !isExpectedDaemonProcess(&Lock{PID: pid}) {
+				return nil, fmt.Errorf("daemon 进程已退出")
+			}
+			continue
+		}
+		if st := State(p); !st.Running {
+			return nil, fmt.Errorf("daemon lock 指向的进程无效")
+		}
+		probeTimeout := min(250*time.Millisecond, time.Until(deadline))
+		if probeTimeout <= 0 {
+			break
+		}
+		if err := probeDaemonHealth(lock, probeTimeout); err == nil {
+			return lock, nil
+		} else {
+			lastErr = err
 		}
 	}
-	return nil, errs.New(errs.CodeUnknown, "daemon 启动超时（3s 内未写出 lock）").
-		WithHint("查看 yoooclaw daemon logs 排查")
+	return nil, lastErr
+}
+
+func probeDaemonHealth(lock *Lock, timeout time.Duration) error {
+	client := &http.Client{Timeout: timeout}
+	resp, err := client.Get(daemonBaseURL(lock.Bind, lock.Port) + "/health")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("health 返回 HTTP %d", resp.StatusCode)
+	}
+	var body struct {
+		Server string `json:"server"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil || body.Server != "yoooclaw" {
+		return fmt.Errorf("health 响应不是 yoooclaw daemon")
+	}
+	return nil
 }
 
 func replaceEnv(env []string, key, value string) []string {
@@ -133,8 +190,9 @@ func Stop(p paths.Paths) (map[string]any, error) {
 
 // StopWithOptions stops a daemon after optional owner/generation checks.
 func StopWithOptions(p paths.Paths, opts StopOpts) (map[string]any, error) {
-	lock := ReadLock(p)
-	if lock == nil || !isProcessAlive(lock.PID) {
+	state := State(p)
+	lock := state.Lock
+	if lock == nil || !state.Running {
 		RemoveLock(p)
 		return nil, errs.New(errs.CodeDaemonNotRunning, "daemon 未运行")
 	}
@@ -153,15 +211,20 @@ func StopWithOptions(p paths.Paths, opts StopOpts) (map[string]any, error) {
 	}
 	for i := 0; i < 100; i++ {
 		time.Sleep(100 * time.Millisecond)
-		current := ReadLock(p)
-		if current == nil || current.PID != lock.PID || !isProcessAlive(lock.PID) {
+		currentState := State(p)
+		current := currentState.Lock
+		if current == nil || current.PID != lock.PID || !currentState.Running {
 			if current != nil && current.PID == lock.PID {
 				RemoveLock(p)
 			}
 			return map[string]any{"ok": true, "stopped": lock.PID, "signal": signal}, nil
 		}
 	}
-	_ = forceKill(lock.PID)
+	// Revalidate identity before SIGKILL so PID reuse can never make a stale
+	// daemon lock terminate an unrelated WSL process.
+	if current := State(p); current.Running && current.Lock != nil && current.Lock.PID == lock.PID {
+		_ = forceKill(lock.PID)
+	}
 	if current := ReadLock(p); current != nil && current.PID == lock.PID {
 		RemoveLock(p)
 	}

--- a/internal/daemon/spawn_test.go
+++ b/internal/daemon/spawn_test.go
@@ -1,0 +1,80 @@
+package daemon
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestProbeDaemonHealthRequiresHTTPResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"server":"yoooclaw"}`))
+	}))
+	defer server.Close()
+	host, rawPort, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, _ := strconv.Atoi(rawPort)
+	if err := probeDaemonHealth(&Lock{Bind: host, Port: port}, time.Second); err != nil {
+		t.Fatalf("healthy daemon probe failed: %v", err)
+	}
+}
+
+func TestProbeDaemonHealthRejectsUnrelatedHTTPService(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"server":"something-else"}`))
+	}))
+	defer server.Close()
+	host, rawPort, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, _ := strconv.Atoi(rawPort)
+	if err := probeDaemonHealth(&Lock{Bind: host, Port: port}, time.Second); err == nil {
+		t.Fatal("unrelated HTTP service must not satisfy daemon readiness")
+	}
+}
+
+func TestWaitForDaemonReadyUsesHealthNotLockAlone(t *testing.T) {
+	p := sandboxPaths(t)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+	if err := WriteLock(p, Lock{PID: os.Getpid(), Bind: "127.0.0.1", Port: port}); err != nil {
+		t.Fatal(err)
+	}
+
+	ready := make(chan struct{})
+	go func() {
+		time.Sleep(250 * time.Millisecond)
+		close(ready)
+		_ = http.Serve(ln, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"server":"yoooclaw"}`))
+		}))
+	}()
+	started := time.Now()
+	lock, err := waitForDaemonReady(p, os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-ready
+	if lock.Port != port {
+		t.Fatalf("ready lock port = %d, want %d", lock.Port, port)
+	}
+	if time.Since(started) < 200*time.Millisecond {
+		t.Fatal("lock alone was treated as ready before HTTP started")
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {

--- a/release.sh
+++ b/release.sh
@@ -72,7 +72,7 @@ if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
 fi
 
 base=$(git rev-parse --abbrev-ref HEAD)
-echo "→ $pkgname：$current → $next（从 $base 切 $branch）"
+echo "→ ${pkgname}：${current} → ${next}（从 ${base} 切 ${branch}）"
 
 # ── 创建分支 + 改版本（仅替换首个 "version" 行，保证 1 行 diff）+ 提交 + 打 tag ──
 git checkout -b "$branch"


### PR DESCRIPTION
## What changed

- classify localhost HTTP reset/EOF/timeout as daemon unavailable
- require a real YoooClaw `/health` response before daemon startup succeeds
- clean locks transactionally when startup fails
- reject Linux/WSL zombie and PID-reuse locks using `/proc` identity checks
- revalidate daemon identity before restart, stop, or forced termination
- fix the release helper's variable expansion under `set -u`

## Root cause

The daemon lifecycle treated a live PID and a written lock as readiness. In WSL, persisted locks can outlive the distro process namespace, PIDs are reused, and zombies still pass signal-0 checks. Clients then sent HTTP to a stale endpoint and surfaced connection reset without allowing lifecycle recovery.

## Validation

- `go test ./...`
- `go test -race ./internal/daemon ./internal/cli ./yclib`
- `go vet ./...`
- GitHub release workflow passed Linux preflight, multi-platform builds, Apple signing/notarization, npm publish, and GitHub Release creation
- real daemon start, 100 status probes, and stop completed successfully

Released as `cli-v0.5.3`.
