### PR TITLE
Make notification storage writes atomic

### DIFF
--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -375,8 +375,9 @@ func (s *server) handleIngest(w http.ResponseWriter, r *http.Request, auth authR
 	result := s.storage.Ingest(filtered, auth.clientLabel)
 	s.recordIngest(result)
 	writeJSON(w, 200, map[string]any{
-		"ok": true, "received": result.Received, "ingested": result.Ingested,
+		"ok": result.Failed == 0, "received": result.Received, "ingested": result.Ingested,
 		"dedupedById": result.DedupedByID, "dedupedByContent": result.DedupedByContent, "invalid": result.Invalid,
+		"failed": result.Failed,
 	})
 }
 

--- a/internal/notif/storage.go
+++ b/internal/notif/storage.go
@@ -1,6 +1,7 @@
 package notif
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -10,6 +11,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/YoooClaw/cli/internal/fsutil"
 )
 
 var dateDirRE = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
@@ -18,6 +21,7 @@ const (
 	idIndexDirName         = ".ids"
 	contentKeyIndexDirName = ".keys"
 	unitSep                = "\x1f"
+	storedFileMode         = 0o644
 )
 
 // Logger 是存储层依赖的最小日志接口。
@@ -28,12 +32,14 @@ type Logger interface {
 
 // IngestResult 是一次 ingest 的统计 + 新插入条目。
 type IngestResult struct {
-	Received         int                  `json:"received"`
-	Ingested         int                  `json:"ingested"`
-	DedupedByID      int                  `json:"dedupedById"`
-	DedupedByContent int                  `json:"dedupedByContent"`
-	Invalid          int                  `json:"invalid"`
-	Inserted         []StoredNotification `json:"-"`
+	Received         int `json:"received"`
+	Ingested         int `json:"ingested"`
+	DedupedByID      int `json:"dedupedById"`
+	DedupedByContent int `json:"dedupedByContent"`
+	Invalid          int `json:"invalid"`
+	// Failed 是落盘失败的条数。这些通知既没入库也没记索引，重发可以重新入库。
+	Failed   int                  `json:"failed"`
+	Inserted []StoredNotification `json:"-"`
 }
 
 // Storage 是 date-keyed JSON 通知存储（含 id / content-key 双重去重）。
@@ -46,6 +52,7 @@ type Storage struct {
 	mu             sync.Mutex
 	idCache        map[string]map[string]bool
 	contentKeyCach map[string]map[string]bool
+	dayCache       map[string][]StoredNotification
 }
 
 // NewStorage 构造存储；dir 为 notifications 目录。
@@ -58,7 +65,45 @@ func NewStorage(dir string, cfg PluginConfig, logger Logger) *Storage {
 		logger:         logger,
 		idCache:        map[string]map[string]bool{},
 		contentKeyCach: map[string]map[string]bool{},
+		dayCache:       map[string][]StoredNotification{},
 	}
+}
+
+func (s *Storage) dayPath(dateKey string) string {
+	return filepath.Join(s.dir, dateKey+".json")
+}
+
+// loadDay 读取当天已落盘的条目。
+//
+// 当天文件损坏时（例如旧版本非原子写被中断留下的半截 JSON）不能当作「空的一天」
+// 静默继续——那样下一次写入会把残骸连同它代表的数据一起覆盖掉。这里把损坏文件
+// 隔离备份，并丢弃当天的 id / content-key 索引：索引描述的是已经读不出来的数据，
+// 留着它只会让手机重发的同一批通知被判定为重复，永远回不来。
+func (s *Storage) loadDay(dateKey string) []StoredNotification {
+	if entries, ok := s.dayCache[dateKey]; ok {
+		return entries
+	}
+	filePath := s.dayPath(dateKey)
+	entries, err := readStoredFile(filePath)
+	if err != nil {
+		s.quarantineDay(dateKey, filePath, err)
+		entries = nil
+	}
+	s.dayCache[dateKey] = entries
+	return entries
+}
+
+func (s *Storage) quarantineDay(dateKey, filePath string, cause error) {
+	backup := filePath + ".corrupt-" + time.Now().Format("20060102T150405")
+	if err := os.Rename(filePath, backup); err != nil {
+		s.logger.Warn("当天通知文件损坏且隔离失败: " + dateKey + ", " + err.Error())
+	} else {
+		s.logger.Warn("当天通知文件损坏，已隔离为 " + filepath.Base(backup) + "（" + cause.Error() + "）")
+	}
+	_ = os.Remove(filepath.Join(s.idIndexDir, dateKey+".ids"))
+	_ = os.Remove(filepath.Join(s.contentKeyDir, dateKey+".keys"))
+	delete(s.idCache, dateKey)
+	delete(s.contentKeyCach, dateKey)
 }
 
 // Init 准备目录；content-key 索引每次启动重建。
@@ -73,7 +118,19 @@ func (s *Storage) Init() error {
 	return os.MkdirAll(s.contentKeyDir, 0o755)
 }
 
+// staged 是一天里待落盘的新条目，以及为它们在内存缓存中占位的索引键。
+// 索引键先入缓存（这样同一批里的重复能被挡掉），落盘成功后才写进索引文件；
+// 落盘失败则从缓存回滚，避免索引比数据先一步存在。
+type staged struct {
+	entries    []StoredNotification
+	idKeys     []string
+	contentKys []string
+}
+
 // Ingest 写入一批通知，去重后返回统计与新插入条目。clientLabel 为来源（缺省 "default"）。
+//
+// 按日期分组、每天只落盘一次：逐条覆写整个当天数组会带来 O(n²) 的写放大
+// （一批 800 条能为一个 241 KB 的文件写掉近 100 MB）。
 func (s *Storage) Ingest(items []RawNotification, clientLabel string) IngestResult {
 	if clientLabel == "" {
 		clientLabel = "default"
@@ -82,56 +139,127 @@ func (s *Storage) Ingest(items []RawNotification, clientLabel string) IngestResu
 	defer s.mu.Unlock()
 
 	result := IngestResult{Received: len(items)}
+	days := map[string]*staged{}
+	var dayOrder []string
+	// 记录每条新条目属于哪一天，好在落盘后按原始顺序还原 Inserted。
+	type placed struct {
+		dateKey string
+		entry   StoredNotification
+	}
+	var placedItems []placed
+
 	for _, n := range items {
-		kind, entry := s.writeOne(n, clientLabel)
-		switch kind {
-		case "ingested":
-			result.Ingested++
-			result.Inserted = append(result.Inserted, entry)
-		case "dedupedById":
-			result.DedupedByID++
-		case "dedupedByContent":
-			result.DedupedByContent++
-		case "invalid":
+		ts, ok := ParseTime(n.Timestamp)
+		if !ok {
+			s.logger.Warn("忽略非法 timestamp 的通知: " + n.ID)
 			result.Invalid++
+			continue
+		}
+		dateKey := ts.In(time.Local).Format("2006-01-02")
+		// 先加载当天数据：损坏的文件在这里被隔离，索引也一并重置，
+		// 这样后面的 hasID 不会拿着一份「描述已不存在数据」的索引去挡掉重发。
+		existing := s.loadDay(dateKey)
+
+		entry := s.buildStored(n, clientLabel)
+		if entry.AppDisplayName == "" {
+			entry.AppDisplayName = entry.AppName
+		}
+		label := labelOrLegacy(entry.ClientLabel)
+		normalizedID := strings.TrimSpace(n.ID)
+
+		if normalizedID != "" && s.hasID(dateKey, label, normalizedID) {
+			result.DedupedByID++
+			continue
+		}
+		if s.hasContentKey(dateKey, existing, entry) {
+			result.DedupedByContent++
+			continue
+		}
+
+		day, ok := days[dateKey]
+		if !ok {
+			day = &staged{}
+			days[dateKey] = day
+			dayOrder = append(dayOrder, dateKey)
+		}
+		day.entries = append(day.entries, entry)
+		placedItems = append(placedItems, placed{dateKey: dateKey, entry: entry})
+
+		// 占位到内存缓存，挡掉同一批内部的重复。
+		if normalizedID != "" {
+			key := s.idKey(label, normalizedID)
+			s.idSet(dateKey)[key] = true
+			day.idKeys = append(day.idKeys, key)
+		}
+		ck := contentKey(entry)
+		s.contentKeySet(dateKey, existing)[ck] = true
+		day.contentKys = append(day.contentKys, ck)
+	}
+
+	failedDays := map[string]bool{}
+	for _, dateKey := range dayOrder {
+		if err := s.flushDay(dateKey, days[dateKey]); err != nil {
+			failedDays[dateKey] = true
+			s.logger.Warn("当天通知落盘失败，本批不计入库存: " + dateKey + ", " + err.Error())
 		}
 	}
+
+	for _, p := range placedItems {
+		if failedDays[p.dateKey] {
+			result.Failed++
+			continue
+		}
+		result.Ingested++
+		result.Inserted = append(result.Inserted, p.entry)
+	}
+
 	s.prune()
 	return result
 }
 
-func (s *Storage) writeOne(n RawNotification, clientLabel string) (string, StoredNotification) {
-	ts, ok := ParseTime(n.Timestamp)
-	if !ok {
-		s.logger.Warn("忽略非法 timestamp 的通知: " + n.ID)
-		return "invalid", StoredNotification{}
+// flushDay 把一天的新条目一次性原子写入，成功后才把索引落盘。
+func (s *Storage) flushDay(dateKey string, day *staged) error {
+	if len(day.entries) == 0 {
+		return nil
 	}
-	dateKey := ts.In(time.Local).Format("2006-01-02")
-	filePath := filepath.Join(s.dir, dateKey+".json")
-	normalizedID := strings.TrimSpace(n.ID)
-	entry := s.buildStored(n, clientLabel)
+	filePath := s.dayPath(dateKey)
+	arr := append(s.loadDay(dateKey), day.entries...)
 
-	if normalizedID != "" && s.hasID(dateKey, labelOrLegacy(entry.ClientLabel), normalizedID) {
-		return "dedupedById", StoredNotification{}
+	data, err := json.MarshalIndent(arr, "", "  ")
+	if err != nil {
+		s.revertStaged(dateKey, day)
+		return err
 	}
-	if s.hasContentKey(dateKey, filePath, entry) {
-		return "dedupedByContent", StoredNotification{}
+	// 原子写：os.WriteFile 先截断再写，中途崩溃会留下半截 JSON，
+	// 之后解析失败就会把当天数据整份丢掉。
+	if err := fsutil.WriteAtomic(filePath, data, storedFileMode); err != nil {
+		s.revertStaged(dateKey, day)
+		return err
 	}
+	s.dayCache[dateKey] = arr
 
-	if entry.AppDisplayName == "" {
-		entry.AppDisplayName = entry.AppName
+	for _, key := range day.idKeys {
+		appendLine(filepath.Join(s.idIndexDir, dateKey+".ids"), key)
 	}
-	arr := readStoredFile(filePath)
-	arr = append(arr, entry)
-	if data, err := json.MarshalIndent(arr, "", "  "); err == nil {
-		_ = os.WriteFile(filePath, data, 0o644)
+	for _, key := range day.contentKys {
+		appendLine(filepath.Join(s.contentKeyDir, dateKey+".keys"), key)
 	}
+	return nil
+}
 
-	if normalizedID != "" {
-		s.recordID(dateKey, labelOrLegacy(entry.ClientLabel), normalizedID)
+// revertStaged 撤回落盘失败那批在内存缓存里的索引占位，否则这些通知会被
+// 永久判定为「已存在」，重发也进不来。
+func (s *Storage) revertStaged(dateKey string, day *staged) {
+	if set, ok := s.idCache[dateKey]; ok {
+		for _, key := range day.idKeys {
+			delete(set, key)
+		}
 	}
-	s.recordContentKey(dateKey, filePath, entry)
-	return "ingested", entry
+	if set, ok := s.contentKeyCach[dateKey]; ok {
+		for _, key := range day.contentKys {
+			delete(set, key)
+		}
+	}
 }
 
 func (s *Storage) buildStored(n RawNotification, clientLabel string) StoredNotification {
@@ -217,16 +345,6 @@ func (s *Storage) hasID(dateKey, label, id string) bool {
 	return usesLegacyIDKey(label) && set[id]
 }
 
-func (s *Storage) recordID(dateKey, label, id string) {
-	set := s.idSet(dateKey)
-	key := s.idKey(label, id)
-	if set[key] {
-		return
-	}
-	appendLine(filepath.Join(s.idIndexDir, dateKey+".ids"), key)
-	set[key] = true
-}
-
 func contentKey(e StoredNotification) string {
 	h := sha256.New()
 	h.Write([]byte(labelOrLegacy(e.ClientLabel)))
@@ -241,13 +359,15 @@ func contentKey(e StoredNotification) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-func (s *Storage) contentKeySet(dateKey, filePath string) map[string]bool {
+// contentKeySet 从当天已落盘的条目重建 content-key 索引（Init 时清空 .keys 目录，
+// 所以这份索引始终派生自数据本身，不会比数据活得更久）。
+func (s *Storage) contentKeySet(dateKey string, existing []StoredNotification) map[string]bool {
 	if set, ok := s.contentKeyCach[dateKey]; ok {
 		return set
 	}
 	set := map[string]bool{}
 	keyPath := filepath.Join(s.contentKeyDir, dateKey+".keys")
-	for _, item := range readStoredFile(filePath) {
+	for _, item := range existing {
 		set[contentKey(item)] = true
 	}
 	if len(set) > 0 {
@@ -256,7 +376,7 @@ func (s *Storage) contentKeySet(dateKey, filePath string) map[string]bool {
 			b.WriteString(k)
 			b.WriteString("\n")
 		}
-		_ = os.WriteFile(keyPath, []byte(b.String()), 0o644)
+		_ = fsutil.WriteAtomic(keyPath, []byte(b.String()), storedFileMode)
 	} else {
 		_ = os.Remove(keyPath)
 	}
@@ -264,8 +384,8 @@ func (s *Storage) contentKeySet(dateKey, filePath string) map[string]bool {
 	return set
 }
 
-func (s *Storage) hasContentKey(dateKey, filePath string, e StoredNotification) bool {
-	set := s.contentKeySet(dateKey, filePath)
+func (s *Storage) hasContentKey(dateKey string, existing []StoredNotification, e StoredNotification) bool {
+	set := s.contentKeySet(dateKey, existing)
 	for _, label := range contentKeyLabels(e.ClientLabel) {
 		probe := e
 		probe.ClientLabel = label
@@ -284,22 +404,16 @@ func contentKeyLabels(label string) []string {
 	return []string{l}
 }
 
-func (s *Storage) recordContentKey(dateKey, filePath string, e StoredNotification) {
-	set := s.contentKeySet(dateKey, filePath)
-	key := contentKey(e)
-	if set[key] {
-		return
-	}
-	appendLine(filepath.Join(s.contentKeyDir, dateKey+".keys"), key)
-	set[key] = true
-}
-
 func (s *Storage) prune() {
 	if s.cfg.RetentionDays == nil {
 		return
 	}
 	cutoff := time.Now().Add(-time.Duration(*s.cfg.RetentionDays) * 24 * time.Hour).In(time.Local).Format("2006-01-02")
-	pruneByDate(s.dir, cutoff, []string{".json", ".md"}, func(k string) { delete(s.idCache, k); delete(s.contentKeyCach, k) }, false)
+	pruneByDate(s.dir, cutoff, []string{".json", ".md"}, func(k string) {
+		delete(s.idCache, k)
+		delete(s.contentKeyCach, k)
+		delete(s.dayCache, k)
+	}, false)
 	pruneByDate(s.idIndexDir, cutoff, []string{".ids"}, func(k string) { delete(s.idCache, k) }, true)
 	pruneByDate(s.contentKeyDir, cutoff, []string{".keys"}, func(k string) { delete(s.contentKeyCach, k) }, true)
 }
@@ -330,16 +444,24 @@ func pruneByDate(dir, cutoff string, exts []string, evict func(string), filesOnl
 	}
 }
 
-func readStoredFile(filePath string) []StoredNotification {
+// readStoredFile 读取当天条目。文件不存在返回空；内容损坏返回错误，
+// 交由调用方隔离——静默当成空的一天会让下一次写入覆盖掉当天全部数据。
+func readStoredFile(filePath string) ([]StoredNotification, error) {
 	raw, err := os.ReadFile(filePath)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
 	if err != nil {
-		return nil
+		return nil, err
+	}
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return nil, nil
 	}
 	var items []StoredNotification
-	if json.Unmarshal(raw, &items) != nil {
-		return nil
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return nil, err
 	}
-	return items
+	return items, nil
 }
 
 func appendLine(path, line string) {

--- a/internal/notif/storage_writepath_test.go
+++ b/internal/notif/storage_writepath_test.go
@@ -1,0 +1,205 @@
+package notif
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/YoooClaw/cli/internal/testutil"
+)
+
+func newTestStorage(t *testing.T, dir string) *Storage {
+	t.Helper()
+	s := NewStorage(dir, PluginConfig{}, testutil.Logger{T: t})
+	if err := s.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	return s
+}
+
+func notifAt(id string, ts time.Time, body string) RawNotification {
+	return RawNotification{
+		ID: id, App: "com.tencent.xin", Title: "老板",
+		Body: body, Timestamp: ts.Format(time.RFC3339),
+	}
+}
+
+// 一批通知里同一天只应落盘一次，而不是每条都覆写整个当天数组。
+func TestIngestWritesEachDayOnce(t *testing.T) {
+	dir := t.TempDir()
+	s := newTestStorage(t, dir)
+
+	day1 := time.Date(2026, 3, 23, 9, 0, 0, 0, time.Local)
+	day2 := day1.AddDate(0, 0, 1)
+
+	var items []RawNotification
+	for i := 0; i < 50; i++ {
+		items = append(items, notifAt(fmt.Sprintf("a-%d", i), day1.Add(time.Duration(i)*time.Second), fmt.Sprintf("d1-%d", i)))
+		items = append(items, notifAt(fmt.Sprintf("b-%d", i), day2.Add(time.Duration(i)*time.Second), fmt.Sprintf("d2-%d", i)))
+	}
+
+	res := s.Ingest(items, "probe")
+	if res.Ingested != 100 || res.Failed != 0 {
+		t.Fatalf("ingested=%d failed=%d, 期望 100/0", res.Ingested, res.Failed)
+	}
+
+	for _, day := range []time.Time{day1, day2} {
+		key := day.Format("2006-01-02")
+		entries, err := readStoredFile(filepath.Join(dir, key+".json"))
+		if err != nil {
+			t.Fatalf("%s: %v", key, err)
+		}
+		if len(entries) != 50 {
+			t.Fatalf("%s 落盘 %d 条，期望 50", key, len(entries))
+		}
+	}
+	if len(res.Inserted) != 100 {
+		t.Fatalf("Inserted=%d，期望 100", len(res.Inserted))
+	}
+	// Inserted 必须保持入参顺序（跨天交替），而不是按天分组后的顺序。
+	if res.Inserted[0].Content != "d1-0" || res.Inserted[1].Content != "d2-0" {
+		t.Fatalf("Inserted 顺序被打乱: %q, %q", res.Inserted[0].Content, res.Inserted[1].Content)
+	}
+}
+
+// 半截 JSON（旧版非原子写被中断的产物）不能被当成空的一天静默覆盖。
+func TestTruncatedDayFileIsQuarantinedNotOverwritten(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	dayKey := now.Format("2006-01-02")
+	dayFile := filepath.Join(dir, dayKey+".json")
+
+	s := newTestStorage(t, dir)
+	original := []RawNotification{
+		notifAt("a", now, "1"), notifAt("b", now, "2"), notifAt("c", now, "3"),
+	}
+	s.Ingest(original, "probe")
+
+	raw, err := os.ReadFile(dayFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dayFile, raw[:len(raw)/2], 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 新进程：缓存是空的，重新加载当天。
+	s2 := newTestStorage(t, dir)
+	res := s2.Ingest(original, "probe")
+
+	// 损坏的字节必须被留下来，而不是被覆盖掉。
+	matches, _ := filepath.Glob(dayFile + ".corrupt-*")
+	if len(matches) != 1 {
+		t.Fatalf("期望隔离出 1 个 .corrupt 备份，实际 %d 个", len(matches))
+	}
+
+	// 索引不能比数据活得久：重发的 3 条必须能重新入库。
+	if res.Ingested != 3 {
+		t.Fatalf("重发后 ingested=%d dedupedById=%d，期望 3 条全部重新入库",
+			res.Ingested, res.DedupedByID)
+	}
+	entries, err := readStoredFile(dayFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("当天文件 %d 条，期望 3 条", len(entries))
+	}
+}
+
+// 落盘失败时不能记索引，否则这批通知重发也进不来。
+func TestFailedFlushDoesNotPoisonIndexes(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	dateKey := now.Format("2006-01-02")
+	s := newTestStorage(t, dir)
+
+	// 用一个非空目录占住当天文件路径，让原子写的 rename 失败。
+	// 顺带预热 dayCache：否则 loadDay 会把这个目录当成损坏文件隔离走，
+	// 路径反而腾空了——这里要验证的是落盘真的失败之后的回滚。
+	blocker := s.dayPath(dateKey)
+	if err := os.MkdirAll(blocker, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(blocker, "blocker"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s.dayCache[dateKey] = nil
+
+	items := []RawNotification{notifAt("a", now, "1"), notifAt("b", now, "2")}
+	res := s.Ingest(items, "probe")
+	if res.Ingested != 0 || res.Failed != 2 {
+		t.Fatalf("ingested=%d failed=%d，期望 0/2", res.Ingested, res.Failed)
+	}
+
+	// 移开障碍后重发：两条都应该进得来，说明失败那批没有在索引里留下占位。
+	if err := os.RemoveAll(blocker); err != nil {
+		t.Fatal(err)
+	}
+	delete(s.dayCache, dateKey)
+	res = s.Ingest(items, "probe")
+	if res.Ingested != 2 {
+		t.Fatalf("重发 ingested=%d dedupedById=%d dedupedByContent=%d，期望 2 条入库",
+			res.Ingested, res.DedupedByID, res.DedupedByContent)
+	}
+}
+
+// 同一批里的重复仍然要被挡掉（索引占位不能因为延迟落盘而失效）。
+func TestIntraBatchDedupStillApplies(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	s := newTestStorage(t, dir)
+
+	res := s.Ingest([]RawNotification{
+		notifAt("a", now, "1"),
+		notifAt("a", now, "1"), // 同 id
+		notifAt("", now, "1"),  // 无 id，但内容与第一条一致
+	}, "probe")
+
+	if res.Ingested != 1 {
+		t.Fatalf("ingested=%d，期望 1", res.Ingested)
+	}
+	if res.DedupedByID != 1 || res.DedupedByContent != 1 {
+		t.Fatalf("dedupedById=%d dedupedByContent=%d，期望 1/1", res.DedupedByID, res.DedupedByContent)
+	}
+
+	entries, err := readStoredFile(filepath.Join(dir, now.Format("2006-01-02")+".json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("当天落盘 %d 条，期望 1", len(entries))
+	}
+}
+
+// 落盘的仍然是合法 JSON 数组，且已有数据会被保留。
+func TestIngestAppendsToExistingDay(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	dayFile := filepath.Join(dir, now.Format("2006-01-02")+".json")
+
+	s := newTestStorage(t, dir)
+	s.Ingest([]RawNotification{notifAt("a", now, "1")}, "probe")
+
+	s2 := newTestStorage(t, dir)
+	s2.Ingest([]RawNotification{notifAt("b", now, "2")}, "probe")
+
+	raw, err := os.ReadFile(dayFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var entries []StoredNotification
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		t.Fatalf("落盘内容不是合法 JSON 数组: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("当天 %d 条，期望 2 条（新旧都在）", len(entries))
+	}
+	if !strings.HasSuffix(strings.TrimSpace(string(raw)), "]") {
+		t.Fatalf("落盘内容看起来被截断了")
+	}
+}


### PR DESCRIPTION
## 变更
- 将同一天的通知按批次原子落盘，降低写放大并避免中断时留下半截 JSON。
- 隔离损坏的通知文件，并清理对应去重索引以允许客户端重发。
- 落盘失败时回滚内存去重占位，并在 ingest 响应中报告 `failed`。

## 影响
- 防止通知文件损坏后静默覆盖和丢失。
- 同一批通知按日期仅写一次，改善大批量导入性能。

## 验证
- `go test ./...`
- `go test -race ./internal/notif`
- `go vet ./...`