### PR TITLE
cli-0.6.0-beta.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ This repo ships a SKILL.md under [skills/](skills/) that teaches agents to call 
 | Skill                          | Description                                                                                                                                |
 | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | `yoooclaw-notification-query`  | Query/aggregate/summarize phone notifications: "show me recent notifications", "who's contacted me", "summarize the last N notifications". Small batches use `summary`, large batches use `summary-job`; disk-only, no daemon required |
-| `yoooclaw-lightrule-create`    | Create/manage persistent "notification → light effect" rules from natural language or stdin; the daemon evaluates and triggers light effects after ingest (🟡) |
+| `yoooclaw-lightrule-create`    | Create/manage persistent "notification → light effect" rules from natural language; rules are compiled, stored, and evaluated by the cloud Notification Intelligence Service |
 | `yoooclaw-tunnel-debug`        | Debug the phone-side push path: combine auth / daemon / tunnel / gateway status to pinpoint local config, ingest auth, and Relay WebSocket issues (🟡) |
 
 ```bash
@@ -263,7 +263,7 @@ yoooclaw recording list --status synced
 yoooclaw recording setup-asr --mode api --language auto --non-interactive
 yoooclaw recording setup-asr --mode api --language zh-TW --non-interactive   # Traditional Chinese / Taiwan hint
 yoooclaw recording setup-asr --mode api --language zh-Hant --non-interactive # Traditional Chinese script hint
-yoooclaw lightrule create --from-file -          # Submit a rule definition from stdin
+yoooclaw lightrule create --intent "Flash red when my boss messages me on WeChat"  # Compiled & stored by the cloud service
 yoooclaw monitor create daily-standup --schedule "0 9 * * 1-5" --match-rules '{"keyword":"standup"}'
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -133,7 +133,7 @@ npx skills@latest add YoooClaw/skills --skill yoooclaw-cli --global --agent clau
 | Skill                         | 说明                                                                                                            |
 | ----------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `yoooclaw-notification-query` | 查询/汇总/总结手机通知：「看看最近的通知」「谁找过我」「总结最近约 N 条通知」。小批量走 `summary`、大批量走 `summary-job`，纯读磁盘、不需要 daemon |
-| `yoooclaw-lightrule-create`   | 从自然语言或 stdin 创建/管理「通知 → 灯效」持久规则，由 daemon 在 ingest 后评估命中并触发灯效（🟡）             |
+| `yoooclaw-lightrule-create`   | 从自然语言创建/管理「通知 → 灯效」持久规则，由云端 Notification Intelligence Service 编译、存储并评估触发       |
 | `yoooclaw-tunnel-debug`       | 排查手机端推送链路：组合 auth / daemon / tunnel / gateway 状态定位本地配置、ingest 鉴权与 Relay WebSocket（🟡） |
 
 ```bash
@@ -265,7 +265,7 @@ yoooclaw recording list --status synced
 yoooclaw recording setup-asr --mode api --language auto --non-interactive
 yoooclaw recording setup-asr --mode api --language zh-TW --non-interactive   # 繁体中文 / 台湾语境提示
 yoooclaw recording setup-asr --mode api --language zh-Hant --non-interactive # 繁体中文脚本提示
-yoooclaw lightrule create --from-file -          # 从 stdin 提交规则定义
+yoooclaw lightrule create --intent "老板发微信时红灯快闪"   # 云端 Agent 编译并保存规则
 yoooclaw monitor create daily-standup --schedule "0 9 * * 1-5" --match-rules '{"keyword":"standup"}'
 ```
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -164,12 +164,36 @@ func TestLightSendValidation(t *testing.T) {
 	}
 }
 
+func TestLightruleCloudValidation(t *testing.T) {
+	sandbox(t)
+	// 以下用例都在本地参数校验阶段失败，不触达云端。
+	cases := []struct {
+		args     []string
+		wantCode string
+	}{
+		{[]string{"lightrule", "create"}, "YOOOCLAW_INVALID_ARGUMENT"},                                        // 缺 --intent
+		{[]string{"lightrule", "update", "r1"}, "YOOOCLAW_INVALID_ARGUMENT"},                                  // 无更新字段
+		{[]string{"lightrule", "update", "r1", "--intent", "改绿灯", "--title", "t"}, "YOOOCLAW_INVALID_ARGUMENT"}, // ruleText 与普通字段混用
+		{[]string{"lightrule", "update", "r1", "--repeat-times", "abc"}, "YOOOCLAW_INVALID_ARGUMENT"},
+		{[]string{"lightrule", "update", "r1", "--segments", `[{"mode":"nope"}]`}, "VALIDATION_FAILED"},
+	}
+	for _, tc := range cases {
+		out, code := execCLI(t, tc.args...)
+		if code == 0 {
+			t.Errorf("%v should fail", tc.args)
+			continue
+		}
+		if got := decode(t, out)["error"].(map[string]any)["code"]; got != tc.wantCode {
+			t.Errorf("%v expected %s, got %v: %s", tc.args, tc.wantCode, got, out)
+		}
+	}
+}
+
 func TestDaemonDependentCommandsWithoutDaemon(t *testing.T) {
 	sandbox(t)
-	// 这些 🟡 命令在 daemon 未运行时应统一报 DAEMON_NOT_RUNNING
+	// 这些 🟡 命令在 daemon 未运行时应统一报 DAEMON_NOT_RUNNING。
+	// （light/lightrule 自 daemonless 重构起直连本地文件与灯效云，不再在列。）
 	cases := [][]string{
-		{"light", "send", "--preset", "red-steady"},
-		{"lightrule", "list"},
 		{"tunnel", "status"},
 	}
 	for _, args := range cases {

--- a/internal/cli/cmd_daemon.go
+++ b/internal/cli/cmd_daemon.go
@@ -102,6 +102,11 @@ func daemonStart(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, erro
 		daemon.RemoveLock(ctx.Paths)
 	}
 	opts := startOptsFromCmd(cmd)
+	// detach 模式下子进程失败只会表现为"等 lock 超时"；先在父进程做
+	// 写者锁预检，把 YOOOCLAW_DAEMON_DISABLED_BY_PLUGIN 直接抛给调用方。
+	if err := daemon.PrecheckStart(ctx, opts); err != nil {
+		return nil, err
+	}
 	if flagBool(cmd, "no-detach") {
 		if err := daemon.RunForeground(ctx, opts); err != nil {
 			return nil, err

--- a/internal/cli/cmd_light.go
+++ b/internal/cli/cmd_light.go
@@ -2,20 +2,28 @@ package cli
 
 import (
 	"encoding/json"
-	"os"
 	"strconv"
 
 	"github.com/YoooClaw/cli/internal/clictx"
-	"github.com/YoooClaw/cli/internal/daemon"
+	"github.com/YoooClaw/cli/internal/creds"
 	"github.com/YoooClaw/cli/internal/errs"
+	"github.com/YoooClaw/cli/internal/light"
+	"github.com/YoooClaw/cli/internal/lightgw"
+	"github.com/YoooClaw/cli/internal/lightrule"
 	"github.com/YoooClaw/cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
+// 灯效命令与 openclaw plugin 的 Agent 工具同构，全部触发云端接口：
+// light send 打灯效下发 API，lightrule CRUD 打 Notification Intelligence
+// Service 的插件侧规则 API（见 internal/lightrule/client.go）。
+// 仅 +gateway（hermes 插件桥）保留本地规则文件形态，与 plugin 的
+// gateway 方法 / daemon HTTP 逐字节同构。
+
 // ── light ──
 
 func newLightCmd() *cobra.Command {
-	c := &cobra.Command{Use: "light", Short: "灯效硬件控制 🟡"}
+	c := &cobra.Command{Use: "light", Short: "灯效硬件控制（云端下发）"}
 
 	send := &cobra.Command{Use: "send", Short: "发送灯效指令到硬件（--segments / --preset / --rule 三选一）", Args: cobra.NoArgs, RunE: run(lightSend)}
 	send.Flags().String("segments", "", "灯效参数 JSON（原始段）")
@@ -26,7 +34,11 @@ func newLightCmd() *cobra.Command {
 
 	blink := &cobra.Command{Use: "+blink", Short: "灯效连通性测试（red-strobe-3）", Args: cobra.NoArgs, RunE: run(lightBlink)}
 
-	c.AddCommand(send, blink)
+	// （内部）hermes 插件桥的 gateway 入口：stdin 读参数 JSON，输出
+	// {"status":<http 状态码>,"body":<daemon HTTP 同构响应体>} envelope。
+	gateway := &cobra.Command{Use: "+gateway <method>", Hidden: true, Args: cobra.ExactArgs(1), RunE: run(lightGateway)}
+
+	c.AddCommand(send, blink, gateway)
 	return c
 }
 
@@ -47,7 +59,15 @@ func lightSend(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error)
 		body["preset"] = preset
 	}
 	if rule != "" {
-		body["rule"] = rule
+		// 规则存在云端，先解析成 segments 再下发（本地规则文件仅供 +gateway 兼容路径）。
+		resolved, err := lightruleFind(rule)
+		if err != nil {
+			return nil, err
+		}
+		body["segments"] = resolved["segments"]
+		if !flagBool(cmd, "repeat") && flagStr(cmd, "repeat-times") == "" {
+			body["repeat_times"] = resolved["repeat_times"]
+		}
 	}
 	if flagBool(cmd, "repeat") {
 		body["repeat"] = true
@@ -59,35 +79,86 @@ func lightSend(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error)
 		}
 		body["repeat_times"] = n
 	}
-	c, err := daemonProxy(ctx)
-	if err != nil {
-		return nil, err
-	}
-	_, resBody, err := c.Request("POST", "/light/send", body)
-	return resBody, err
+	return lightSendDirect(ctx, body)
 }
 
 func lightBlink(ctx *clictx.Context, _ *cobra.Command, _ []string) (any, error) {
-	c, err := daemonProxy(ctx)
+	return lightSendDirect(ctx, map[string]any{"preset": "red-strobe-3"})
+}
+
+func lightSendDirect(ctx *clictx.Context, body map[string]any) (any, error) {
+	result, gerr := lightgw.Send(ctx.Paths.LightRules, body, creds.ResolveAPIKey().Value, noopLightLogger{})
+	if gerr != nil {
+		return nil, errs.New(gerr.Code, gerr.Message)
+	}
+	return result, nil
+}
+
+// lightGateway 是插件桥的子进程入口：与 daemon 对同一 method 的 HTTP 响应
+// 逐字节同构（status + body），插件侧零适配转发。
+func lightGateway(ctx *clictx.Context, _ *cobra.Command, args []string) (any, error) {
+	raw, err := prompt.ReadStdin()
 	if err != nil {
 		return nil, err
 	}
-	_, resBody, err := c.Request("POST", "/light/send", map[string]any{"preset": "red-strobe-3"})
-	return resBody, err
+	body := map[string]any{}
+	if raw != "" {
+		if json.Unmarshal([]byte(raw), &body) != nil {
+			return nil, errs.New(errs.CodeInvalidArgument, "stdin 参数不是合法 JSON 对象")
+		}
+	}
+	method := args[0]
+	if method == "light.send" {
+		result, gerr := lightgw.Send(ctx.Paths.LightRules, body, creds.ResolveAPIKey().Value, noopLightLogger{})
+		if gerr != nil {
+			status := gerr.Status
+			if status == 0 {
+				status = 400
+			}
+			return gatewayEnvelope(status, gatewayErrBody(gerr)), nil
+		}
+		return gatewayEnvelope(200, result), nil
+	}
+	payload, gerr := lightgw.Rules(ctx.Paths.LightRules, method, body)
+	if gerr != nil {
+		if gerr.Status == 404 {
+			return gatewayEnvelope(404, gatewayErrBody(gerr)), nil
+		}
+		return gatewayEnvelope(200, gatewayErrBody(gerr)), nil
+	}
+	return gatewayEnvelope(200, map[string]any{"ok": true, "data": payload}), nil
 }
 
-// ── lightrule ──
+func gatewayEnvelope(status int, body any) map[string]any {
+	return map[string]any{"ok": true, "status": status, "body": body}
+}
+
+func gatewayErrBody(gerr *lightgw.Err) map[string]any {
+	return map[string]any{"ok": false, "error": map[string]any{"code": gerr.Code, "message": gerr.Message}}
+}
+
+type noopLightLogger struct{}
+
+func (noopLightLogger) Info(string) {}
+func (noopLightLogger) Warn(string) {}
+
+// ── lightrule（云端 Notification Intelligence Service）──
 
 func newLightruleCmd() *cobra.Command {
-	c := &cobra.Command{Use: "lightrule", Short: "灯效规则管理 🟡"}
+	c := &cobra.Command{Use: "lightrule", Short: "灯效规则管理（云端）"}
 
-	list := &cobra.Command{Use: "list", Short: "列出所有规则及状态", Args: cobra.NoArgs, RunE: run(lightruleList)}
+	list := &cobra.Command{Use: "list", Short: "列出云端所有规则及状态", Args: cobra.NoArgs, RunE: run(lightruleList)}
 	show := &cobra.Command{Use: "show <id>", Short: "查看单条规则详情", Args: cobra.ExactArgs(1), RunE: run(lightruleShow)}
 
-	create := &cobra.Command{Use: "create", Short: "创建规则（--from-file / --intent ...）", Args: cobra.NoArgs, RunE: run(lightruleCreate)}
-	addRuleFlags(create)
-	update := &cobra.Command{Use: "update <id>", Short: "更新现有规则", Args: cobra.ExactArgs(1), RunE: run(lightruleUpdate)}
-	addRuleFlags(update)
+	create := &cobra.Command{Use: "create", Short: "创建规则（--intent 自然语言，云端 Agent 编译）", Args: cobra.NoArgs, RunE: run(lightruleCreate)}
+	create.Flags().String("intent", "", "自然语言规则，例如“老板发微信时红灯快闪”")
+	update := &cobra.Command{Use: "update <id>", Short: "更新规则（--intent 重编译，或 --title/--description/--segments/--repeat-times 局部更新）", Args: cobra.ExactArgs(1), RunE: run(lightruleUpdate)}
+	update.Flags().String("intent", "", "新的自然语言规则，传入后由云端 Agent 重编译（不能与其他字段混用）")
+	update.Flags().String("title", "", "新的展示名/短标题")
+	update.Flags().String("description", "", "新的触发条件描述")
+	update.Flags().String("segments", "", "新的灯效段序列 JSON")
+	update.Flags().Bool("repeat", false, "无限循环播放")
+	update.Flags().String("repeat-times", "", "重复次数（0=无限，1=一轮）")
 
 	del := &cobra.Command{Use: "delete <id>", Short: "删除规则（--yes）", Args: cobra.ExactArgs(1), RunE: run(lightruleDelete)}
 	del.Flags().Bool("yes", false, "跳过确认")
@@ -101,159 +172,131 @@ func newLightruleCmd() *cobra.Command {
 	return c
 }
 
-func addRuleFlags(c *cobra.Command) {
-	c.Flags().String("from-file", "", "从 JSON 读规则（- 为 stdin）")
-	c.Flags().String("name", "", "规则名")
-	c.Flags().String("intent", "", "自然语言意图描述")
-	c.Flags().String("light-action", "", "命中后的 light 动作 JSON")
-	c.Flags().String("match-rules", "", "前置硬过滤规则 JSON")
+func lightruleClient() *lightrule.Client {
+	return &lightrule.Client{APIKey: creds.ResolveAPIKey().Value, Logger: noopLightLogger{}}
 }
 
-func lightruleListRules(c *daemon.Client) ([]any, error) {
-	_, body, err := c.Request("POST", "/gateway/lightrules.list", map[string]any{})
-	if err != nil {
-		return nil, err
+// lightruleErr 把云端 APIError 转成 CLI 结构化错误（code 原样透传）。
+func lightruleErr(err error) error {
+	if e, ok := err.(*lightrule.APIError); ok {
+		return errs.New(e.Code, e.Message)
 	}
-	if m, ok := body.(map[string]any); ok {
-		if data, ok := m["data"].(map[string]any); ok {
-			if rules, ok := data["rules"].([]any); ok {
-				return rules, nil
-			}
+	return err
+}
+
+// lightruleFind 按 id/name 从云端解析单条规则。
+func lightruleFind(id string) (map[string]any, error) {
+	rules, err := lightruleClient().List()
+	if err != nil {
+		return nil, lightruleErr(err)
+	}
+	for _, rule := range rules {
+		if rule["id"] == id || rule["name"] == id {
+			return rule, nil
 		}
 	}
-	return []any{}, nil
+	return nil, errs.New(errs.CodeNotFound, "灯效规则不存在："+id)
 }
 
-func lightruleList(ctx *clictx.Context, _ *cobra.Command, _ []string) (any, error) {
-	c, err := daemonProxy(ctx)
+func lightruleList(_ *clictx.Context, _ *cobra.Command, _ []string) (any, error) {
+	rules, err := lightruleClient().List()
 	if err != nil {
-		return nil, err
-	}
-	rules, err := lightruleListRules(c)
-	if err != nil {
-		return nil, err
+		return nil, lightruleErr(err)
 	}
 	return map[string]any{"ok": true, "rules": rules}, nil
 }
 
-func lightruleShow(ctx *clictx.Context, _ *cobra.Command, args []string) (any, error) {
-	c, err := daemonProxy(ctx)
+func lightruleShow(_ *clictx.Context, _ *cobra.Command, args []string) (any, error) {
+	rule, err := lightruleFind(args[0])
 	if err != nil {
 		return nil, err
 	}
-	rules, err := lightruleListRules(c)
-	if err != nil {
-		return nil, err
-	}
-	id := args[0]
-	for _, r := range rules {
-		if m, ok := r.(map[string]any); ok && (m["id"] == id || m["name"] == id) {
-			return map[string]any{"ok": true, "rule": m}, nil
-		}
-	}
-	return nil, errs.New(errs.CodeNotFound, "规则不存在："+id)
+	return map[string]any{"ok": true, "rule": rule}, nil
 }
 
-func buildRuleParams(cmd *cobra.Command, name string) (map[string]any, error) {
-	if ff := flagStr(cmd, "from-file"); ff != "" {
-		var raw string
-		if ff == "-" {
-			s, err := prompt.ReadStdin()
-			if err != nil {
-				return nil, err
-			}
-			raw = s
-		} else {
-			b, err := os.ReadFile(ff)
-			if err != nil {
-				return nil, errs.New(errs.CodeInvalidArgument, "无法读取文件："+ff)
-			}
-			raw = string(b)
-		}
-		var m map[string]any
-		if json.Unmarshal([]byte(raw), &m) != nil {
-			return nil, errs.New(errs.CodeInvalidArgument, "--from-file 内容不是合法 JSON 对象")
-		}
-		return m, nil
+func lightruleCreate(_ *clictx.Context, cmd *cobra.Command, _ []string) (any, error) {
+	intent := flagStr(cmd, "intent")
+	if intent == "" {
+		return nil, errs.New(errs.CodeInvalidArgument, "需要 --intent（自然语言规则，云端 Agent 编译）")
 	}
+	result, err := lightruleClient().Create(intent)
+	if err != nil {
+		return nil, lightruleErr(err)
+	}
+	result["ok"] = true
+	return result, nil
+}
 
-	params := map[string]any{}
-	if name != "" {
-		params["name"] = name
+// buildRulePatch 组装云端 PATCH 体：--intent（ruleText 重编译）与普通字段互斥；
+// segments 本地先过 light.ValidateSegments，repeat/repeat-times 归一化成 repeat_times。
+func buildRulePatch(cmd *cobra.Command) (map[string]any, error) {
+	patch := map[string]any{}
+	if title := flagStr(cmd, "title"); title != "" {
+		patch["title"] = title
 	}
-	if n := flagStr(cmd, "name"); n != "" {
-		params["name"] = n
+	if desc := flagStr(cmd, "description"); desc != "" {
+		patch["description"] = desc
+	}
+	if segs := flagStr(cmd, "segments"); segs != "" {
+		v, err := parseJSONArg(segs, "--segments")
+		if err != nil {
+			return nil, err
+		}
+		res := light.ValidateSegments(v)
+		if !res.Valid {
+			data, _ := json.Marshal(res.Errors)
+			return nil, errs.New("VALIDATION_FAILED", string(data))
+		}
+		patch["segments"] = res.Segments
+	}
+	if flagBool(cmd, "repeat") || flagStr(cmd, "repeat-times") != "" {
+		var repeatTimes any
+		if rt := flagStr(cmd, "repeat-times"); rt != "" {
+			n, err := strconv.ParseFloat(rt, 64)
+			if err != nil {
+				return nil, errs.New(errs.CodeInvalidArgument, "--repeat-times 必须是数字")
+			}
+			repeatTimes = n
+		}
+		var repeat any
+		if flagBool(cmd, "repeat") {
+			repeat = true
+		}
+		normalized, err := light.NormalizeRepeatTimes(light.RepeatInputFromAny(repeat, repeatTimes))
+		if err == nil {
+			err = light.AssertAncsRepeatTimes(normalized)
+		}
+		if err != nil {
+			return nil, errs.New("VALIDATION_FAILED", err.Error())
+		}
+		patch["repeat_times"] = float64(normalized)
 	}
 	if intent := flagStr(cmd, "intent"); intent != "" {
-		params["description"] = intent
-	}
-	if la := flagStr(cmd, "light-action"); la != "" {
-		action, err := parseJSONArg(la, "--light-action")
-		if err != nil {
-			return nil, err
+		if len(patch) > 0 {
+			return nil, errs.New(errs.CodeInvalidArgument, "--intent 不能与 --title/--description/--segments/--repeat-times 混用")
 		}
-		params["segments"] = segmentsFromAction(action)
+		patch["ruleText"] = intent
 	}
-	if mr := flagStr(cmd, "match-rules"); mr != "" {
-		match, err := parseJSONArg(mr, "--match-rules")
-		if err != nil {
-			return nil, err
-		}
-		params["matchRules"] = match
+	if len(patch) == 0 {
+		return nil, errs.New(errs.CodeInvalidArgument, "至少提供一个更新字段")
 	}
-	return params, nil
+	return patch, nil
 }
 
-// segmentsFromAction 对齐 TS：数组直接用；对象取 .segments，缺省回退整体。
-func segmentsFromAction(action any) any {
-	if _, ok := action.([]any); ok {
-		return action
+func lightruleUpdate(_ *clictx.Context, cmd *cobra.Command, args []string) (any, error) {
+	patch, err := buildRulePatch(cmd)
+	if err != nil {
+		return nil, err
 	}
-	if obj, ok := action.(map[string]any); ok {
-		if segs, ok := obj["segments"]; ok {
-			return segs
-		}
+	result, err := lightruleClient().Update(args[0], patch)
+	if err != nil {
+		return nil, lightruleErr(err)
 	}
-	return action
+	result["ok"] = true
+	return result, nil
 }
 
-func lightruleCreate(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error) {
-	c, err := daemonProxy(ctx)
-	if err != nil {
-		return nil, err
-	}
-	params, err := buildRuleParams(cmd, "")
-	if err != nil {
-		return nil, err
-	}
-	_, body, err := c.Request("POST", "/gateway/lightrules.create", params)
-	if err != nil {
-		return nil, err
-	}
-	if m, ok := body.(map[string]any); !ok || m["ok"] == false {
-		return nil, errs.New(errs.CodeInvalidArgument, createErrorMessage(body))
-	}
-	return dataOrBody(body), nil
-}
-
-func lightruleUpdate(ctx *clictx.Context, cmd *cobra.Command, args []string) (any, error) {
-	c, err := daemonProxy(ctx)
-	if err != nil {
-		return nil, err
-	}
-	params, err := buildRuleParams(cmd, args[0])
-	if err != nil {
-		return nil, err
-	}
-	params["name"] = args[0]
-	_, body, err := c.Request("POST", "/gateway/lightrules.update", params)
-	if err != nil {
-		return nil, err
-	}
-	return dataOrBody(body), nil
-}
-
-func lightruleDelete(ctx *clictx.Context, cmd *cobra.Command, args []string) (any, error) {
+func lightruleDelete(_ *clictx.Context, cmd *cobra.Command, args []string) (any, error) {
 	if !flagBool(cmd, "yes") {
 		ok, err := prompt.Confirm("确认删除规则 `"+args[0]+"`？", false)
 		if err != nil {
@@ -263,85 +306,51 @@ func lightruleDelete(ctx *clictx.Context, cmd *cobra.Command, args []string) (an
 			return nil, errs.New(errs.CodeConfirmationRequired, "已取消")
 		}
 	}
-	c, err := daemonProxy(ctx)
+	result, err := lightruleClient().Delete(args[0])
 	if err != nil {
-		return nil, err
+		return nil, lightruleErr(err)
 	}
-	_, body, err := c.Request("POST", "/gateway/lightrules.delete", map[string]any{"name": args[0]})
+	result["ok"] = true
+	result["deleted"] = true
+	return result, nil
+}
+
+func lightruleEnable(_ *clictx.Context, _ *cobra.Command, args []string) (any, error) {
+	return lightruleSetEnabled(args[0], true)
+}
+
+func lightruleDisable(_ *clictx.Context, _ *cobra.Command, args []string) (any, error) {
+	return lightruleSetEnabled(args[0], false)
+}
+
+func lightruleSetEnabled(id string, enabled bool) (any, error) {
+	result, err := lightruleClient().Update(id, map[string]any{"enabled": enabled})
 	if err != nil {
-		return nil, err
+		return nil, lightruleErr(err)
 	}
-	return dataOrBody(body), nil
+	result["ok"] = true
+	return result, nil
 }
 
-func lightruleEnable(ctx *clictx.Context, _ *cobra.Command, args []string) (any, error) {
-	return lightruleSetEnabled(ctx, args[0], true)
+func lightruleOn(_ *clictx.Context, _ *cobra.Command, _ []string) (any, error) {
+	return lightruleToggleAll(true)
 }
 
-func lightruleDisable(ctx *clictx.Context, _ *cobra.Command, args []string) (any, error) {
-	return lightruleSetEnabled(ctx, args[0], false)
+func lightruleOff(_ *clictx.Context, _ *cobra.Command, _ []string) (any, error) {
+	return lightruleToggleAll(false)
 }
 
-func lightruleSetEnabled(ctx *clictx.Context, id string, enabled bool) (any, error) {
-	c, err := daemonProxy(ctx)
+func lightruleToggleAll(enabled bool) (any, error) {
+	client := lightruleClient()
+	rules, err := client.List()
 	if err != nil {
-		return nil, err
-	}
-	_, body, err := c.Request("POST", "/gateway/lightrules.update", map[string]any{"name": id, "enabled": enabled})
-	if err != nil {
-		return nil, err
-	}
-	return dataOrBody(body), nil
-}
-
-func lightruleOn(ctx *clictx.Context, _ *cobra.Command, _ []string) (any, error) {
-	return lightruleToggleAll(ctx, true)
-}
-
-func lightruleOff(ctx *clictx.Context, _ *cobra.Command, _ []string) (any, error) {
-	return lightruleToggleAll(ctx, false)
-}
-
-func lightruleToggleAll(ctx *clictx.Context, enabled bool) (any, error) {
-	c, err := daemonProxy(ctx)
-	if err != nil {
-		return nil, err
-	}
-	rules, err := lightruleListRules(c)
-	if err != nil {
-		return nil, err
+		return nil, lightruleErr(err)
 	}
 	results := make([]any, 0, len(rules))
-	for _, r := range rules {
-		m, _ := r.(map[string]any)
-		name := m["name"]
-		_, body, err := c.Request("POST", "/gateway/lightrules.update", map[string]any{"name": name, "enabled": enabled})
-		ok := err == nil
-		if bm, isMap := body.(map[string]any); isMap && bm["ok"] == false {
-			ok = false
-		}
-		results = append(results, map[string]any{"name": name, "ok": ok})
+	for _, rule := range rules {
+		id, _ := rule["id"].(string)
+		_, updateErr := client.Update(id, map[string]any{"enabled": enabled})
+		results = append(results, map[string]any{"id": id, "name": rule["name"], "ok": updateErr == nil})
 	}
 	return map[string]any{"ok": true, "enabled": enabled, "count": len(results), "results": results}, nil
-}
-
-// dataOrBody 返回 gateway 响应里的 data；缺省回退整个 body。
-func dataOrBody(body any) any {
-	if m, ok := body.(map[string]any); ok {
-		if data, ok := m["data"]; ok {
-			return data
-		}
-	}
-	return body
-}
-
-func createErrorMessage(body any) string {
-	if m, ok := body.(map[string]any); ok {
-		if e, ok := m["error"]; ok {
-			data, _ := json.Marshal(e)
-			return string(data)
-		}
-	}
-	data, _ := json.Marshal(body)
-	return string(data)
 }

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -90,6 +90,13 @@ func RunForeground(ctx *clictx.Context, opts StartOpts) error {
 		return errs.New(errs.CodeUnauthorized, "proxied 模式需要至少一个 api-key 供宿主推送鉴权").
 			WithHint("先设置 api-key，或改用 --ingress=standalone")
 	}
+	// standalone daemon 与 hermes 插件的存储写者锁互斥（daemonless plugin
+	// mode）；proxied 模式豁免——那是插件自己托管的 daemon。
+	if mode != config.IngressProxied {
+		if err := checkWriterLock(ctx.Paths); err != nil {
+			return err
+		}
+	}
 
 	storage := notif.NewStorage(ctx.Paths.Notifications, notif.PluginConfig{
 		RetentionDays: cfg.Notification.RetentionDays, IgnoredApps: cfg.Notification.IgnoredApps,

--- a/internal/daemon/server_light.go
+++ b/internal/daemon/server_light.go
@@ -1,191 +1,62 @@
 package daemon
 
 import (
-	"encoding/json"
 	"net/http"
 	"strings"
 
 	"github.com/YoooClaw/cli/internal/creds"
-	"github.com/YoooClaw/cli/internal/light"
-	"github.com/YoooClaw/cli/internal/lightrule"
+	"github.com/YoooClaw/cli/internal/lightgw"
 )
 
-// handleLightSend 处理 POST /light/send：segments / preset / rule 三选一，编码后下发灯效云 API。
+// handleLightSend 处理 POST /light/send：核心逻辑在 lightgw.Send（与 CLI 共用）。
 func (s *server) handleLightSend(w http.ResponseWriter, r *http.Request) {
 	var body map[string]any
 	if !decodeBody(w, r, &body) {
 		return
 	}
-
-	repeatInput := light.RepeatInputFromAny(body["repeat"], body["repeat_times"])
-	reason, _ := body["reason"].(string)
-	title, _ := body["title"].(string)
-
-	var segments []map[string]any
-	switch {
-	case body["segments"] != nil:
-		res := light.ValidateSegments(body["segments"])
-		if !res.Valid {
-			writeJSON(w, 400, errBody("VALIDATION_FAILED", validationMessage(res)))
-			return
+	apiKey := creds.ResolveAPIKey().Value
+	result, gerr := lightgw.Send(s.ctx.Paths.LightRules, body, apiKey, s.logger)
+	if gerr != nil {
+		status := gerr.Status
+		if status == 0 {
+			status = 400
 		}
-		segments = res.Segments
-	case asString(body["preset"]) != "":
-		preset, ok := light.LookupPreset(asString(body["preset"]))
-		if !ok {
-			writeJSON(w, 404, errBody("YOOOCLAW_NOT_FOUND", "未知预设："+asString(body["preset"])))
-			return
-		}
-		segments = preset.Segments
-		if body["repeat"] == nil && body["repeat_times"] == nil {
-			rt := float64(preset.RepeatTimes)
-			repeatInput = light.RepeatInput{RepeatTimes: &rt}
-		}
-	case asString(body["rule"]) != "":
-		rule := lightrule.Get(s.ctx.Paths.LightRules, asString(body["rule"]))
-		if rule == nil {
-			writeJSON(w, 404, errBody("YOOOCLAW_NOT_FOUND", "灯效规则不存在："+asString(body["rule"])))
-			return
-		}
-		segments = rule.Segments
-		if body["repeat"] == nil && body["repeat_times"] == nil {
-			rt := float64(rule.RepeatTimes)
-			repeatInput = light.RepeatInput{RepeatTimes: &rt}
-		}
-	default:
-		writeJSON(w, 400, errBody("INVALID_PARAMS", "需要 segments / preset / rule 之一"))
+		writeJSON(w, status, errBody(gerr.Code, gerr.Message))
 		return
 	}
-
-	apiKey := creds.ResolveAPIKey().Value
-	result := light.SendLightEffect(apiKey, segments, repeatInput, reason, title, s.logger)
 	writeJSON(w, 200, result)
 }
 
-// handleLightrules 处理 /gateway/lightrules.{list,create,update,delete}。
+// handleLightrules 处理 /gateway/lightrules.{list,create,update,delete}：
+// 核心逻辑在 lightgw.Rules（与 CLI 共用），此处只做 HTTP 壳与日志。
 func (s *server) handleLightrules(w http.ResponseWriter, r *http.Request, path string) {
 	if r.Method != http.MethodPost {
 		writeJSON(w, 404, errBody("YOOOCLAW_NOT_FOUND", "未知路径："+path))
 		return
 	}
-	method := strings.TrimPrefix(path, "/gateway/")
-	base := s.ctx.Paths.LightRules
-
-	switch method {
-	case "lightrules.list":
-		rules := []map[string]any{}
-		for _, m := range lightrule.List(base) {
-			rm := metaToMap(m)
-			rm["id"] = m.Name
-			rules = append(rules, rm)
-		}
-		gatewayOK(w, map[string]any{"ok": true, "rules": rules})
-
-	case "lightrules.create":
-		var body map[string]any
-		if !decodeBody(w, r, &body) {
-			return
-		}
-		name := asString(body["name"])
-		if name == "" {
-			gatewayErr(w, "INVALID_PARAMS", "name is required")
-			return
-		}
-		description := asString(body["description"])
-		if description == "" {
-			gatewayErr(w, "INVALID_PARAMS", "description is required")
-			return
-		}
-		title := strings.TrimSpace(asString(body["title"]))
-		if title == "" {
-			title = name
-		}
-		res := light.ValidateSegments(body["segments"])
-		if !res.Valid {
-			gatewayErr(w, "VALIDATION_FAILED", validationErrorsJSON(res))
-			return
-		}
-		meta, err := lightrule.Create(base, lightrule.CreateParams{
-			Name: name, Title: title, Description: description, Segments: res.Segments,
-			Repeat: boolPtrFromAny(body["repeat"]), RepeatTimes: floatPtrFromAny(body["repeat_times"]),
-		})
-		if err != nil {
-			gatewayRuleErr(w, err)
-			return
-		}
-		s.logger.Info("Light rule created: " + name)
-		gatewayOK(w, map[string]any{"ok": true, "id": meta.Name, "name": meta.Name, "title": meta.Title, "rule": metaToMap(*meta)})
-
-	case "lightrules.update":
-		var body map[string]any
-		if !decodeBody(w, r, &body) {
-			return
-		}
-		name := resolveRuleIdentifier(body)
-		if name == "" {
-			gatewayErr(w, "INVALID_PARAMS", "name is required (or provide id/ruleId/ruleName)")
-			return
-		}
-		params := lightrule.UpdateParams{
-			Name:        name,
-			Repeat:      boolPtrFromAny(body["repeat"]),
-			RepeatTimes: floatPtrFromAny(body["repeat_times"]),
-			Enabled:     boolPtrFromAny(body["enabled"]),
-		}
-		if raw, ok := body["title"]; ok {
-			t := strings.TrimSpace(asString(raw))
-			if t == "" {
-				gatewayErr(w, "INVALID_PARAMS", "title must be a non-empty string")
-				return
-			}
-			params.Title = &t
-		}
-		if raw, ok := body["description"]; ok {
-			d, isStr := raw.(string)
-			if !isStr {
-				gatewayErr(w, "INVALID_PARAMS", "description must be a string")
-				return
-			}
-			params.Description = &d
-		}
-		if body["segments"] != nil {
-			res := light.ValidateSegments(body["segments"])
-			if !res.Valid {
-				gatewayErr(w, "VALIDATION_FAILED", validationErrorsJSON(res))
-				return
-			}
-			params.Segments = res.Segments
-			params.HasSegments = true
-		}
-		meta, err := lightrule.Update(base, params)
-		if err != nil {
-			gatewayRuleErr(w, err)
-			return
-		}
-		s.logger.Info("Light rule updated: " + name)
-		gatewayOK(w, map[string]any{"ok": true, "id": meta.Name, "name": meta.Name, "title": meta.Title, "updated": true, "rule": metaToMap(*meta)})
-
-	case "lightrules.delete":
-		var body map[string]any
-		if !decodeBody(w, r, &body) {
-			return
-		}
-		name := resolveRuleIdentifier(body)
-		if name == "" {
-			gatewayErr(w, "INVALID_PARAMS", "name is required (or provide id/ruleId/ruleName)")
-			return
-		}
-		deleted, err := lightrule.Delete(base, name)
-		if err != nil {
-			gatewayRuleErr(w, err)
-			return
-		}
-		s.logger.Info("Light rule deleted: " + deleted)
-		gatewayOK(w, map[string]any{"ok": true, "id": deleted, "name": deleted, "deleted": true})
-
-	default:
-		writeJSON(w, 404, errBody("YOOOCLAW_NOT_FOUND", "未知路径："+path))
+	var body map[string]any
+	if !decodeBody(w, r, &body) {
+		return
 	}
+	method := strings.TrimPrefix(path, "/gateway/")
+	payload, gerr := lightgw.Rules(s.ctx.Paths.LightRules, method, body)
+	if gerr != nil {
+		if gerr.Status == 404 {
+			writeJSON(w, 404, errBody(gerr.Code, gerr.Message))
+			return
+		}
+		gatewayErr(w, gerr.Code, gerr.Message)
+		return
+	}
+	switch method {
+	case "lightrules.create":
+		s.logger.Info("Light rule created: " + asString(payload["name"]))
+	case "lightrules.update":
+		s.logger.Info("Light rule updated: " + asString(payload["name"]))
+	case "lightrules.delete":
+		s.logger.Info("Light rule deleted: " + asString(payload["name"]))
+	}
+	gatewayOK(w, payload)
 }
 
 // gatewayOK / gatewayErr 统一 gateway 响应外壳：CLI 读取 res.body.data。
@@ -197,64 +68,7 @@ func gatewayErr(w http.ResponseWriter, code, message string) {
 	writeJSON(w, 200, map[string]any{"ok": false, "error": map[string]any{"code": code, "message": message}})
 }
 
-func gatewayRuleErr(w http.ResponseWriter, err error) {
-	if e, ok := err.(*lightrule.Error); ok {
-		gatewayErr(w, e.Code, e.Message)
-		return
-	}
-	gatewayErr(w, "INTERNAL_ERROR", err.Error())
-}
-
-func resolveRuleIdentifier(body map[string]any) string {
-	for _, key := range []string{"name", "id", "ruleId", "ruleName"} {
-		if s := asString(body[key]); s != "" {
-			n := strings.TrimSpace(s)
-			if strings.HasSuffix(strings.ToLower(n), ".json") {
-				n = n[:len(n)-len(".json")]
-			}
-			if n != "" {
-				return n
-			}
-		}
-	}
-	return ""
-}
-
-func metaToMap(m lightrule.Meta) map[string]any {
-	data, _ := json.Marshal(m)
-	var out map[string]any
-	_ = json.Unmarshal(data, &out)
-	return out
-}
-
-func validationMessage(res light.ValidationResult) string {
-	parts := make([]string, len(res.Errors))
-	for i, e := range res.Errors {
-		parts[i] = e.Field + ": " + e.Message
-	}
-	return strings.Join(parts, "; ")
-}
-
-func validationErrorsJSON(res light.ValidationResult) string {
-	data, _ := json.Marshal(res.Errors)
-	return string(data)
-}
-
 func asString(v any) string {
 	s, _ := v.(string)
 	return s
-}
-
-func boolPtrFromAny(v any) *bool {
-	if b, ok := v.(bool); ok {
-		return &b
-	}
-	return nil
-}
-
-func floatPtrFromAny(v any) *float64 {
-	if f, ok := v.(float64); ok {
-		return &f
-	}
-	return nil
 }

--- a/internal/daemon/writerlock.go
+++ b/internal/daemon/writerlock.go
@@ -1,0 +1,66 @@
+package daemon
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/YoooClaw/cli/internal/clictx"
+	"github.com/YoooClaw/cli/internal/config"
+	"github.com/YoooClaw/cli/internal/errs"
+	"github.com/YoooClaw/cli/internal/paths"
+)
+
+// writerLockFileName 是 hermes 插件的 profile 写者锁文件名。
+// 插件模式下插件直写通知存储并全程持有该锁（OS 建议锁，进程退出自动释放）；
+// standalone daemon 与插件互斥，启动前必须探测。
+const writerLockFileName = "writer.lock"
+
+// PrecheckStart 在 spawn / 前台运行前做启动前校验：standalone（非 proxied）
+// 模式与 hermes 插件的写者锁互斥。proxied 模式豁免——那是插件自己托管的
+// daemon，不写通知、不拨隧道。
+func PrecheckStart(ctx *clictx.Context, opts StartOpts) error {
+	cfg, err := config.Load(ctx.Paths)
+	if err != nil {
+		return err
+	}
+	if resolveIngressMode(opts, cfg) == config.IngressProxied {
+		return nil
+	}
+	return checkWriterLock(ctx.Paths)
+}
+
+// checkWriterLock 探测写者锁；被其他进程持有时返回结构化错误。
+// 探测本身出错（权限等）按未持有处理——诊断逻辑不能把 daemon 卡死。
+func checkWriterLock(p paths.Paths) error {
+	path := filepath.Join(p.Dir, writerLockFileName)
+	held, err := probeFileLock(path)
+	if err != nil || !held {
+		return nil
+	}
+	return errs.New(errs.CodeDaemonDisabledByPlugin,
+		"通知存储由 "+writerLockOwnerHint(path)+" 独占，standalone daemon 已禁用").
+		WithHint("停用 hermes 插件后重试；插件运行期间的通知采集由插件直写完成")
+}
+
+// writerLockOwnerHint 读取锁文件元数据拼诊断信息；内容仅供展示，
+// 互斥语义完全由 OS 锁保证。
+func writerLockOwnerHint(path string) string {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "hermes 插件"
+	}
+	var meta struct {
+		Owner string `json:"owner"`
+		PID   int    `json:"pid"`
+	}
+	if json.Unmarshal(raw, &meta) != nil || meta.Owner == "" {
+		return "hermes 插件"
+	}
+	hint := meta.Owner
+	if meta.PID > 0 {
+		hint += " (pid " + strconv.Itoa(meta.PID) + ")"
+	}
+	return hint
+}

--- a/internal/daemon/writerlock_unix.go
+++ b/internal/daemon/writerlock_unix.go
@@ -1,0 +1,31 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"syscall"
+)
+
+// probeFileLock 非阻塞探测 flock：拿得到（随即释放）或文件不存在 → 未被持有。
+// 与插件侧 writer_lock.py 的 fcntl.flock(LOCK_EX) 同一锁命名空间。
+func probeFileLock(path string) (bool, error) {
+	f, err := os.OpenFile(path, os.O_RDONLY, 0)
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			return true, nil
+		}
+		return false, err
+	}
+	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	return false, nil
+}

--- a/internal/daemon/writerlock_unix_test.go
+++ b/internal/daemon/writerlock_unix_test.go
@@ -1,0 +1,76 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/YoooClaw/cli/internal/errs"
+	"github.com/YoooClaw/cli/internal/paths"
+)
+
+func TestProbeFileLockMissingFile(t *testing.T) {
+	held, err := probeFileLock(filepath.Join(t.TempDir(), "writer.lock"))
+	if err != nil || held {
+		t.Fatalf("missing lock file should be not-held, got held=%v err=%v", held, err)
+	}
+}
+
+func TestProbeFileLockHeldAndReleased(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "writer.lock")
+	if err := os.WriteFile(path, []byte(`{"owner":"hermes-plugin","pid":123}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	holder, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer holder.Close()
+	// flock 以 open file description 为粒度：同进程另一个 fd 也会冲突，
+	// 因此可以进程内模拟"插件持锁"。
+	if err := syscall.Flock(int(holder.Fd()), syscall.LOCK_EX); err != nil {
+		t.Fatal(err)
+	}
+
+	held, err := probeFileLock(path)
+	if err != nil || !held {
+		t.Fatalf("expected held=true, got held=%v err=%v", held, err)
+	}
+
+	if err := syscall.Flock(int(holder.Fd()), syscall.LOCK_UN); err != nil {
+		t.Fatal(err)
+	}
+	held, err = probeFileLock(path)
+	if err != nil || held {
+		t.Fatalf("expected held=false after unlock, got held=%v err=%v", held, err)
+	}
+}
+
+func TestCheckWriterLockReturnsStructuredError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "writer.lock")
+	if err := os.WriteFile(path, []byte(`{"owner":"hermes-plugin","pid":42}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	holder, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer holder.Close()
+	if err := syscall.Flock(int(holder.Fd()), syscall.LOCK_EX); err != nil {
+		t.Fatal(err)
+	}
+
+	checkErr := checkWriterLock(paths.Paths{Dir: dir})
+	if checkErr == nil {
+		t.Fatal("expected error while writer lock is held")
+	}
+	var cliErr *errs.Error
+	if !errors.As(checkErr, &cliErr) || cliErr.Code != errs.CodeDaemonDisabledByPlugin {
+		t.Fatalf("expected %s, got %v", errs.CodeDaemonDisabledByPlugin, checkErr)
+	}
+}

--- a/internal/daemon/writerlock_windows.go
+++ b/internal/daemon/writerlock_windows.go
@@ -1,0 +1,51 @@
+//go:build windows
+
+package daemon
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	kernel32         = syscall.NewLazyDLL("kernel32.dll")
+	procLockFileEx   = kernel32.NewProc("LockFileEx")
+	procUnlockFileEx = kernel32.NewProc("UnlockFileEx")
+)
+
+const (
+	lockfileFailImmediately = 0x00000001
+	lockfileExclusiveLock   = 0x00000002
+	errorLockViolation      = 33 // ERROR_LOCK_VIOLATION
+)
+
+// probeFileLock 非阻塞探测字节区间锁 [0,1)：与插件侧 writer_lock.py 的
+// msvcrt.locking(LK_NBLCK, 1) 同一锁命名空间（底层同为 LockFile 区间锁）。
+func probeFileLock(path string) (bool, error) {
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+	var overlapped syscall.Overlapped
+	ret, _, callErr := procLockFileEx.Call(
+		f.Fd(),
+		uintptr(lockfileExclusiveLock|lockfileFailImmediately),
+		0, 1, 0,
+		uintptr(unsafe.Pointer(&overlapped)),
+	)
+	if ret == 0 {
+		if errno, ok := callErr.(syscall.Errno); ok && errno == errorLockViolation {
+			return true, nil
+		}
+		return false, callErr
+	}
+	_, _, _ = procUnlockFileEx.Call(f.Fd(), 0, 1, 0, uintptr(unsafe.Pointer(&overlapped)))
+	return false, nil
+}

--- a/internal/errs/errors.go
+++ b/internal/errs/errors.go
@@ -12,6 +12,7 @@ const (
 	CodeNotImplemented          = "YOOOCLAW_NOT_IMPLEMENTED"
 	CodeDaemonNotRunning        = "YOOOCLAW_DAEMON_NOT_RUNNING"
 	CodeDaemonAlreadyRunning    = "YOOOCLAW_DAEMON_ALREADY_RUNNING"
+	CodeDaemonDisabledByPlugin  = "YOOOCLAW_DAEMON_DISABLED_BY_PLUGIN"
 	CodeDaemonLifecycleMismatch = "YOOOCLAW_DAEMON_LIFECYCLE_MISMATCH"
 	CodeUnauthorized            = "YOOOCLAW_UNAUTHORIZED"
 	CodeConfigInvalid           = "YOOOCLAW_CONFIG_INVALID"

--- a/internal/lightgw/gateway.go
+++ b/internal/lightgw/gateway.go
@@ -1,0 +1,220 @@
+// Package lightgw 承载灯效 gateway 的核心逻辑（lightrules CRUD + light send），
+// 供 daemon HTTP handler 与 CLI 命令共用——CLI 侧从此不依赖 daemon 进程。
+// （light 与 lightrule 互不引用，本包同时引两者，避免循环依赖。）
+package lightgw
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/YoooClaw/cli/internal/light"
+	"github.com/YoooClaw/cli/internal/lightrule"
+)
+
+// Err 是 gateway 语义的结构化错误；Status 供非 gateway 壳的 HTTP 路径
+// （/light/send）区分 400/404，gateway 壳路径恒为 200 + ok:false。
+type Err struct {
+	Code    string
+	Message string
+	Status  int
+}
+
+func (e *Err) Error() string { return e.Message }
+
+// Rules 处理 lightrules.{list,create,update,delete}（原 daemon handleLightrules 核心）。
+// 返回 gatewayOK 的 payload；未知 method 返回 code=YOOOCLAW_NOT_FOUND、Status=404。
+func Rules(base, method string, body map[string]any) (map[string]any, *Err) {
+	switch method {
+	case "lightrules.list":
+		rules := []map[string]any{}
+		for _, m := range lightrule.List(base) {
+			rm := metaToMap(m)
+			rm["id"] = m.Name
+			rules = append(rules, rm)
+		}
+		return map[string]any{"ok": true, "rules": rules}, nil
+
+	case "lightrules.create":
+		name := asString(body["name"])
+		if name == "" {
+			return nil, &Err{Code: "INVALID_PARAMS", Message: "name is required"}
+		}
+		description := asString(body["description"])
+		if description == "" {
+			return nil, &Err{Code: "INVALID_PARAMS", Message: "description is required"}
+		}
+		title := strings.TrimSpace(asString(body["title"]))
+		if title == "" {
+			title = name
+		}
+		res := light.ValidateSegments(body["segments"])
+		if !res.Valid {
+			return nil, &Err{Code: "VALIDATION_FAILED", Message: validationErrorsJSON(res)}
+		}
+		meta, err := lightrule.Create(base, lightrule.CreateParams{
+			Name: name, Title: title, Description: description, Segments: res.Segments,
+			Repeat: boolPtrFromAny(body["repeat"]), RepeatTimes: floatPtrFromAny(body["repeat_times"]),
+		})
+		if err != nil {
+			return nil, ruleErr(err)
+		}
+		return map[string]any{"ok": true, "id": meta.Name, "name": meta.Name, "title": meta.Title, "rule": metaToMap(*meta)}, nil
+
+	case "lightrules.update":
+		name := ResolveRuleIdentifier(body)
+		if name == "" {
+			return nil, &Err{Code: "INVALID_PARAMS", Message: "name is required (or provide id/ruleId/ruleName)"}
+		}
+		params := lightrule.UpdateParams{
+			Name:        name,
+			Repeat:      boolPtrFromAny(body["repeat"]),
+			RepeatTimes: floatPtrFromAny(body["repeat_times"]),
+			Enabled:     boolPtrFromAny(body["enabled"]),
+		}
+		if raw, ok := body["title"]; ok {
+			t := strings.TrimSpace(asString(raw))
+			if t == "" {
+				return nil, &Err{Code: "INVALID_PARAMS", Message: "title must be a non-empty string"}
+			}
+			params.Title = &t
+		}
+		if raw, ok := body["description"]; ok {
+			d, isStr := raw.(string)
+			if !isStr {
+				return nil, &Err{Code: "INVALID_PARAMS", Message: "description must be a string"}
+			}
+			params.Description = &d
+		}
+		if body["segments"] != nil {
+			res := light.ValidateSegments(body["segments"])
+			if !res.Valid {
+				return nil, &Err{Code: "VALIDATION_FAILED", Message: validationErrorsJSON(res)}
+			}
+			params.Segments = res.Segments
+			params.HasSegments = true
+		}
+		meta, err := lightrule.Update(base, params)
+		if err != nil {
+			return nil, ruleErr(err)
+		}
+		return map[string]any{"ok": true, "id": meta.Name, "name": meta.Name, "title": meta.Title, "updated": true, "rule": metaToMap(*meta)}, nil
+
+	case "lightrules.delete":
+		name := ResolveRuleIdentifier(body)
+		if name == "" {
+			return nil, &Err{Code: "INVALID_PARAMS", Message: "name is required (or provide id/ruleId/ruleName)"}
+		}
+		deleted, err := lightrule.Delete(base, name)
+		if err != nil {
+			return nil, ruleErr(err)
+		}
+		return map[string]any{"ok": true, "id": deleted, "name": deleted, "deleted": true}, nil
+
+	default:
+		return nil, &Err{Code: "YOOOCLAW_NOT_FOUND", Message: "未知路径：/gateway/" + method, Status: 404}
+	}
+}
+
+// Send 处理 /light/send 核心（原 daemon handleLightSend）：segments / preset /
+// rule 三选一，编码后下发灯效云 API。
+func Send(base string, body map[string]any, apiKey string, logger light.Logger) (any, *Err) {
+	repeatInput := light.RepeatInputFromAny(body["repeat"], body["repeat_times"])
+	reason, _ := body["reason"].(string)
+	title, _ := body["title"].(string)
+
+	var segments []map[string]any
+	switch {
+	case body["segments"] != nil:
+		res := light.ValidateSegments(body["segments"])
+		if !res.Valid {
+			return nil, &Err{Code: "VALIDATION_FAILED", Message: validationMessage(res), Status: 400}
+		}
+		segments = res.Segments
+	case asString(body["preset"]) != "":
+		preset, ok := light.LookupPreset(asString(body["preset"]))
+		if !ok {
+			return nil, &Err{Code: "YOOOCLAW_NOT_FOUND", Message: "未知预设：" + asString(body["preset"]), Status: 404}
+		}
+		segments = preset.Segments
+		if body["repeat"] == nil && body["repeat_times"] == nil {
+			rt := float64(preset.RepeatTimes)
+			repeatInput = light.RepeatInput{RepeatTimes: &rt}
+		}
+	case asString(body["rule"]) != "":
+		rule := lightrule.Get(base, asString(body["rule"]))
+		if rule == nil {
+			return nil, &Err{Code: "YOOOCLAW_NOT_FOUND", Message: "灯效规则不存在：" + asString(body["rule"]), Status: 404}
+		}
+		segments = rule.Segments
+		if body["repeat"] == nil && body["repeat_times"] == nil {
+			rt := float64(rule.RepeatTimes)
+			repeatInput = light.RepeatInput{RepeatTimes: &rt}
+		}
+	default:
+		return nil, &Err{Code: "INVALID_PARAMS", Message: "需要 segments / preset / rule 之一", Status: 400}
+	}
+
+	return light.SendLightEffect(apiKey, segments, repeatInput, reason, title, logger), nil
+}
+
+func ruleErr(err error) *Err {
+	if e, ok := err.(*lightrule.Error); ok {
+		return &Err{Code: e.Code, Message: e.Message}
+	}
+	return &Err{Code: "INTERNAL_ERROR", Message: err.Error()}
+}
+
+// ResolveRuleIdentifier 从 body 的 name/id/ruleId/ruleName 解析规则名（剥 .json 后缀）。
+func ResolveRuleIdentifier(body map[string]any) string {
+	for _, key := range []string{"name", "id", "ruleId", "ruleName"} {
+		if s := asString(body[key]); s != "" {
+			n := strings.TrimSpace(s)
+			if strings.HasSuffix(strings.ToLower(n), ".json") {
+				n = n[:len(n)-len(".json")]
+			}
+			if n != "" {
+				return n
+			}
+		}
+	}
+	return ""
+}
+
+func metaToMap(m lightrule.Meta) map[string]any {
+	data, _ := json.Marshal(m)
+	var out map[string]any
+	_ = json.Unmarshal(data, &out)
+	return out
+}
+
+func validationMessage(res light.ValidationResult) string {
+	parts := make([]string, len(res.Errors))
+	for i, e := range res.Errors {
+		parts[i] = e.Field + ": " + e.Message
+	}
+	return strings.Join(parts, "; ")
+}
+
+func validationErrorsJSON(res light.ValidationResult) string {
+	data, _ := json.Marshal(res.Errors)
+	return string(data)
+}
+
+func asString(v any) string {
+	s, _ := v.(string)
+	return s
+}
+
+func boolPtrFromAny(v any) *bool {
+	if b, ok := v.(bool); ok {
+		return &b
+	}
+	return nil
+}
+
+func floatPtrFromAny(v any) *float64 {
+	if f, ok := v.(float64); ok {
+		return &f
+	}
+	return nil
+}

--- a/internal/lightrule/client.go
+++ b/internal/lightrule/client.go
@@ -1,0 +1,391 @@
+package lightrule
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/YoooClaw/cli/internal/envhost"
+)
+
+// 本文件是云端灯效规则 client（Go 版 NotificationIntelligenceLightRuleClient，
+// 对齐 openclaw plugin 的 src/light-rules/client.ts）：CRUD 全部打到
+// Notification Intelligence Service 的插件侧 API，X-Api-Key-Id 鉴权。
+// create 只接收自然语言 ruleText，由云端独立 Agent 编译出 name/title/segments。
+// （本地文件存储见 storage.go，仅供 daemon/gateway 兼容路径使用。）
+
+// APIPath 是插件侧灯效规则 API 前缀（与 plugin env.ts 的常量一致）。
+const APIPath = "/api/plugin/notification-intelligence/light-rules"
+
+// APIURL 返回云端灯效规则 API 端点（主机随 PHONE_NOTIFICATIONS_ENV 切换）。
+func APIURL() string {
+	return "https://" + envhost.Host() + APIPath
+}
+
+// APIError 是云端请求的结构化错误。Code 可能是业务码（INVALID_PARAMS /
+// NOT_FOUND / BUSINESS_FAILED / AUTH_REQUIRED / INVALID_RESPONSE）或 HTTP 状态码字符串。
+type APIError struct {
+	Code    string
+	Message string
+	Status  int
+}
+
+func (e *APIError) Error() string { return e.Message }
+
+// ClientLogger 是 client 依赖的最小日志接口。
+type ClientLogger interface {
+	Info(string)
+	Warn(string)
+}
+
+// Client 是云端灯效规则 client。零值不可用，APIKey 必填。
+type Client struct {
+	APIKey     string
+	BaseURL    string       // 空则用 APIURL()
+	Logger     ClientLogger // 可为 nil
+	HTTPClient *http.Client // 可为 nil，默认 30s 超时
+}
+
+// updatePatchKeys 是 PATCH 允许透传的字段白名单（对齐 TS sanitizeUpdatePatch）。
+var updatePatchKeys = []string{"ruleText", "title", "description", "enabled", "segments", "repeat_times", "repeat"}
+
+// simpleIdentifierRE 判定可直接当 URL 路径段 PATCH 的标识符（对齐 TS shouldPatchIdentifierDirectly）。
+var simpleIdentifierRE = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:-]*$`)
+
+// List 拉取当前账号的全部灯效规则（含 enabled 状态），字段缺省按 plugin 同款规则补齐。
+func (c *Client) List() ([]map[string]any, error) {
+	data, err := c.request("GET", "", nil)
+	if err != nil {
+		return nil, err
+	}
+	raw, _ := data["rules"].([]any)
+	rules := make([]map[string]any, 0, len(raw))
+	for _, item := range raw {
+		rule, nerr := normalizeRuleRecord(item)
+		if nerr != nil {
+			return nil, nerr
+		}
+		rules = append(rules, rule)
+	}
+	return rules, nil
+}
+
+// Create 提交自然语言 ruleText，云端 Agent 编译并保存规则。
+func (c *Client) Create(ruleText string) (map[string]any, error) {
+	ruleText = strings.TrimSpace(ruleText)
+	if ruleText == "" {
+		return nil, &APIError{Code: "INVALID_PARAMS", Message: "ruleText is required"}
+	}
+	data, err := c.request("POST", "", map[string]any{"ruleText": ruleText})
+	if err != nil {
+		return nil, err
+	}
+	id, name := nonEmptyString(data["id"]), nonEmptyString(data["name"])
+	if id == "" || name == "" {
+		return nil, &APIError{Code: "INVALID_RESPONSE", Message: "Notification Intelligence create response missing id/name"}
+	}
+	out := map[string]any{"id": id, "name": name}
+	copyOptional(out, data, "requestId", "warning")
+	return out, nil
+}
+
+// Update 按 id/name PATCH 规则。patch 里传 ruleText 表示云端重编译，
+// 传 title/description/enabled/segments/repeat_times/repeat 表示普通字段局部更新。
+// 简单标识符先直接 PATCH，404 再走 list 解析（对齐 TS update 流程）。
+func (c *Client) Update(identifier string, patch map[string]any) (map[string]any, error) {
+	body := map[string]any{}
+	for _, key := range updatePatchKeys {
+		if v, ok := patch[key]; ok && v != nil {
+			body[key] = v
+		}
+	}
+	if len(body) == 0 {
+		return nil, &APIError{Code: "INVALID_PARAMS", Message: "at least one update field is required"}
+	}
+
+	normalized := normalizeLookupName(identifier)
+	if normalized == "" {
+		return nil, &APIError{Code: "INVALID_PARAMS", Message: "rule id/name is required"}
+	}
+
+	if simpleIdentifierRE.MatchString(normalized) {
+		c.logInfo("Light rules API update: direct PATCH identifier=" + normalized)
+		out, err := c.patchRule(normalized, normalized, body)
+		if err == nil || !isNotFound(err) {
+			return out, err
+		}
+		c.logInfo("Light rules API update: direct PATCH missed identifier=" + normalized + "; resolving by list")
+	}
+
+	id, name, err := c.resolveIdentifier(normalized)
+	if err != nil {
+		return nil, err
+	}
+	c.logInfo("Light rules API update: PATCH targetId=" + id + " identifier=" + normalized)
+	return c.patchRule(id, name, body)
+}
+
+// Delete 按 id/name 删除规则（云端当前实现为软删除）。
+func (c *Client) Delete(identifier string) (map[string]any, error) {
+	id, name, err := c.resolveIdentifier(identifier)
+	if err != nil {
+		return nil, err
+	}
+	data, err := c.request("DELETE", "/"+urlPathEscape(id), nil)
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]any{
+		"id":   firstNonEmpty(nonEmptyString(data["id"]), id),
+		"name": firstNonEmpty(nonEmptyString(data["name"]), name),
+	}
+	copyOptional(out, data, "requestId")
+	return out, nil
+}
+
+func (c *Client) patchRule(id, name string, body map[string]any) (map[string]any, error) {
+	data, err := c.request("PATCH", "/"+urlPathEscape(id), body)
+	if err != nil {
+		return nil, err
+	}
+	var rule map[string]any
+	if data["rule"] != nil {
+		if rule, err = normalizeRuleRecord(data["rule"]); err != nil {
+			return nil, err
+		}
+	}
+	out := map[string]any{
+		"id":      firstNonEmpty(nonEmptyString(data["id"]), nonEmptyString(rule["id"]), id),
+		"name":    firstNonEmpty(nonEmptyString(data["name"]), nonEmptyString(rule["name"]), name),
+		"updated": true,
+	}
+	if title := firstNonEmpty(nonEmptyString(data["title"]), nonEmptyString(rule["title"])); title != "" {
+		out["title"] = title
+	}
+	if rule != nil {
+		out["rule"] = rule
+	}
+	copyOptional(out, data, "requestId", "warning")
+	return out, nil
+}
+
+func (c *Client) resolveIdentifier(identifier string) (id, name string, err error) {
+	normalized := normalizeLookupName(identifier)
+	if normalized == "" {
+		return "", "", &APIError{Code: "INVALID_PARAMS", Message: "rule id/name is required"}
+	}
+	rules, err := c.List()
+	if err != nil {
+		return "", "", err
+	}
+	for _, rule := range rules {
+		if rule["id"] == normalized || rule["name"] == normalized {
+			return nonEmptyString(rule["id"]), nonEmptyString(rule["name"]), nil
+		}
+	}
+	return "", "", &APIError{Code: "NOT_FOUND", Message: "灯效规则 '" + normalized + "' 不存在"}
+}
+
+// request 发起一次云端请求并解包 ResponseBean{code,msg,data}：
+// code!="000000" 或 data.success==false 均视为失败（对齐 TS request）。
+func (c *Client) request(method, path string, body map[string]any) (map[string]any, error) {
+	apiKey := strings.TrimSpace(c.APIKey)
+	if apiKey == "" {
+		return nil, &APIError{Code: "AUTH_REQUIRED", Message: "API Key 未配置，请先 `yoooclaw auth login`"}
+	}
+
+	base := c.BaseURL
+	if base == "" {
+		base = APIURL()
+	}
+	url := base + path
+
+	var reader io.Reader
+	if body != nil {
+		payload, err := json.Marshal(body)
+		if err != nil {
+			return nil, &APIError{Code: "INVALID_PARAMS", Message: err.Error()}
+		}
+		reader = bytes.NewReader(payload)
+	}
+	req, err := http.NewRequest(method, url, reader)
+	if err != nil {
+		return nil, &APIError{Code: "INVALID_PARAMS", Message: err.Error()}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Api-Key-Id", strings.TrimPrefix(apiKey, "Bearer "))
+
+	client := c.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+	startedAt := time.Now()
+	res, err := client.Do(req)
+	if err != nil {
+		c.logWarn(fmt.Sprintf("Light rules API: %s %s failed: %v", method, url, err))
+		return nil, &APIError{Code: "NETWORK_ERROR", Message: err.Error()}
+	}
+	defer res.Body.Close()
+	text, _ := io.ReadAll(res.Body)
+
+	var parsed map[string]any
+	parseErr := json.Unmarshal(text, &parsed)
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		message := remoteErrorMessage(parsed, string(text), res.StatusCode)
+		c.logWarn(fmt.Sprintf("Light rules API: %s %s failed status=%d message=%s", method, url, res.StatusCode, message))
+		return nil, &APIError{Code: strconv.Itoa(res.StatusCode), Message: decorateRemoteErrorMessage(message, url), Status: res.StatusCode}
+	}
+	if parseErr != nil || parsed == nil {
+		return nil, &APIError{Code: "INVALID_RESPONSE", Message: "empty or invalid JSON response"}
+	}
+
+	if code := nonEmptyString(parsed["code"]); code != "" && code != "000000" {
+		msg := firstNonEmpty(nonEmptyString(parsed["msg"]), nonEmptyString(parsed["message"]), "remote request failed")
+		return nil, &APIError{Code: code, Message: msg}
+	}
+
+	data, ok := parsed["data"].(map[string]any)
+	if !ok {
+		if parsed["data"] == nil {
+			data = parsed
+		} else {
+			return nil, &APIError{Code: "INVALID_RESPONSE", Message: "response data is empty"}
+		}
+	}
+	if success, isBool := data["success"].(bool); isBool && !success {
+		msg := firstNonEmpty(nonEmptyString(data["message"]), "remote business request failed")
+		return nil, &APIError{Code: "BUSINESS_FAILED", Message: msg}
+	}
+
+	c.logInfo(fmt.Sprintf("Light rules API: %s %s ok elapsedMs=%d", method, url, time.Since(startedAt).Milliseconds()))
+	return data, nil
+}
+
+func (c *Client) logInfo(msg string) {
+	if c.Logger != nil {
+		c.Logger.Info(msg)
+	}
+}
+
+func (c *Client) logWarn(msg string) {
+	if c.Logger != nil {
+		c.Logger.Warn(msg)
+	}
+}
+
+// normalizeRuleRecord 补齐云端规则记录的缺省字段（对齐 TS normalizeRuleRecord）。
+func normalizeRuleRecord(value any) (map[string]any, error) {
+	raw, ok := value.(map[string]any)
+	if !ok {
+		return nil, &APIError{Code: "INVALID_RESPONSE", Message: "invalid light rule item"}
+	}
+	name := nonEmptyString(raw["name"])
+	id := firstNonEmpty(nonEmptyString(raw["id"]), name)
+	if id == "" || name == "" {
+		return nil, &APIError{Code: "INVALID_RESPONSE", Message: "light rule item missing id/name"}
+	}
+	rule := map[string]any{}
+	for k, v := range raw {
+		rule[k] = v
+	}
+	rule["id"] = id
+	rule["name"] = name
+	rule["title"] = firstNonEmpty(nonEmptyString(raw["title"]), name)
+	rule["type"] = "light-rule"
+	rule["description"] = firstNonEmpty(nonEmptyString(raw["description"]), name)
+	if _, ok := raw["segments"].([]any); !ok {
+		rule["segments"] = []any{}
+	}
+	if _, ok := raw["repeat_times"].(float64); !ok {
+		rule["repeat_times"] = float64(1)
+	}
+	if _, ok := raw["enabled"].(bool); !ok {
+		rule["enabled"] = true
+	}
+	if nonEmptyString(raw["createdAt"]) == "" {
+		rule["createdAt"] = time.Unix(0, 0).UTC().Format(time.RFC3339)
+	}
+	return rule, nil
+}
+
+func remoteErrorMessage(parsed map[string]any, text string, status int) string {
+	if parsed != nil {
+		if msg := firstNonEmpty(nonEmptyString(parsed["msg"]), nonEmptyString(parsed["message"])); msg != "" {
+			return msg
+		}
+		if data, ok := parsed["data"].(map[string]any); ok {
+			if msg := nonEmptyString(data["message"]); msg != "" {
+				return msg
+			}
+		}
+	}
+	if msg := strings.TrimSpace(text); msg != "" {
+		return msg
+	}
+	return "HTTP " + strconv.Itoa(status)
+}
+
+// decorateRemoteErrorMessage 为 “jwt is missing” 401 补充排障指引（对齐 TS 同名函数）。
+func decorateRemoteErrorMessage(message, url string) string {
+	if !strings.Contains(strings.ToLower(message), "jwt is missing") {
+		return message
+	}
+	if strings.Contains(url, APIPath) {
+		return message + "。请求已命中插件侧 API " + APIPath + "，插件侧鉴权应只使用 " +
+			"X-Api-Key-Id；当前 401 来自云端 JWT 鉴权层，说明该插件前缀没有被网关/服务端放行到 API Key 鉴权。" +
+			"请后端检查网关白名单和 Notification Intelligence Service 插件路由：" + url
+	}
+	return message + "。灯效规则应调用插件侧 API " + APIPath + "，并通过 X-Api-Key-Id 鉴权；" +
+		"当前请求可能命中了 App 端 JWT 接口：" + url
+}
+
+func isNotFound(err error) bool {
+	e, ok := err.(*APIError)
+	if !ok {
+		return false
+	}
+	return e.Status == 404 || e.Code == "404" || e.Code == "NOT_FOUND"
+}
+
+func nonEmptyString(v any) string {
+	s, _ := v.(string)
+	return strings.TrimSpace(s)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func copyOptional(dst, src map[string]any, keys ...string) {
+	for _, key := range keys {
+		if v := nonEmptyString(src[key]); v != "" {
+			dst[key] = v
+		}
+	}
+}
+
+func urlPathEscape(s string) string {
+	// 与 TS encodeURIComponent 对齐：规则 id 可能含非 ASCII。
+	escaped := strings.Builder{}
+	for _, b := range []byte(s) {
+		if b >= 'A' && b <= 'Z' || b >= 'a' && b <= 'z' || b >= '0' && b <= '9' ||
+			b == '-' || b == '_' || b == '.' || b == '~' {
+			escaped.WriteByte(b)
+		} else {
+			escaped.WriteString(fmt.Sprintf("%%%02X", b))
+		}
+	}
+	return escaped.String()
+}

--- a/internal/lightrule/client_test.go
+++ b/internal/lightrule/client_test.go
@@ -1,0 +1,262 @@
+package lightrule
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// beanOK 包一层云端 ResponseBean{code:"000000", data}。
+func beanOK(data map[string]any) []byte {
+	raw, _ := json.Marshal(map[string]any{"code": "000000", "msg": "success", "data": data})
+	return raw
+}
+
+type recordedRequest struct {
+	Method string
+	Path   string
+	APIKey string
+	Body   map[string]any
+}
+
+func recordRequest(t *testing.T, r *http.Request) recordedRequest {
+	t.Helper()
+	rec := recordedRequest{Method: r.Method, Path: r.URL.EscapedPath(), APIKey: r.Header.Get("X-Api-Key-Id")}
+	raw, _ := io.ReadAll(r.Body)
+	if len(raw) > 0 {
+		_ = json.Unmarshal(raw, &rec.Body)
+	}
+	return rec
+}
+
+func TestCreateSendsRuleTextWithAPIKeyHeader(t *testing.T) {
+	var got recordedRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = recordRequest(t, r)
+		w.Write(beanOK(map[string]any{"success": true, "id": "rule-1", "name": "boss-wechat", "requestId": "req-9"}))
+	}))
+	defer server.Close()
+
+	c := &Client{APIKey: "Bearer ak-123", BaseURL: server.URL}
+	out, err := c.Create("老板发微信时红灯快闪")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Method != "POST" || got.APIKey != "ak-123" {
+		t.Errorf("expected POST with stripped Bearer key, got %+v", got)
+	}
+	if got.Body["ruleText"] != "老板发微信时红灯快闪" {
+		t.Errorf("ruleText not sent: %+v", got.Body)
+	}
+	if out["id"] != "rule-1" || out["name"] != "boss-wechat" || out["requestId"] != "req-9" {
+		t.Errorf("unexpected create result: %+v", out)
+	}
+}
+
+func TestCreateRejectsEmptyRuleTextAndMissingID(t *testing.T) {
+	c := &Client{APIKey: "ak", BaseURL: "http://unused.invalid"}
+	if _, err := c.Create("  "); err == nil || err.(*APIError).Code != "INVALID_PARAMS" {
+		t.Errorf("expected INVALID_PARAMS, got %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write(beanOK(map[string]any{"success": true}))
+	}))
+	defer server.Close()
+	c.BaseURL = server.URL
+	if _, err := c.Create("有通知时亮灯"); err == nil || err.(*APIError).Code != "INVALID_RESPONSE" {
+		t.Errorf("expected INVALID_RESPONSE on missing id/name, got %v", err)
+	}
+}
+
+func TestListNormalizesRecords(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write(beanOK(map[string]any{"success": true, "rules": []any{
+			map[string]any{"name": "minimal"},
+			map[string]any{"id": "r2", "name": "full", "title": "满配", "enabled": false, "repeat_times": float64(3), "segments": []any{map[string]any{"mode": "steady"}}},
+		}}))
+	}))
+	defer server.Close()
+
+	rules, err := (&Client{APIKey: "ak", BaseURL: server.URL}).List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rules) != 2 {
+		t.Fatalf("expected 2 rules, got %d", len(rules))
+	}
+	m := rules[0]
+	if m["id"] != "minimal" || m["title"] != "minimal" || m["enabled"] != true || m["repeat_times"] != float64(1) || m["type"] != "light-rule" {
+		t.Errorf("defaults not applied: %+v", m)
+	}
+	if segs, ok := m["segments"].([]any); !ok || len(segs) != 0 {
+		t.Errorf("segments default should be empty array: %+v", m["segments"])
+	}
+	f := rules[1]
+	if f["id"] != "r2" || f["title"] != "满配" || f["enabled"] != false || f["repeat_times"] != float64(3) {
+		t.Errorf("explicit fields overwritten: %+v", f)
+	}
+}
+
+func TestUpdatePatchesSlugIdentifierDirectly(t *testing.T) {
+	var reqs []recordedRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqs = append(reqs, recordRequest(t, r))
+		w.Write(beanOK(map[string]any{"success": true, "id": "boss-wechat", "name": "boss-wechat", "title": "老板微信"}))
+	}))
+	defer server.Close()
+
+	out, err := (&Client{APIKey: "ak", BaseURL: server.URL}).Update("boss-wechat.json", map[string]any{
+		"enabled": false, "matchRules": "should-be-dropped",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reqs) != 1 || reqs[0].Method != "PATCH" || reqs[0].Path != "/boss-wechat" {
+		t.Fatalf("expected single direct PATCH, got %+v", reqs)
+	}
+	if _, ok := reqs[0].Body["matchRules"]; ok {
+		t.Errorf("non-whitelisted patch key should be dropped: %+v", reqs[0].Body)
+	}
+	if reqs[0].Body["enabled"] != false {
+		t.Errorf("enabled not sent: %+v", reqs[0].Body)
+	}
+	if out["updated"] != true || out["title"] != "老板微信" {
+		t.Errorf("unexpected update result: %+v", out)
+	}
+}
+
+func TestUpdateFallsBackToListResolutionOn404(t *testing.T) {
+	var reqs []recordedRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec := recordRequest(t, r)
+		reqs = append(reqs, rec)
+		switch {
+		case rec.Method == "PATCH" && rec.Path == "/boss-wechat":
+			w.WriteHeader(404)
+			w.Write([]byte(`{"msg":"not found"}`))
+		case rec.Method == "GET":
+			w.Write(beanOK(map[string]any{"success": true, "rules": []any{
+				map[string]any{"id": "uuid-1", "name": "boss-wechat"},
+			}}))
+		case rec.Method == "PATCH" && rec.Path == "/uuid-1":
+			w.Write(beanOK(map[string]any{"success": true, "id": "uuid-1", "name": "boss-wechat"}))
+		default:
+			t.Errorf("unexpected request: %+v", rec)
+			w.WriteHeader(500)
+		}
+	}))
+	defer server.Close()
+
+	out, err := (&Client{APIKey: "ak", BaseURL: server.URL}).Update("boss-wechat", map[string]any{"ruleText": "改成绿灯"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reqs) != 3 {
+		t.Fatalf("expected direct PATCH + list + resolved PATCH, got %+v", reqs)
+	}
+	if out["id"] != "uuid-1" || out["updated"] != true {
+		t.Errorf("unexpected result: %+v", out)
+	}
+}
+
+func TestUpdateRequiresPatchFieldsAndIdentifier(t *testing.T) {
+	c := &Client{APIKey: "ak", BaseURL: "http://unused.invalid"}
+	if _, err := c.Update("x", map[string]any{}); err == nil || err.(*APIError).Code != "INVALID_PARAMS" {
+		t.Errorf("empty patch should fail INVALID_PARAMS, got %v", err)
+	}
+	if _, err := c.Update("  ", map[string]any{"enabled": true}); err == nil || err.(*APIError).Code != "INVALID_PARAMS" {
+		t.Errorf("empty identifier should fail INVALID_PARAMS, got %v", err)
+	}
+}
+
+func TestDeleteResolvesIdentifierThenDeletes(t *testing.T) {
+	var reqs []recordedRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec := recordRequest(t, r)
+		reqs = append(reqs, rec)
+		if rec.Method == "GET" {
+			w.Write(beanOK(map[string]any{"success": true, "rules": []any{
+				map[string]any{"id": "uuid-7", "name": "boss-wechat"},
+			}}))
+			return
+		}
+		w.Write(beanOK(map[string]any{"success": true, "requestId": "req-1"}))
+	}))
+	defer server.Close()
+
+	out, err := (&Client{APIKey: "ak", BaseURL: server.URL}).Delete("boss-wechat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reqs) != 2 || reqs[1].Method != "DELETE" || reqs[1].Path != "/uuid-7" {
+		t.Fatalf("expected list then DELETE /uuid-7, got %+v", reqs)
+	}
+	if out["id"] != "uuid-7" || out["name"] != "boss-wechat" || out["requestId"] != "req-1" {
+		t.Errorf("unexpected delete result: %+v", out)
+	}
+}
+
+func TestDeleteUnknownRuleFailsNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write(beanOK(map[string]any{"success": true, "rules": []any{}}))
+	}))
+	defer server.Close()
+	_, err := (&Client{APIKey: "ak", BaseURL: server.URL}).Delete("ghost")
+	if err == nil || err.(*APIError).Code != "NOT_FOUND" {
+		t.Errorf("expected NOT_FOUND, got %v", err)
+	}
+}
+
+func TestRequestErrorMapping(t *testing.T) {
+	cases := []struct {
+		name     string
+		status   int
+		body     string
+		wantCode string
+	}{
+		{"bean business code", 200, `{"code":"100403","msg":"配额不足"}`, "100403"},
+		{"data success false", 200, `{"code":"000000","data":{"success":false,"message":"编译失败"}}`, "BUSINESS_FAILED"},
+		{"http 500 plain text", 500, `boom`, "500"},
+		{"invalid json", 200, `not-json`, "INVALID_RESPONSE"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				w.Write([]byte(tc.body))
+			}))
+			defer server.Close()
+			_, err := (&Client{APIKey: "ak", BaseURL: server.URL}).List()
+			if err == nil || err.(*APIError).Code != tc.wantCode {
+				t.Errorf("expected code %s, got %v", tc.wantCode, err)
+			}
+		})
+	}
+}
+
+func TestRequestRequiresAPIKey(t *testing.T) {
+	_, err := (&Client{BaseURL: "http://unused.invalid"}).List()
+	if err == nil || err.(*APIError).Code != "AUTH_REQUIRED" {
+		t.Errorf("expected AUTH_REQUIRED, got %v", err)
+	}
+}
+
+func TestJwtMissingErrorGetsDecorated(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(401)
+		w.Write([]byte(`{"msg":"JWT is missing"}`))
+	}))
+	defer server.Close()
+	_, err := (&Client{APIKey: "ak", BaseURL: server.URL + APIPath}).List()
+	apiErr, ok := err.(*APIError)
+	if !ok || apiErr.Status != 401 {
+		t.Fatalf("expected 401 APIError, got %v", err)
+	}
+	if !strings.Contains(apiErr.Message, "X-Api-Key-Id") {
+		t.Errorf("jwt error should be decorated: %s", apiErr.Message)
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.5.3",
+  "version": "0.6.0-beta.0",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {

--- a/skills/yoooclaw-lightrule-create/SKILL.md
+++ b/skills/yoooclaw-lightrule-create/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: yoooclaw-lightrule-create
-description: 用 yoooclaw CLI 创建/管理"通知→灯效"规则。当用户表达"收到/当/如果某类通知或消息时，亮灯/闪灯/变成某种灯效"这类**持久规则**诉求时激活。规则由 daemon 在通知 ingest 后评估命中并触发灯效。需要 daemon 在运行（🟡）。从 stdin 用 --from-file - 提交规则定义最稳妥。
+description: 用 yoooclaw CLI 创建/管理"通知→灯效"规则。当用户表达"收到/当/如果某类通知或消息时，亮灯/闪灯/变成某种灯效"这类**持久规则**诉求时激活。规则保存在云端 Notification Intelligence Service，由云端评估命中并触发灯效。只需把用户的自然语言诉求原样传给 --intent。
 ---
 
-# yoooclaw 灯效规则创建（从 stdin）
+# yoooclaw 灯效规则创建（云端）
 
-灯效规则是**持久**的：通知到达后 daemon 评估是否命中，命中则播放灯效。
+灯效规则是**持久**的：保存在云端 Notification Intelligence Service，通知到达后由云端评估是否命中，命中则播放灯效。
 和"立即放一次灯效测试"不同（那是 `yoooclaw light send`）。
 
-> 需要 daemon 在跑：先 `yoooclaw daemon status`，未运行则 `yoooclaw daemon start`。
+> 不需要 daemon。规则 CRUD 直接打云端 API（X-Api-Key-Id 鉴权），需要已 `yoooclaw auth login`。
 
 ## 何时激活
 
@@ -19,45 +19,46 @@ description: 用 yoooclaw CLI 创建/管理"通知→灯效"规则。当用户�
 
 不要为这类诉求调用 `light send`（那只用于一次性测试/预览）。
 
-## 创建规则（首选 --from-file - 从 stdin）
+## 创建规则（自然语言 --intent）
+
+把用户的原始自然语言诉求整理成一句话传给 `--intent`，由云端独立 Agent
+编译出 name/title/description/segments/repeat_times 并保存：
 
 ```bash
-cat <<'JSON' | yoooclaw lightrule create --from-file - --format json
-{
-  "name": "wechat-at-me",
-  "title": "微信@我",
-  "description": "微信群里有人@我时红灯快闪",
-  "segments": [
-    { "mode": "strobe", "duration_s": 2, "brightness": 255,
-      "color": { "r": 255, "g": 0, "b": 0 }, "interval_ms": 200 }
-  ]
-}
-JSON
+yoooclaw lightrule create --intent "微信群里有人@我时红灯快闪" --format json
 ```
 
-字段说明：
-
-- `name`（必填）：规则唯一标识。
-- `description`（必填）：自然语言意图，daemon 的 webhook 评估器据此判断通知是否命中。
-- `segments`（必填）：命中后播放的灯效，遵循 light protocol（mode/duration_s/brightness/color/interval_ms 等）。
-- 也可用 flag 形式：`--name --intent <描述> --light-action <segments JSON> --match-rules <硬过滤 JSON>`。
+返回 `{ok, id, name}`（可能带 `warning`）。**不需要**自己构造 segments。
 
 ## 管理
 
 ```bash
-yoooclaw lightrule list --format json          # 列出全部规则及 enabled 状态
-yoooclaw lightrule show <name> --format json   # 单条详情
-yoooclaw lightrule disable <name>              # 停用（不删除）
-yoooclaw lightrule enable <name>               # 启用
+yoooclaw lightrule list --format json          # 列出云端全部规则及 enabled 状态
+yoooclaw lightrule show <id> --format json     # 单条详情（id 或 name 均可）
+yoooclaw lightrule disable <id>                # 停用（不删除）
+yoooclaw lightrule enable <id>                 # 启用
 yoooclaw lightrule +off                        # 停用所有
 yoooclaw lightrule +on                         # 启用所有
-yoooclaw lightrule delete <name> --yes         # 删除
+yoooclaw lightrule delete <id> --yes           # 删除（云端软删除）
 ```
+
+## 更新
+
+两种互斥形态：
+
+```bash
+# 语义重编译：传新的自然语言，云端 Agent 重新生成灯效
+yoooclaw lightrule update <id> --intent "改成绿灯呼吸"
+
+# 普通字段局部更新（不重编译）
+yoooclaw lightrule update <id> --title "老板微信" --repeat-times 3
+yoooclaw lightrule update <id> --segments '[{"mode":"strobe","duration_s":2,"brightness":255,"color":{"r":255,"g":0,"b":0},"interval_ms":200}]'
+```
+
+`--intent` 不能与 `--title/--description/--segments/--repeat-times` 混用。
 
 ## 错误处理
 
-- `YOOOCLAW_DAEMON_NOT_RUNNING`：先 `yoooclaw daemon start` 再重试。
-- 创建失败通常表现为 `YOOOCLAW_INVALID_ARGUMENT`，`error.message` 中会带底层
-  `VALIDATION_FAILED`（segments 不合法）或 `INVALID_PARAMS`（缺 name/description）；
-  按具体校验项修正 JSON 后重新提交。
-- 规则名重复：换 `name` 或先 `delete`。
+- `AUTH_REQUIRED`：先 `yoooclaw auth login` 配置 API Key。
+- `NOT_FOUND`：id/name 不存在，先 `lightrule list` 确认。
+- `VALIDATION_FAILED`：segments 不符合 light protocol，`error.message` 内有逐字段错误。


### PR DESCRIPTION
发布 0.6.0-beta.0（合回主干）。

主要改动：
- **lightrule 管理切云端**：新增 Go 版 Notification Intelligence 规则 client（`internal/lightrule/client.go`），`lightrule` CRUD 与 `light send --rule` 全部触发云端插件侧 API（X-Api-Key-Id 鉴权），create 只传自然语言 `--intent` 由云端 Agent 编译，与 openclaw plugin 的 Agent 工具同构；`+gateway`/daemon 保留本地规则文件形态（与 plugin gateway 方法逐字节同构）
- **daemonless 写者锁**：standalone daemon 与 hermes 插件的存储写者互斥（`internal/daemon/writerlock*`），`daemon start` 父进程预检，新增 `YOOOCLAW_DAEMON_DISABLED_BY_PLUGIN` 错误码
- lightrule skill 文档与 README 同步云端用法

🤖 Generated with [Claude Code](https://claude.com/claude-code)