### PR TITLE
docs: document Traditional Chinese ASR hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,9 +261,13 @@ yoooclaw notification stats --dim app --from 2026-05-26
 yoooclaw notification summary-job create --from 2026-06-01T00:00:00+08:00 --chunk-size 150  # Chunked summarization for large notification batches: create→next→commit→result
 yoooclaw recording list --status synced
 yoooclaw recording setup-asr --mode api --language auto --non-interactive
+yoooclaw recording setup-asr --mode api --language zh-TW --non-interactive   # Traditional Chinese / Taiwan hint
+yoooclaw recording setup-asr --mode api --language zh-Hant --non-interactive # Traditional Chinese script hint
 yoooclaw lightrule create --from-file -          # Submit a rule definition from stdin
 yoooclaw monitor create daily-standup --schedule "0 9 * * 1-5" --match-rules '{"keyword":"standup"}'
 ```
+
+For ASR language hints, `auto` keeps provider-side detection. Use `zh-TW` for Traditional Chinese in a Taiwan context, or `zh-Hant` when only the Traditional Chinese script preference matters.
 
 ### 3. Raw API
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -263,9 +263,13 @@ yoooclaw notification stats --dim app --from 2026-05-26
 yoooclaw notification summary-job create --from 2026-06-01T00:00:00+08:00 --chunk-size 150  # 大批量通知分片总结：create→next→commit→result
 yoooclaw recording list --status synced
 yoooclaw recording setup-asr --mode api --language auto --non-interactive
+yoooclaw recording setup-asr --mode api --language zh-TW --non-interactive   # 繁体中文 / 台湾语境提示
+yoooclaw recording setup-asr --mode api --language zh-Hant --non-interactive # 繁体中文脚本提示
 yoooclaw lightrule create --from-file -          # 从 stdin 提交规则定义
 yoooclaw monitor create daily-standup --schedule "0 9 * * 1-5" --match-rules '{"keyword":"standup"}'
 ```
+
+ASR 语言提示中，`auto` 表示保留 provider 侧自动识别；台湾繁体中文场景可使用 `zh-TW`，仅需指定繁体中文脚本时可使用 `zh-Hant`。
 
 ### 3. Raw API
 

--- a/internal/cli/cmd_recording.go
+++ b/internal/cli/cmd_recording.go
@@ -28,7 +28,7 @@ func newRecordingCmd() *cobra.Command {
 	setupAsr.Flags().String("mode", "", "api | local（默认 api）")
 	setupAsr.Flags().String("api-key", "", "api 模式：可选；留空则用 account ock- key")
 	setupAsr.Flags().String("endpoint", "", "api 模式：自定义 model-proxy 端点")
-	setupAsr.Flags().String("language", "", "api 模式：语言提示，如 zh / en / auto")
+	setupAsr.Flags().String("language", "", "api 模式：语言提示，如 auto / zh / zh-CN / zh-TW / zh-Hant / en")
 	setupAsr.Flags().String("model", "", "local 模式：Whisper 模型名")
 	setupAsr.Flags().Bool("non-interactive", false, "跳过向导，从参数构造配置")
 
@@ -189,7 +189,7 @@ func recordingSetupAsr(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any
 			if endpoint, err = prompt.Ask("model-proxy endpoint（留空走默认）", endpoint); err != nil {
 				return nil, err
 			}
-			if language, err = prompt.Ask("语言提示（zh / en / auto）", firstNonEmpty(language, "auto")); err != nil {
+			if language, err = prompt.Ask("语言提示（auto / zh / zh-CN / zh-TW / zh-Hant / en）", firstNonEmpty(language, "auto")); err != nil {
 				return nil, err
 			}
 		} else if mode == "local" {


### PR DESCRIPTION
## Summary

- Document `zh-TW` and `zh-Hant` as ASR language hints in the README examples.
- Expand `recording setup-asr --language` help text and interactive prompt examples to include Traditional Chinese values.
- Clarify when to use `zh-TW` versus `zh-Hant`.

## Context

This is a small first step for #34. The CLI already persists arbitrary `asr.api.language` values and accepts `zh-TW` via `recordings.asr.init`; this PR makes the supported Traditional Chinese hints discoverable from help text and docs.

It intentionally does not change App/cloud `recordings.result.write` behavior or add Simplified-to-Traditional post-processing.

## Verification

- `git diff --check`
- Static readback of changed README and CLI help strings
- `go test ./internal/cli` was not run because the local environment used for this PR does not have a Go toolchain installed (`SKIP_GO_TEST: go toolchain not installed`).

Closes #34? No — this only documents the CLI-side language hints; the end-to-end App/cloud path still needs follow-up.
