### PR TITLE
ci: notify Feishu after builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,33 @@ jobs:
 
       - name: Build npm distribution (current platform)
         run: scripts/build-go.sh --current
+
+      - name: Notify Feishu (build complete)
+        if: success() && github.event_name == 'push'
+        env:
+          HOOK: ${{ secrets.FEISHU_WEBHOOK_2 }}
+        run: |
+          if [ -z "$HOOK" ]; then
+            echo "::warning::FEISHU_WEBHOOK_2 未配置，跳过构建通知"
+            exit 0
+          fi
+
+          RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          SHORT_SHA="$(git rev-parse --short=12 "$GITHUB_SHA")"
+          TEXT="✅ @yoooclaw/cli 构建完成
+
+          🌿 分支：${GITHUB_REF_NAME}
+          🔖 Commit：${SHORT_SHA}
+          🔎 ${RUN_URL}"
+          PAYLOAD=$(jq -nc --arg t "$TEXT" '{msg_type:"text", content:{text:$t}}')
+
+          if ! resp=$(curl -fsS -X POST -H 'Content-Type: application/json' -d "$PAYLOAD" "$HOOK"); then
+            echo "::warning::Feishu webhook 推送失败（curl 请求错误）"
+            exit 0
+          fi
+          code=$(printf '%s' "$resp" | jq -r '.code // .StatusCode // empty')
+          if [ "$code" != "0" ]; then
+            echo "::warning::Feishu webhook 推送被拒绝（响应: ${resp}）"
+            exit 0
+          fi
+          echo "::notice::Feishu 构建通知已送达"

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -431,7 +431,6 @@ jobs:
       - name: Notify Feishu
         if: success()
         env:
-          HOOK_1: ${{ secrets.FEISHU_WEBHOOK_1 }}
           HOOK_2: ${{ secrets.FEISHU_WEBHOOK_2 }}
         run: |
           CURRENT_TAG="cli-v${VERSION}"
@@ -470,7 +469,7 @@ jobs:
 
           PAYLOAD=$(jq -nc --arg t "$TEXT" '{msg_type:"text", content:{text:$t}}')
 
-          for hook in "$HOOK_1" "$HOOK_2"; do
+          for hook in "$HOOK_2"; do
             [ -z "$hook" ] && continue
             if ! curl -fsS -X POST -H 'Content-Type: application/json' -d "$PAYLOAD" "$hook"; then
               echo "::warning::Feishu webhook 推送失败"


### PR DESCRIPTION
从 codex/atomic-notification-storage 分支单独摘出的 CI 提交（该分支的存储修复已随 #38 合入 master，此提交当时未包含在内）。

## 变更
- `ci.yml`：构建完成后推送 Feishu 通知
- `release-cli.yml`：Feishu 通知收敛到单个 webhook（移除 `FEISHU_WEBHOOK_1`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)