### PR TITLE
cli-0.6.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.6.0-beta.0",
+  "version": "0.6.0-beta.1",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {


### PR DESCRIPTION
## 变更
- 发布 CLI 0.6.0-beta.1

## 验证
- go test ./...
- Release CLI workflow 通过

该版本将 daemonless 插件 writer lock 状态在 fork 前返回，避免 App 误报 daemon 启动超时。