### PR TITLE
cli-0.6.0-beta.2

### DIFF
--- a/internal/daemon/addrinuse_unix.go
+++ b/internal/daemon/addrinuse_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"errors"
+	"syscall"
+)
+
+func isAddrInUse(err error) bool {
+	return errors.Is(err, syscall.EADDRINUSE)
+}

--- a/internal/daemon/addrinuse_windows.go
+++ b/internal/daemon/addrinuse_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package daemon
+
+import (
+	"errors"
+	"syscall"
+)
+
+// wsaeaddrinuse 是 Windows 的 WSAEADDRINUSE（10048），stdlib syscall 没有导出它。
+const wsaeaddrinuse = syscall.Errno(10048)
+
+func isAddrInUse(err error) bool {
+	return errors.Is(err, wsaeaddrinuse)
+}

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -53,8 +54,10 @@ func newClient(p paths.Paths, token string) *Client {
 	}
 }
 
-// Request 调 daemon；localhost 连接失败（包括 reset/EOF/超时）统一报
-// DAEMON_NOT_RUNNING，让生命周期监管可以清理陈旧 lock 并重启 daemon。
+// Request 调 daemon；localhost 连接失败（refused/reset/EOF）报 DAEMON_NOT_RUNNING，
+// 让生命周期监管可以清理陈旧 lock 并重启 daemon。**超时除外**：超时只说明 daemon
+// 忙或慢，进程多半还活着，报 DAEMON_UNRESPONSIVE——监管方拿到它应该退避重试，
+// 而不是删 lock 重启一个活着的进程（那会造成新旧进程并存、端口漂移）。
 func (c *Client) Request(method, path string, body any) (int, any, error) {
 	var reader io.Reader
 	if body != nil {
@@ -75,6 +78,10 @@ func (c *Client) Request(method, path string, body any) (int, any, error) {
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
+		if isTimeoutErr(err) {
+			return 0, nil, errs.New(errs.CodeDaemonUnresponsive, "daemon 响应超时（进程可能仍在运行，只是繁忙）",
+				map[string]any{"hint": "稍后重试；持续超时再考虑 yoooclaw daemon restart", "baseUrl": c.BaseURL, "cause": err.Error()})
+		}
 		return 0, nil, errs.New(errs.CodeDaemonNotRunning, "daemon 未启动或无响应",
 			map[string]any{"hint": "先执行 yoooclaw daemon start", "baseUrl": c.BaseURL, "cause": err.Error()})
 	}
@@ -91,6 +98,16 @@ func (c *Client) Request(method, path string, body any) (int, any, error) {
 			map[string]any{"status": resp.StatusCode})
 	}
 	return resp.StatusCode, parsed, nil
+}
+
+// isTimeoutErr 识别请求超时（context deadline / net timeout）。
+// 连接建立失败（refused/reset）不算：那些才是「daemon 不在」的信号。
+func isTimeoutErr(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
 }
 
 func daemonBaseURL(bind string, port int) string {

--- a/internal/daemon/client_test.go
+++ b/internal/daemon/client_test.go
@@ -64,6 +64,23 @@ func TestClientRequestConnectionResetIsDaemonNotRunning(t *testing.T) {
 	}
 }
 
+func TestClientRequestTimeoutIsUnresponsive(t *testing.T) {
+	t.Parallel()
+	block := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-block // 模拟繁忙的 daemon：连接建立成功但迟迟不响应
+	}))
+	// Cleanup 在 defer 之后执行：srv.Close 会等 in-flight handler 结束，
+	// 必须先 close(block) 放行。
+	t.Cleanup(srv.Close)
+	defer close(block)
+	c := &Client{BaseURL: srv.URL, timeout: 100 * time.Millisecond}
+	_, _, err := c.Request("GET", "/daemon/status", nil)
+	if e, ok := err.(*errs.Error); !ok || e.Code != errs.CodeDaemonUnresponsive {
+		t.Fatalf("timeout should map to DAEMON_UNRESPONSIVE (not NOT_RUNNING), got %v", err)
+	}
+}
+
 func TestClientRequestSuccess(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "Bearer tok" {

--- a/internal/daemon/lock.go
+++ b/internal/daemon/lock.go
@@ -4,11 +4,20 @@
 package daemon
 
 import (
+	"errors"
 	"os"
 
 	"github.com/YoooClaw/cli/internal/fsutil"
 	"github.com/YoooClaw/cli/internal/paths"
 )
+
+// daemonSingletonName 是 daemon 进程的 OS 级单例锁文件（flock / LockFileEx）。
+// daemon.lock 是原子替换的 JSON（rename 会换 inode），锁不能直接加在它上面。
+// OS 锁随进程退出（含崩溃）自动释放，不存在陈旧状态。
+const daemonSingletonName = "daemon.flock"
+
+// errProcessLockHeld 表示单例锁已被其他进程持有。
+var errProcessLockHeld = errors.New("daemon 单例锁已被其他进程持有")
 
 // Lock 是 daemon.lock 的内容。
 type Lock struct {
@@ -64,6 +73,15 @@ func WriteLock(p paths.Paths, lock Lock) error {
 // RemoveLock 删除锁文件。
 func RemoveLock(p paths.Paths) {
 	_ = os.Remove(p.DaemonLock)
+}
+
+// RemoveLockIfOwnedBy 仅当锁仍指向 pid 时删除。daemon 自身的退出路径必须用
+// 这个变体：迟退出的旧进程不能删掉新 daemon 刚写下的锁，否则新 daemon 会被
+// 误判为未运行而再次触发重启。
+func RemoveLockIfOwnedBy(p paths.Paths, pid int) {
+	if lock := ReadLock(p); lock != nil && lock.PID == pid {
+		RemoveLock(p)
+	}
 }
 
 // IsProcessAlive 导出探活（供 daemon 命令判断目标进程）。

--- a/internal/daemon/lock_test.go
+++ b/internal/daemon/lock_test.go
@@ -54,6 +54,22 @@ func TestLockRoundTrip(t *testing.T) {
 	}
 }
 
+func TestRemoveLockIfOwnedBy(t *testing.T) {
+	p := sandboxPaths(t)
+	if err := WriteLock(p, Lock{PID: 4242, Port: 1}); err != nil {
+		t.Fatal(err)
+	}
+	// 迟退出的旧进程（pid 不同）不能删掉新 daemon 的锁。
+	RemoveLockIfOwnedBy(p, 1111)
+	if ReadLock(p) == nil {
+		t.Fatal("lock owned by another pid must survive")
+	}
+	RemoveLockIfOwnedBy(p, 4242)
+	if ReadLock(p) != nil {
+		t.Fatal("owner pid should remove the lock")
+	}
+}
+
 func TestStopRejectsLifecycleMismatch(t *testing.T) {
 	p := sandboxPaths(t)
 	if err := WriteLock(p, Lock{PID: os.Getpid(), Owner: "hermes-plugin", Generation: "gen-1", Port: 1}); err != nil {

--- a/internal/daemon/logger.go
+++ b/internal/daemon/logger.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -11,14 +12,21 @@ import (
 
 var levelOrder = map[string]int{"error": 0, "warn": 1, "info": 2, "debug": 3, "trace": 4}
 
+// logRetentionDays 是轮转出的历史日志（daemon.log.YYYY-MM-DD）保留天数。
+// 不清理的话长期运行的机器会被日志慢慢填满磁盘，进而拖垮通知落盘。
+const logRetentionDays = 7
+
 // Logger 是 daemon 文件 logger，写 daemon.log 并按日期轮转为 daemon.log.YYYY-MM-DD。
 // 行格式：`<ISO本地时间> [LEVEL] message`（与 logread 解析一致）。
+// 文件句柄常驻（每行 open/close 在心跳、ingest 高频写下开销可观），仅在跨天
+// 轮转或写失败时重开。
 type Logger struct {
 	logFile    string
 	level      string
 	alsoStderr bool
 	mu         sync.Mutex
 	currentDay string
+	f          *os.File
 }
 
 // NewLogger 构造 logger。
@@ -29,6 +37,7 @@ func NewLogger(logFile, level string, alsoStderr bool) *Logger {
 	_ = fsutil.EnsureDir(filepath.Dir(logFile), fsutil.DirMode)
 	l := &Logger{logFile: logFile, level: level, alsoStderr: alsoStderr, currentDay: dateKey(time.Now())}
 	l.rotateIfNeeded(time.Now())
+	l.cleanupRotated(time.Now())
 	return l
 }
 
@@ -48,6 +57,8 @@ func (l *Logger) enabled(level string) bool {
 	return lv <= cur
 }
 
+// rotateIfNeeded 按日期轮转；调用方须已持有 l.mu（或在构造期单线程调用），
+// 且已关闭常驻句柄——rename 一个仍被持有的 fd 会让后续写落进轮转后的文件。
 func (l *Logger) rotateIfNeeded(now time.Time) {
 	info, err := os.Stat(l.logFile)
 	if err != nil {
@@ -59,6 +70,27 @@ func (l *Logger) rotateIfNeeded(now time.Time) {
 	}
 }
 
+// cleanupRotated 删除超过保留期的历史日志文件。
+func (l *Logger) cleanupRotated(now time.Time) {
+	dir := filepath.Dir(l.logFile)
+	prefix := filepath.Base(l.logFile) + "."
+	cutoff := dateKey(now.AddDate(0, 0, -logRetentionDays))
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		day := strings.TrimPrefix(name, prefix)
+		if len(day) == 10 && day < cutoff {
+			_ = os.Remove(filepath.Join(dir, name))
+		}
+	}
+}
+
 func (l *Logger) write(level, msg string) {
 	if !l.enabled(level) {
 		return
@@ -67,17 +99,42 @@ func (l *Logger) write(level, msg string) {
 	defer l.mu.Unlock()
 	now := time.Now()
 	if dateKey(now) != l.currentDay {
+		if l.f != nil {
+			_ = l.f.Close()
+			l.f = nil
+		}
 		l.rotateIfNeeded(now)
+		l.cleanupRotated(now)
 		l.currentDay = dateKey(now)
 	}
 	line := isoLocal(now) + " [" + upper(level) + "] " + msg + "\n"
-	if f, err := os.OpenFile(l.logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644); err == nil {
-		_, _ = f.WriteString(line)
-		_ = f.Close()
-	}
+	l.writeLineLocked(line)
 	if l.alsoStderr {
 		_, _ = os.Stderr.WriteString(line)
 	}
+}
+
+func (l *Logger) writeLineLocked(line string) {
+	if l.f == nil && !l.reopenLocked() {
+		return
+	}
+	if _, err := l.f.WriteString(line); err != nil {
+		// 句柄可能已失效（文件被外部删除/移动），重开一次再试。
+		_ = l.f.Close()
+		l.f = nil
+		if l.reopenLocked() {
+			_, _ = l.f.WriteString(line)
+		}
+	}
+}
+
+func (l *Logger) reopenLocked() bool {
+	f, err := os.OpenFile(l.logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return false
+	}
+	l.f = f
+	return true
 }
 
 func upper(s string) string {

--- a/internal/daemon/logger_test.go
+++ b/internal/daemon/logger_test.go
@@ -34,6 +34,26 @@ func TestLoggerWritesLevels(t *testing.T) {
 	}
 }
 
+func TestLoggerCleanupRotated(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "daemon.log")
+	stale := logFile + ".2020-01-01"
+	fresh := logFile + "." + dateKey(time.Now().AddDate(0, 0, -1))
+	for _, f := range []string{stale, fresh} {
+		if err := os.WriteFile(f, []byte("x\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	NewLogger(logFile, "info", false)
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Error("rotated log beyond retention should be removed")
+	}
+	if _, err := os.Stat(fresh); err != nil {
+		t.Error("recent rotated log should survive cleanup")
+	}
+}
+
 func TestLoggerLevelDefaults(t *testing.T) {
 	t.Parallel()
 	l := NewLogger(filepath.Join(t.TempDir(), "x.log"), "", false)

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -1,13 +1,16 @@
 package daemon
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -80,6 +83,17 @@ func RunForeground(ctx *clictx.Context, opts StartOpts) error {
 	}
 
 	_ = fsutil.EnsureDir(ctx.Paths.Dir, fsutil.DirMode)
+	// OS 级单例互斥。仅靠 daemon.lock 的 check-then-write 有竞态：两个 daemon
+	// 并发启动时端口 +1 回退让双方都能起来，后者的 lock 覆盖前者，之后退出时
+	// 再互删对方的锁。flock 拿不到直接拒绝启动；获取本身出错（受限文件系统等）
+	// 按未持有处理，退回原有 lock 文件语义，不把 daemon 卡死。
+	releaseSingleton, lockErr := acquireProcessLock(filepath.Join(ctx.Paths.Dir, daemonSingletonName))
+	if errors.Is(lockErr, errProcessLockHeld) {
+		return errs.New(errs.CodeDaemonAlreadyRunning, "另一个 daemon 进程持有单例锁，拒绝重复启动")
+	}
+	if releaseSingleton != nil {
+		defer releaseSingleton()
+	}
 	ctx.Paths.MigrateLogs()
 	logger := NewLogger(ctx.Paths.DaemonLog, logLevel, false)
 	st := &runtimeState{startedAt: time.Now().UTC().Format(time.RFC3339)}
@@ -133,7 +147,15 @@ func RunForeground(ctx *clictx.Context, opts StartOpts) error {
 	defer ln.Close()
 	srv.port = actualPort
 
-	httpSrv := &http.Server{Handler: srv}
+	// ReadHeaderTimeout/IdleTimeout 防止半开连接把 goroutine/fd 无限攒下去
+	// （长期运行后 accept 堆死是「daemon 还在但没响应」的典型来源）。
+	// 不设 WriteTimeout/ReadTimeout：慢速手机端上传大 payload 是合法场景，
+	// 请求体大小由 ServeHTTP 里的 MaxBytesReader 兜底。
+	httpSrv := &http.Server{
+		Handler:           srv,
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       2 * time.Minute,
+	}
 	if err := WriteLock(ctx.Paths, Lock{
 		PID: os.Getpid(), StartedAt: st.startedAt, Bind: bind, Port: actualPort, LogLevel: logLevel,
 		Owner: opts.Owner, Generation: opts.Generation, Executable: executable, Version: version.Version, Profile: ctx.Profile,
@@ -141,8 +163,10 @@ func RunForeground(ctx *clictx.Context, opts StartOpts) error {
 		return err
 	}
 	// Every non-os.Exit return path must retire the lock. This includes startup
-	// failures and unexpected http.Server termination.
-	defer RemoveLock(ctx.Paths)
+	// failures and unexpected http.Server termination. Removal is PID-guarded:
+	// a lingering old daemon must never delete a newer daemon's lock.
+	selfPID := os.Getpid()
+	defer RemoveLockIfOwnedBy(ctx.Paths, selfPID)
 	logger.Info(fmt.Sprintf("yoooclaw daemon 启动：%s:%d（profile=%s, pid=%d）", bind, actualPort, ctx.Profile, os.Getpid()))
 	switch mode {
 	case config.IngressProxied:
@@ -175,11 +199,17 @@ func RunForeground(ctx *clictx.Context, opts StartOpts) error {
 	signal.Notify(stop, syscall.SIGTERM, syscall.SIGINT)
 	srv.shutdown = func(reason string) {
 		logger.Info("daemon 退出（" + reason + "）")
-		if srv.tunnelSupervisor != nil {
-			srv.tunnelSupervisor.StopAll(reason)
+		if sup := srv.supervisor(); sup != nil {
+			sup.StopAll(reason)
 		}
-		_ = httpSrv.Close()
-		RemoveLock(ctx.Paths)
+		// 给 in-flight 请求 3 秒收尾（正在落盘的 ingest 批次能写完），
+		// 超时再硬关，保证退出不会被慢客户端拖死。
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		if err := httpSrv.Shutdown(shutdownCtx); err != nil {
+			_ = httpSrv.Close()
+		}
+		RemoveLockIfOwnedBy(ctx.Paths, selfPID)
 		os.Exit(0)
 	}
 
@@ -190,7 +220,7 @@ func RunForeground(ctx *clictx.Context, opts StartOpts) error {
 
 	if err := httpSrv.Serve(ln); err != nil && err != http.ErrServerClosed {
 		logger.Error("HTTP server 异常：" + err.Error())
-		RemoveLock(ctx.Paths)
+		RemoveLockIfOwnedBy(ctx.Paths, selfPID)
 		return err
 	}
 	return nil
@@ -204,11 +234,8 @@ type server struct {
 	storage           *notif.Storage
 	recordingStorage  *recording.Storage
 	recordingEventLog *recording.EventLog
-	tunnelSupervisor  *relay.Supervisor
-	egress            Egress
 	ingressMode       string
 	token             string
-	credentialSet     creds.CredentialSet
 	ignored           map[string]bool
 	bind              string
 	port              int
@@ -216,7 +243,37 @@ type server struct {
 	generation        string
 	executable        string
 	shutdown          func(string)
+
+	// shareMu 保护下面三个字段：/daemon/reload 会在请求 goroutine 里整体替换它们，
+	// 而每个并发请求都在读（鉴权、status、egress 推送）。
+	shareMu          sync.RWMutex
+	credentialSet    creds.CredentialSet
+	tunnelSupervisor *relay.Supervisor
+	egress           Egress
 }
+
+func (s *server) snapshotCreds() creds.CredentialSet {
+	s.shareMu.RLock()
+	defer s.shareMu.RUnlock()
+	return s.credentialSet
+}
+
+func (s *server) supervisor() *relay.Supervisor {
+	s.shareMu.RLock()
+	defer s.shareMu.RUnlock()
+	return s.tunnelSupervisor
+}
+
+func (s *server) currentEgress() Egress {
+	s.shareMu.RLock()
+	defer s.shareMu.RUnlock()
+	return s.egress
+}
+
+// maxRequestBodyBytes 是单请求体上限。最大的合法 payload 是 base64 图片同步
+// （config.image.maxBytes 默认 20MB，base64 膨胀 ~1.37x），64MB 足够宽裕；
+// 没有上限的话一个恶意/异常的大 POST 就能把 daemon 直接 OOM。
+const maxRequestBodyBytes = 64 << 20
 
 func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer func() {
@@ -225,6 +282,9 @@ func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, 500, map[string]any{"ok": false, "error": map[string]any{"code": "INTERNAL_ERROR", "message": fmt.Sprintf("%v", rec)}})
 		}
 	}()
+	if r.Body != nil {
+		r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	}
 	path := r.URL.Path
 
 	if path == "/health" && r.Method == http.MethodGet {
@@ -246,27 +306,10 @@ func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		s.logger.Info("收到 /daemon/stop，准备优雅退出")
 		go func() { time.Sleep(50 * time.Millisecond); s.shutdown("stop-endpoint") }()
 	case path == "/daemon/reload" && r.Method == http.MethodPost:
-		s.credentialSet = creds.ResolveAPIKeyEntries()
-		relayResult := relay.ApplyResult{}
-		if s.ingressMode == config.IngressStandalone && s.cfg.Relay.Enabled {
-			if s.tunnelSupervisor == nil && len(s.credentialSet.Entries) > 0 {
-				s.tunnelSupervisor = relay.NewSupervisor(relay.SupervisorOptions{
-					TunnelURL:          config.ResolveRelayURL(s.cfg),
-					HTTPBaseURL:        "http://127.0.0.1:" + fmt.Sprint(s.port),
-					HTTPToken:          s.token,
-					HeartbeatSec:       s.cfg.Relay.HeartbeatSec,
-					ReconnectBackoffMs: s.cfg.Relay.ReconnectBackoffMs,
-					StateDir:           s.ctx.Paths.Dir,
-					Logger:             s.logger,
-				})
-			}
-			if s.tunnelSupervisor != nil {
-				relayResult = s.tunnelSupervisor.Apply(s.credentialSet)
-			}
-		}
+		set, relayResult := s.reloadCredentials()
 		writeJSON(w, 200, map[string]any{
-			"ok": true, "running": true, "reloaded": true, "mode": s.credentialSet.Mode,
-			"defaultLabel": defaultEntryLabel(s.credentialSet), "warnings": s.credentialSet.Warnings,
+			"ok": true, "running": true, "reloaded": true, "mode": set.Mode,
+			"defaultLabel": defaultEntryLabel(set), "warnings": set.Warnings,
 			"started": relayResult.Started, "stopped": relayResult.Stopped,
 			"restarted": relayResult.Restarted, "unchanged": relayResult.Unchanged,
 		})
@@ -293,6 +336,37 @@ func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	default:
 		writeJSON(w, 404, map[string]any{"ok": false, "error": map[string]any{"code": errs.CodeNotFound, "message": "未知路径：" + path}})
 	}
+}
+
+// reloadCredentials 重读凭据并增量刷新隧道。持 shareMu 写锁做整体替换；
+// supervisor.Apply 里的网络操作是非阻塞的（隧道在各自 goroutine 建连），
+// 不会长时间占住写锁。
+func (s *server) reloadCredentials() (creds.CredentialSet, relay.ApplyResult) {
+	set := creds.ResolveAPIKeyEntries()
+	relayResult := relay.ApplyResult{}
+	s.shareMu.Lock()
+	defer s.shareMu.Unlock()
+	s.credentialSet = set
+	if s.ingressMode == config.IngressStandalone && s.cfg.Relay.Enabled {
+		if s.tunnelSupervisor == nil && len(set.Entries) > 0 {
+			s.tunnelSupervisor = relay.NewSupervisor(relay.SupervisorOptions{
+				TunnelURL:          config.ResolveRelayURL(s.cfg),
+				HTTPBaseURL:        "http://127.0.0.1:" + fmt.Sprint(s.port),
+				HTTPToken:          s.token,
+				HeartbeatSec:       s.cfg.Relay.HeartbeatSec,
+				ReconnectBackoffMs: s.cfg.Relay.ReconnectBackoffMs,
+				StateDir:           s.ctx.Paths.Dir,
+				Logger:             s.logger,
+			})
+			// 启动时没有 api-key 的话 egress 是 Noop；补上隧道后出站事件
+			// 必须跟着切到 Relay，否则 recording.status 等推送会一直被丢弃。
+			s.egress = NewRelayEgress(s.tunnelSupervisor)
+		}
+		if s.tunnelSupervisor != nil {
+			relayResult = s.tunnelSupervisor.Apply(set)
+		}
+	}
+	return set, relayResult
 }
 
 type authResult struct {
@@ -327,7 +401,7 @@ func (s *server) labelForAPIKey(apiKey string) string {
 		return ""
 	}
 	raw := strings.TrimPrefix(apiKey, "Bearer ")
-	for _, e := range s.credentialSet.Entries {
+	for _, e := range s.snapshotCreds().Entries {
 		if strings.TrimPrefix(e.Key, "Bearer ") == raw {
 			return e.Label
 		}
@@ -393,9 +467,10 @@ func (s *server) handleStatus(w http.ResponseWriter) {
 	lastIngest := s.st.lastIngest
 	ingestCount := s.st.ingestCount
 	s.st.mu.Unlock()
+	set := s.snapshotCreds()
 	var defaultLabel any
-	if s.credentialSet.DefaultEntry != nil {
-		defaultLabel = s.credentialSet.DefaultEntry.Label
+	if set.DefaultEntry != nil {
+		defaultLabel = set.DefaultEntry.Label
 	}
 	relayStatus := s.relayStatusPayload()
 	writeJSON(w, 200, map[string]any{
@@ -411,14 +486,14 @@ func (s *server) handleStatus(w http.ResponseWriter) {
 		"ingressMode":    s.ingressMode,
 		"relay":          relayStatus,
 		"tunnels":        relayStatus["tunnels"],
-		"credentialMode": s.credentialSet.Mode, "defaultLabel": defaultLabel,
-		"credentialWarnings": s.credentialSet.Warnings,
+		"credentialMode": set.Mode, "defaultLabel": defaultLabel,
+		"credentialWarnings": set.Warnings,
 	})
 }
 
 func (s *server) relayStatusPayload() map[string]any {
-	if s.tunnelSupervisor != nil {
-		status := s.tunnelSupervisor.Status()
+	if sup := s.supervisor(); sup != nil {
+		status := sup.Status()
 		connected := false
 		reconnectAttempt := 0
 		lastDisconnectReason := ""
@@ -489,7 +564,9 @@ func listenWithFallback(bind string, startPort int, logger *Logger) (net.Listene
 			}
 			return ln, actualPort, nil
 		}
-		if !strings.Contains(err.Error(), "address already in use") {
+		// errno 判断为主（Windows 的报错文案是 "Only one usage of each socket
+		// address"，字符串匹配不到会让端口回退整个失效），字符串匹配只作兜底。
+		if !isAddrInUse(err) && !strings.Contains(err.Error(), "address already in use") {
 			return nil, 0, err
 		}
 		logger.Warn(fmt.Sprintf("端口 %d 被占用，改试 %d", port, port+1))

--- a/internal/daemon/server_ingest.go
+++ b/internal/daemon/server_ingest.go
@@ -230,8 +230,8 @@ func (s *server) handleImageGateway(w http.ResponseWriter, r *http.Request, auth
 
 func (s *server) resolveConfiguredASR(caller *recording.AsrConfig) *recording.AsrConfig {
 	fallback := ""
-	if s.credentialSet.DefaultEntry != nil {
-		fallback = s.credentialSet.DefaultEntry.Key
+	if set := s.snapshotCreds(); set.DefaultEntry != nil {
+		fallback = set.DefaultEntry.Key
 	}
 	return recording.ResolveAsrConfig(caller, recording.LoadLocalAsrConfig(s.ctx.Paths.Recordings), fallback)
 }
@@ -243,8 +243,8 @@ func (s *server) notifyRecordingStatus(event recording.StatusEvent) {
 			s.logger.Warn("[recording-status] 事件落盘失败: " + err.Error())
 		}
 	}
-	if s.egress != nil {
-		if err := s.egress.PushEvent("recording.status", event); err != nil {
+	if egress := s.currentEgress(); egress != nil {
+		if err := egress.PushEvent("recording.status", event); err != nil {
 			s.logger.Warn("[recording-status] 出站事件投递失败: " + err.Error())
 		}
 	}

--- a/internal/daemon/server_services.go
+++ b/internal/daemon/server_services.go
@@ -67,15 +67,17 @@ func (s *server) handleTunnel(w http.ResponseWriter, r *http.Request, path strin
 		if client != "" && client != "all" {
 			relayStatus["tunnels"] = filterRelayTunnels(relayStatus["tunnels"], client)
 		}
+		set := s.snapshotCreds()
 		writeJSON(w, 200, map[string]any{
-			"ok": true, "mode": relayStatus["mode"], "credentialMode": s.credentialSet.Mode,
-			"defaultLabel": defaultEntryLabel(s.credentialSet),
+			"ok": true, "mode": relayStatus["mode"], "credentialMode": set.Mode,
+			"defaultLabel": defaultEntryLabel(set),
 			"connected":    relayStatus["connected"], "relayUrl": relayStatus["url"], "enabled": s.cfg.Relay.Enabled,
 			"reconnectAttempt": relayStatus["reconnectAttempt"], "lastDisconnectReason": relayStatus["lastDisconnectReason"],
 			"note": relayStatus["note"], "tunnels": relayStatus["tunnels"],
 		})
 	case "/tunnel/reconnect":
-		if s.tunnelSupervisor == nil {
+		sup := s.supervisor()
+		if sup == nil {
 			relayStatus := s.relayStatusPayload()
 			writeJSON(w, 200, map[string]any{"ok": true, "mode": relayStatus["mode"], "reconnected": false, "note": relayStatus["note"]})
 			return
@@ -90,7 +92,7 @@ func (s *server) handleTunnel(w http.ResponseWriter, r *http.Request, path strin
 		if client == "all" {
 			client = ""
 		}
-		reconnected, missing := s.tunnelSupervisor.Reconnect(client)
+		reconnected, missing := sup.Reconnect(client)
 		if missing != "" {
 			writeJSON(w, 404, errBody("YOOOCLAW_TUNNEL_LABEL_NOT_FOUND", "隧道不存在："+missing))
 			return
@@ -123,7 +125,7 @@ func (s *server) handleTunnel(w http.ResponseWriter, r *http.Request, path strin
 }
 
 func (s *server) hasCredentialLabel(label string) bool {
-	for _, entry := range s.credentialSet.Entries {
+	for _, entry := range s.snapshotCreds().Entries {
 		if entry.Label == label {
 			return true
 		}

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -131,6 +131,31 @@ func TestServerIngestNotifications(t *testing.T) {
 	}
 }
 
+// TestReloadConcurrentWithRequests 回归 /daemon/reload 与并发请求的数据竞争：
+// reload 整体替换 credentialSet/tunnelSupervisor/egress，其余请求都在读。
+// 由 -race 检测撕裂读写。
+func TestReloadConcurrentWithRequests(t *testing.T) {
+	_, ts := newTestServer(t, "")
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 20; i++ {
+			resp, err := http.Post(ts.URL+"/daemon/reload", "application/json", nil)
+			if err == nil {
+				resp.Body.Close()
+			}
+		}
+	}()
+	for i := 0; i < 20; i++ {
+		resp, err := http.Get(ts.URL + "/daemon/status")
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+	}
+	<-done
+}
+
 func TestServerNotFound(t *testing.T) {
 	_, ts := newTestServer(t, "")
 	resp, err := http.Get(ts.URL + "/no/such/path")

--- a/internal/daemon/singleton_unix.go
+++ b/internal/daemon/singleton_unix.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// acquireProcessLock 非阻塞获取排他 flock 并持有到 release 被调用（或进程退出）。
+// 已被其他进程持有时返回 errProcessLockHeld。
+func acquireProcessLock(path string) (release func(), err error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			return nil, errProcessLockHeld
+		}
+		return nil, err
+	}
+	return func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}, nil
+}

--- a/internal/daemon/singleton_unix_test.go
+++ b/internal/daemon/singleton_unix_test.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestAcquireProcessLockExclusive(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), daemonSingletonName)
+
+	release, err := acquireProcessLock(path)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	// flock 绑定在 open file description 上，二次 open 即使同进程也会冲突。
+	if _, err := acquireProcessLock(path); !errors.Is(err, errProcessLockHeld) {
+		t.Fatalf("second acquire should report held, got %v", err)
+	}
+	release()
+	release2, err := acquireProcessLock(path)
+	if err != nil {
+		t.Fatalf("reacquire after release: %v", err)
+	}
+	release2()
+}

--- a/internal/daemon/singleton_windows.go
+++ b/internal/daemon/singleton_windows.go
@@ -1,0 +1,38 @@
+//go:build windows
+
+package daemon
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// acquireProcessLock 非阻塞获取字节区间锁 [0,1) 并持有到 release 被调用（或进程退出）。
+// 已被其他进程持有时返回 errProcessLockHeld。与 writerlock_windows.go 共用
+// kernel32 的 LockFileEx/UnlockFileEx。
+func acquireProcessLock(path string) (release func(), err error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	var overlapped syscall.Overlapped
+	ret, _, callErr := procLockFileEx.Call(
+		f.Fd(),
+		uintptr(lockfileExclusiveLock|lockfileFailImmediately),
+		0, 1, 0,
+		uintptr(unsafe.Pointer(&overlapped)),
+	)
+	if ret == 0 {
+		_ = f.Close()
+		if errno, ok := callErr.(syscall.Errno); ok && errno == errorLockViolation {
+			return nil, errProcessLockHeld
+		}
+		return nil, callErr
+	}
+	return func() {
+		var ov syscall.Overlapped
+		_, _, _ = procUnlockFileEx.Call(f.Fd(), 0, 1, 0, uintptr(unsafe.Pointer(&ov)))
+		_ = f.Close()
+	}, nil
+}

--- a/internal/daemon/spawn.go
+++ b/internal/daemon/spawn.go
@@ -113,13 +113,18 @@ func spawn(p paths.Paths, executable string, args, env []string, release bool) (
 	if current := ReadLock(p); current != nil && current.PID == cmd.Process.Pid {
 		RemoveLock(p)
 	}
-	return nil, errs.New(errs.CodeUnknown, "daemon 启动失败（3s 内 HTTP 未就绪）："+readyErr.Error()).
+	return nil, errs.New(errs.CodeUnknown, fmt.Sprintf("daemon 启动失败（%s 内 HTTP 未就绪）：%s", daemonReadyTimeout, readyErr.Error())).
 		WithHint("查看 yoooclaw daemon logs 排查")
 }
 
+// daemonReadyTimeout 是等待 fork 出的 daemon 就绪的上限。不能太短：WSL 冷启动、
+// 杀软扫描、高负载机器上 daemon 起来可能超过 3s，等不到就 kill 子进程会让监管方
+// 陷入「反复拉起→反复杀」的重启循环。
+const daemonReadyTimeout = 15 * time.Second
+
 func waitForDaemonReady(p paths.Paths, pid int) (*Lock, error) {
 	var lastErr error = fmt.Errorf("尚未写出 lock")
-	deadline := time.Now().Add(3 * time.Second)
+	deadline := time.Now().Add(daemonReadyTimeout)
 	for time.Now().Before(deadline) {
 		time.Sleep(100 * time.Millisecond)
 		lock := ReadLock(p)

--- a/internal/errs/errors.go
+++ b/internal/errs/errors.go
@@ -31,6 +31,7 @@ const (
 	CodeNetworkError            = "YOOOCLAW_NETWORK_ERROR"
 	CodeConfirmationRequired    = "YOOOCLAW_CONFIRMATION_REQUIRED"
 	CodeNotInteractive          = "YOOOCLAW_NOT_INTERACTIVE"
+	CodeDaemonUnresponsive      = "YOOOCLAW_DAEMON_UNRESPONSIVE"
 )
 
 // Error 携带结构化错误码、提示与进程退出码。

--- a/internal/notif/dayfile.go
+++ b/internal/notif/dayfile.go
@@ -1,0 +1,97 @@
+package notif
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+)
+
+// 日存储文件格式：
+//   - 当前格式 YYYY-MM-DD.jsonl：每行一条 StoredNotification（compact JSON），只追加写。
+//     逐行解析、坏行跳过，torn write 最多损失最后一行。
+//   - 旧格式 YYYY-MM-DD.json：整天一个 JSON 数组，只读兼容（migrate 命令会原样拷入旧文件）；
+//     写路径首次落盘该天时迁移成 .jsonl。
+//   - 两者并存时以 .jsonl 为准：迁移先原子写 .jsonl 再删 .json，中途 crash 只会留下
+//     一份内容已被 .jsonl 完整包含的过期副本。
+var dateFileRE = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2})\.jsonl?$`)
+
+func dayFilePath(dir, dateKey string) string {
+	return filepath.Join(dir, dateKey+".jsonl")
+}
+
+func legacyDayFilePath(dir, dateKey string) string {
+	return filepath.Join(dir, dateKey+".json")
+}
+
+// listDateKeys 列出 YYYY-MM-DD 日期 key（新旧格式合并去重），降序。
+func listDateKeys(dir string) []string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var keys []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if m := dateFileRE.FindStringSubmatch(e.Name()); m != nil && !seen[m[1]] {
+			seen[m[1]] = true
+			keys = append(keys, m[1])
+		}
+	}
+	sort.Sort(sort.Reverse(sort.StringSlice(keys)))
+	return keys
+}
+
+// encodeJSONLines 把条目序列化为 JSONL（每行一条 + 换行）。
+func encodeJSONLines(items []StoredNotification) ([]byte, error) {
+	var buf bytes.Buffer
+	for _, item := range items {
+		b, err := json.Marshal(item)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(b)
+		buf.WriteByte('\n')
+	}
+	return buf.Bytes(), nil
+}
+
+// decodeJSONLines 逐行解析 JSONL，坏行跳过并计数（torn write 的半行落在这里）。
+func decodeJSONLines(raw []byte) (items []StoredNotification, skipped int) {
+	for _, line := range bytes.Split(raw, []byte{'\n'}) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		var item StoredNotification
+		if err := json.Unmarshal(line, &item); err != nil {
+			skipped++
+			continue
+		}
+		items = append(items, item)
+	}
+	return items, skipped
+}
+
+// readDateFile 读取某天的条目（只读路径用，容错：读不出来当空处理）。
+// .jsonl 存在时以它为准，否则回退旧 .json 数组。
+func readDateFile(dir, dateKey string) []StoredNotification {
+	if raw, err := os.ReadFile(dayFilePath(dir, dateKey)); err == nil {
+		items, _ := decodeJSONLines(raw)
+		return items
+	}
+	raw, err := os.ReadFile(legacyDayFilePath(dir, dateKey))
+	if err != nil {
+		return nil
+	}
+	var items []StoredNotification
+	if json.Unmarshal(raw, &items) != nil {
+		return nil
+	}
+	return items
+}

--- a/internal/notif/query.go
+++ b/internal/notif/query.go
@@ -1,9 +1,7 @@
 package notif
 
 import (
-	"encoding/json"
 	"os"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -14,7 +12,6 @@ import (
 )
 
 var isoRE = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(\.\d{1,3})?)?(Z|[+-]\d{2}:\d{2})$`)
-var dateFileRE = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2})\.json$`)
 
 // QueryOptions 是解析后的查询条件。
 type QueryOptions struct {
@@ -170,37 +167,6 @@ func QueryWithStats(notificationsDir string, opts QueryOptions) ([]StoredNotific
 func dirExists(dir string) bool {
 	info, err := os.Stat(dir)
 	return err == nil && info.IsDir()
-}
-
-// listDateKeys 列出 YYYY-MM-DD 日期 key，降序。
-func listDateKeys(dir string) []string {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return nil
-	}
-	var keys []string
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		if m := dateFileRE.FindStringSubmatch(e.Name()); m != nil {
-			keys = append(keys, m[1])
-		}
-	}
-	sort.Sort(sort.Reverse(sort.StringSlice(keys)))
-	return keys
-}
-
-func readDateFile(dir, dateKey string) []StoredNotification {
-	raw, err := os.ReadFile(filepath.Join(dir, dateKey+".json"))
-	if err != nil {
-		return nil
-	}
-	var items []StoredNotification
-	if json.Unmarshal(raw, &items) != nil {
-		return nil
-	}
-	return items
 }
 
 func sortByTimestampDesc(items []StoredNotification) {

--- a/internal/notif/storage.go
+++ b/internal/notif/storage.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -42,7 +43,8 @@ type IngestResult struct {
 	Inserted []StoredNotification `json:"-"`
 }
 
-// Storage 是 date-keyed JSON 通知存储（含 id / content-key 双重去重）。
+// Storage 是 date-keyed JSONL 通知存储（含 id / content-key 双重去重）。
+// 文件格式见 dayfile.go：每天一个 .jsonl 追加写；旧 .json 数组只读兼容 + 懒迁移。
 type Storage struct {
 	dir            string
 	idIndexDir     string
@@ -70,26 +72,44 @@ func NewStorage(dir string, cfg PluginConfig, logger Logger) *Storage {
 }
 
 func (s *Storage) dayPath(dateKey string) string {
-	return filepath.Join(s.dir, dateKey+".json")
+	return dayFilePath(s.dir, dateKey)
 }
 
-// loadDay 读取当天已落盘的条目。
-//
-// 当天文件损坏时（例如旧版本非原子写被中断留下的半截 JSON）不能当作「空的一天」
-// 静默继续——那样下一次写入会把残骸连同它代表的数据一起覆盖掉。这里把损坏文件
-// 隔离备份，并丢弃当天的 id / content-key 索引：索引描述的是已经读不出来的数据，
-// 留着它只会让手机重发的同一批通知被判定为重复，永远回不来。
+// loadDay 读取当天已落盘的条目（带内存缓存）。
 func (s *Storage) loadDay(dateKey string) []StoredNotification {
 	if entries, ok := s.dayCache[dateKey]; ok {
 		return entries
 	}
-	filePath := s.dayPath(dateKey)
-	entries, err := readStoredFile(filePath)
-	if err != nil {
-		s.quarantineDay(dateKey, filePath, err)
-		entries = nil
-	}
+	entries := s.loadDayFromDisk(dateKey)
 	s.dayCache[dateKey] = entries
+	return entries
+}
+
+// loadDayFromDisk 读取当天数据，.jsonl 优先，缺失时回退旧 .json 数组。
+//
+// .jsonl 逐行解析、坏行跳过：追加写永不覆盖已有数据，坏行（torn write 的半行）
+// 最多损失那一条，不需要隔离整天。旧 .json 数组则相反——半截 JSON 解析失败时
+// 不能当作「空的一天」静默继续，那样迁移写 .jsonl 时会把残骸代表的数据一起丢掉，
+// 所以保留隔离逻辑：备份损坏文件并重置当天索引，让手机重发的同批通知能重新入库。
+func (s *Storage) loadDayFromDisk(dateKey string) []StoredNotification {
+	raw, err := os.ReadFile(dayFilePath(s.dir, dateKey))
+	if err == nil {
+		entries, skipped := decodeJSONLines(raw)
+		if skipped > 0 {
+			s.logger.Warn("当天通知文件有 " + strconv.Itoa(skipped) + " 个坏行已跳过: " + dateKey)
+		}
+		return entries
+	}
+	if !os.IsNotExist(err) {
+		s.logger.Warn("读取当天通知文件失败，按空处理: " + dateKey + ", " + err.Error())
+		return nil
+	}
+	legacyPath := legacyDayFilePath(s.dir, dateKey)
+	entries, err := readStoredFile(legacyPath)
+	if err != nil {
+		s.quarantineDay(dateKey, legacyPath, err)
+		return nil
+	}
 	return entries
 }
 
@@ -120,7 +140,7 @@ func (s *Storage) Init() error {
 
 // staged 是一天里待落盘的新条目，以及为它们在内存缓存中占位的索引键。
 // 索引键先入缓存（这样同一批里的重复能被挡掉），落盘成功后才写进索引文件；
-// 落盘失败则从缓存回滚，避免索引比数据先一步存在。
+// 落盘失败则整体失效当天缓存，避免索引比数据先一步存在。
 type staged struct {
 	entries    []StoredNotification
 	idKeys     []string
@@ -129,8 +149,7 @@ type staged struct {
 
 // Ingest 写入一批通知，去重后返回统计与新插入条目。clientLabel 为来源（缺省 "default"）。
 //
-// 按日期分组、每天只落盘一次：逐条覆写整个当天数组会带来 O(n²) 的写放大
-// （一批 800 条能为一个 241 KB 的文件写掉近 100 MB）。
+// 按日期分组、每天只追加一次：写入量只与本批大小成正比，与当天已有多少条无关。
 func (s *Storage) Ingest(items []RawNotification, clientLabel string) IngestResult {
 	if clientLabel == "" {
 		clientLabel = "default"
@@ -214,29 +233,54 @@ func (s *Storage) Ingest(items []RawNotification, clientLabel string) IngestResu
 	}
 
 	s.prune()
+	s.evictColdDays(days)
 	return result
 }
 
-// flushDay 把一天的新条目一次性原子写入，成功后才把索引落盘。
+// evictColdDays 在每批 ingest 结束后逐出「今天和本批之外」日期的内存缓存。
+// dayCache 存的是整天的全量通知，不逐出的话长期运行的 daemon 会把历史每一天
+// 都常驻内存，最终被 OOM 杀掉。被逐出的日期下次触到时从磁盘重读，
+// 补发旧日期通知只是偶发场景，这点 IO 可以接受。
+func (s *Storage) evictColdDays(touched map[string]*staged) {
+	today := time.Now().In(time.Local).Format("2006-01-02")
+	cold := func(dateKey string) bool {
+		if dateKey == today {
+			return false
+		}
+		_, ok := touched[dateKey]
+		return !ok
+	}
+	for dateKey := range s.dayCache {
+		if cold(dateKey) {
+			delete(s.dayCache, dateKey)
+		}
+	}
+	for dateKey := range s.idCache {
+		if cold(dateKey) {
+			delete(s.idCache, dateKey)
+		}
+	}
+	for dateKey := range s.contentKeyCach {
+		if cold(dateKey) {
+			delete(s.contentKeyCach, dateKey)
+		}
+	}
+}
+
+// flushDay 把一天的新条目追加写入 .jsonl，成功后才把索引落盘。
+// 当天还是旧 .json 数组时，先把「旧数据 + 本批」原子写成 .jsonl 完成迁移，
+// 再删掉旧文件——crash 在删除前只会留下一份内容已被 .jsonl 包含的过期副本。
 func (s *Storage) flushDay(dateKey string, day *staged) error {
 	if len(day.entries) == 0 {
 		return nil
 	}
-	filePath := s.dayPath(dateKey)
-	arr := append(s.loadDay(dateKey), day.entries...)
-
-	data, err := json.MarshalIndent(arr, "", "  ")
+	existing := s.loadDay(dateKey)
+	err := s.writeDayLines(dateKey, existing, day.entries)
 	if err != nil {
-		s.revertStaged(dateKey, day)
+		s.invalidateDay(dateKey)
 		return err
 	}
-	// 原子写：os.WriteFile 先截断再写，中途崩溃会留下半截 JSON，
-	// 之后解析失败就会把当天数据整份丢掉。
-	if err := fsutil.WriteAtomic(filePath, data, storedFileMode); err != nil {
-		s.revertStaged(dateKey, day)
-		return err
-	}
-	s.dayCache[dateKey] = arr
+	s.dayCache[dateKey] = append(existing, day.entries...)
 
 	for _, key := range day.idKeys {
 		appendLine(filepath.Join(s.idIndexDir, dateKey+".ids"), key)
@@ -247,19 +291,70 @@ func (s *Storage) flushDay(dateKey string, day *staged) error {
 	return nil
 }
 
-// revertStaged 撤回落盘失败那批在内存缓存里的索引占位，否则这些通知会被
-// 永久判定为「已存在」，重发也进不来。
-func (s *Storage) revertStaged(dateKey string, day *staged) {
-	if set, ok := s.idCache[dateKey]; ok {
-		for _, key := range day.idKeys {
-			delete(set, key)
+func (s *Storage) writeDayLines(dateKey string, existing, entries []StoredNotification) error {
+	newLines, err := encodeJSONLines(entries)
+	if err != nil {
+		return err
+	}
+	filePath := dayFilePath(s.dir, dateKey)
+	legacyPath := legacyDayFilePath(s.dir, dateKey)
+
+	if !fsutil.Exists(filePath) && fsutil.Exists(legacyPath) {
+		existingLines, err := encodeJSONLines(existing)
+		if err != nil {
+			return err
+		}
+		if err := fsutil.WriteAtomic(filePath, append(existingLines, newLines...), storedFileMode); err != nil {
+			return err
+		}
+	} else if err := appendDayLines(filePath, newLines); err != nil {
+		return err
+	}
+	// .jsonl 落盘后旧格式文件只是过期副本（含上次迁移 crash 在删除前留下的）。
+	if fsutil.Exists(legacyPath) {
+		_ = os.Remove(legacyPath)
+	}
+	return nil
+}
+
+// appendDayLines 把整批行一次追加到 .jsonl。文件尾若缺换行（上次 torn write
+// 留下的半行），先补一个换行把半行了结成独立的坏行（读取时被跳过），
+// 避免新数据接在半行后面一起变成垃圾。
+func appendDayLines(path string, lines []byte) error {
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, storedFileMode)
+	if err != nil {
+		return err
+	}
+	info, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return err
+	}
+	offset := info.Size()
+	if offset > 0 {
+		last := make([]byte, 1)
+		if _, err := f.ReadAt(last, offset-1); err != nil {
+			f.Close()
+			return err
+		}
+		if last[0] != '\n' {
+			lines = append([]byte{'\n'}, lines...)
 		}
 	}
-	if set, ok := s.contentKeyCach[dateKey]; ok {
-		for _, key := range day.contentKys {
-			delete(set, key)
-		}
+	if _, err := f.WriteAt(lines, offset); err != nil {
+		f.Close()
+		return err
 	}
+	return f.Close()
+}
+
+// invalidateDay 在落盘失败后丢弃当天的内存缓存与索引占位：追加写可能只写进一半，
+// 内存状态已不可信。下次触到这一天时从磁盘重建（.ids 只在成功后追加，
+// content-key 从数据本身派生），失败批次重发时会与实际落盘的行正确去重。
+func (s *Storage) invalidateDay(dateKey string) {
+	delete(s.dayCache, dateKey)
+	delete(s.idCache, dateKey)
+	delete(s.contentKeyCach, dateKey)
 }
 
 func (s *Storage) buildStored(n RawNotification, clientLabel string) StoredNotification {
@@ -409,7 +504,7 @@ func (s *Storage) prune() {
 		return
 	}
 	cutoff := time.Now().Add(-time.Duration(*s.cfg.RetentionDays) * 24 * time.Hour).In(time.Local).Format("2006-01-02")
-	pruneByDate(s.dir, cutoff, []string{".json", ".md"}, func(k string) {
+	pruneByDate(s.dir, cutoff, []string{".jsonl", ".json", ".md"}, func(k string) {
 		delete(s.idCache, k)
 		delete(s.contentKeyCach, k)
 		delete(s.dayCache, k)
@@ -444,8 +539,8 @@ func pruneByDate(dir, cutoff string, exts []string, evict func(string), filesOnl
 	}
 }
 
-// readStoredFile 读取当天条目。文件不存在返回空；内容损坏返回错误，
-// 交由调用方隔离——静默当成空的一天会让下一次写入覆盖掉当天全部数据。
+// readStoredFile 严格读取旧格式 .json 数组。文件不存在返回空；内容损坏返回错误，
+// 交由调用方隔离——静默当成空的一天会让迁移写 .jsonl 时丢掉当天全部旧数据。
 func readStoredFile(filePath string) ([]StoredNotification, error) {
 	raw, err := os.ReadFile(filePath)
 	if os.IsNotExist(err) {

--- a/internal/notif/storage_test.go
+++ b/internal/notif/storage_test.go
@@ -2,6 +2,7 @@ package notif
 
 import (
 	"testing"
+	"time"
 
 	"github.com/YoooClaw/cli/internal/testutil"
 )
@@ -27,6 +28,27 @@ func TestIngestBasic(t *testing.T) {
 	}
 	if len(res.Inserted) != 2 {
 		t.Errorf("inserted should be 2: %+v", res.Inserted)
+	}
+}
+
+func TestIngestEvictsColdDayCache(t *testing.T) {
+	t.Parallel()
+	s := newStorage(t)
+	old := RawNotification{ID: "old", App: "wechat", Title: "t", Body: "b", Timestamp: "2026-06-07T10:00:00+08:00"}
+	s.Ingest([]RawNotification{old}, "phone-a")
+	// 本批触到的日期允许留在缓存；下一批（不含该日期）后必须被逐出，
+	// 否则长期运行会把历史每一天的全量通知都常驻内存。
+	s.Ingest([]RawNotification{{ID: "now", App: "wechat", Title: "t2", Body: "b2", Timestamp: time.Now().Format(time.RFC3339)}}, "phone-a")
+	s.mu.Lock()
+	_, cached := s.dayCache["2026-06-07"]
+	s.mu.Unlock()
+	if cached {
+		t.Fatal("cold day should be evicted from dayCache")
+	}
+	// 逐出后去重依旧生效（从磁盘/索引文件重建）。
+	res := s.Ingest([]RawNotification{old}, "phone-a")
+	if res.DedupedByID != 1 || res.Ingested != 0 {
+		t.Fatalf("dedup must survive cache eviction: %+v", res)
 	}
 }
 

--- a/internal/notif/storage_writepath_test.go
+++ b/internal/notif/storage_writepath_test.go
@@ -1,6 +1,7 @@
 package notif
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -28,7 +29,7 @@ func notifAt(id string, ts time.Time, body string) RawNotification {
 	}
 }
 
-// 一批通知里同一天只应落盘一次，而不是每条都覆写整个当天数组。
+// 一批通知里同一天只应落盘一次，而且写的是 .jsonl 追加格式。
 func TestIngestWritesEachDayOnce(t *testing.T) {
 	dir := t.TempDir()
 	s := newTestStorage(t, dir)
@@ -49,10 +50,10 @@ func TestIngestWritesEachDayOnce(t *testing.T) {
 
 	for _, day := range []time.Time{day1, day2} {
 		key := day.Format("2006-01-02")
-		entries, err := readStoredFile(filepath.Join(dir, key+".json"))
-		if err != nil {
-			t.Fatalf("%s: %v", key, err)
+		if _, err := os.Stat(dayFilePath(dir, key)); err != nil {
+			t.Fatalf("%s 应落盘为 .jsonl: %v", key, err)
 		}
+		entries := readDateFile(dir, key)
 		if len(entries) != 50 {
 			t.Fatalf("%s 落盘 %d 条，期望 50", key, len(entries))
 		}
@@ -66,12 +67,81 @@ func TestIngestWritesEachDayOnce(t *testing.T) {
 	}
 }
 
-// 半截 JSON（旧版非原子写被中断的产物）不能被当成空的一天静默覆盖。
-func TestTruncatedDayFileIsQuarantinedNotOverwritten(t *testing.T) {
+// 旧格式 .json 数组在首次落盘该天时迁移为 .jsonl：旧数据在前、新数据追加在后，
+// 旧文件删除，且对旧数据的去重依旧生效。
+func TestLegacyDayFileMigratedOnFirstFlush(t *testing.T) {
 	dir := t.TempDir()
 	now := time.Now()
-	dayKey := now.Format("2006-01-02")
-	dayFile := filepath.Join(dir, dayKey+".json")
+	dateKey := now.Format("2006-01-02")
+	legacy := []StoredNotification{
+		{ClientLabel: "probe", AppName: "com.tencent.xin", AppDisplayName: "com.tencent.xin",
+			Title: "老板", Content: "旧-1", Timestamp: now.Format(time.RFC3339)},
+		{ClientLabel: "probe", AppName: "com.tencent.xin", AppDisplayName: "com.tencent.xin",
+			Title: "老板", Content: "旧-2", Timestamp: now.Format(time.RFC3339)},
+	}
+	writeDateFile(t, dir, dateKey, legacy)
+
+	s := newTestStorage(t, dir)
+	res := s.Ingest([]RawNotification{
+		notifAt("dup", now, "旧-1"), // 与旧数据内容一致 -> 内容去重
+		notifAt("new", now, "新-1"),
+	}, "probe")
+	if res.DedupedByContent != 1 || res.Ingested != 1 {
+		t.Fatalf("dedupedByContent=%d ingested=%d，期望 1/1", res.DedupedByContent, res.Ingested)
+	}
+
+	if _, err := os.Stat(legacyDayFilePath(dir, dateKey)); !os.IsNotExist(err) {
+		t.Fatalf("迁移后旧 .json 应被删除, err=%v", err)
+	}
+	entries := readDateFile(dir, dateKey)
+	if len(entries) != 3 {
+		t.Fatalf("迁移后 %d 条，期望 3（旧 2 + 新 1）", len(entries))
+	}
+	// 迁移必须保持顺序（sync checkpoint 按下标消费）。
+	if entries[0].Content != "旧-1" || entries[1].Content != "旧-2" || entries[2].Content != "新-1" {
+		t.Fatalf("迁移后顺序不对: %q %q %q", entries[0].Content, entries[1].Content, entries[2].Content)
+	}
+}
+
+// .jsonl 与过期的旧 .json 并存时（迁移在删除前 crash 的产物）：读以 .jsonl 为准、
+// 日期 key 不重复、下次落盘顺手清掉过期副本。
+func TestStaleLegacyCopyIsIgnoredAndRemoved(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	dateKey := now.Format("2006-01-02")
+
+	s := newTestStorage(t, dir)
+	s.Ingest([]RawNotification{notifAt("a", now, "1")}, "probe")
+	// 伪造迁移残留：内容已包含在 .jsonl 里的过期旧文件。
+	writeDateFile(t, dir, dateKey, readDateFile(dir, dateKey))
+
+	if keys := listDateKeys(dir); len(keys) != 1 || keys[0] != dateKey {
+		t.Fatalf("日期 key 应去重: %v", keys)
+	}
+	if entries := readDateFile(dir, dateKey); len(entries) != 1 {
+		t.Fatalf("读取应以 .jsonl 为准，got %d 条", len(entries))
+	}
+
+	s2 := newTestStorage(t, dir)
+	res := s2.Ingest([]RawNotification{notifAt("b", now, "2")}, "probe")
+	if res.Ingested != 1 {
+		t.Fatalf("ingested=%d，期望 1: %+v", res.Ingested, res)
+	}
+	if _, err := os.Stat(legacyDayFilePath(dir, dateKey)); !os.IsNotExist(err) {
+		t.Fatalf("过期旧文件应被清理, err=%v", err)
+	}
+	if entries := readDateFile(dir, dateKey); len(entries) != 2 {
+		t.Fatalf("当天 %d 条，期望 2", len(entries))
+	}
+}
+
+// 损坏的旧格式 .json（老版本非原子写被中断的产物）不能被当成空的一天静默丢弃，
+// 必须隔离备份；索引不能比数据活得久，重发要能重新入库。
+func TestCorruptLegacyDayFileIsQuarantined(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	dateKey := now.Format("2006-01-02")
+	legacyFile := legacyDayFilePath(dir, dateKey)
 
 	s := newTestStorage(t, dir)
 	original := []RawNotification{
@@ -79,11 +149,16 @@ func TestTruncatedDayFileIsQuarantinedNotOverwritten(t *testing.T) {
 	}
 	s.Ingest(original, "probe")
 
-	raw, err := os.ReadFile(dayFile)
+	// 把已落盘的 .jsonl 内容改造成半截旧格式数组，模拟旧版本升级上来的损坏文件。
+	entries := readDateFile(dir, dateKey)
+	arr, err := json.MarshalIndent(entries, "", "  ")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(dayFile, raw[:len(raw)/2], 0o644); err != nil {
+	if err := os.WriteFile(legacyFile, arr[:len(arr)/2], 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(dayFilePath(dir, dateKey)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -91,8 +166,8 @@ func TestTruncatedDayFileIsQuarantinedNotOverwritten(t *testing.T) {
 	s2 := newTestStorage(t, dir)
 	res := s2.Ingest(original, "probe")
 
-	// 损坏的字节必须被留下来，而不是被覆盖掉。
-	matches, _ := filepath.Glob(dayFile + ".corrupt-*")
+	// 损坏的字节必须被留下来，而不是被丢弃。
+	matches, _ := filepath.Glob(legacyFile + ".corrupt-*")
 	if len(matches) != 1 {
 		t.Fatalf("期望隔离出 1 个 .corrupt 备份，实际 %d 个", len(matches))
 	}
@@ -102,12 +177,57 @@ func TestTruncatedDayFileIsQuarantinedNotOverwritten(t *testing.T) {
 		t.Fatalf("重发后 ingested=%d dedupedById=%d，期望 3 条全部重新入库",
 			res.Ingested, res.DedupedByID)
 	}
-	entries, err := readStoredFile(dayFile)
+	if entries := readDateFile(dir, dateKey); len(entries) != 3 {
+		t.Fatalf("当天文件 %d 条，期望 3 条", len(entries))
+	}
+}
+
+// torn write 留下的半行只损失那一条：读取时跳过，后续追加先补换行把半行了结，
+// 丢失的那条重发时能重新入库（其余条靠内容去重挡掉）。
+func TestTornLastLineIsSkippedAndRepaired(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	dateKey := now.Format("2006-01-02")
+
+	full, err := encodeJSONLines([]StoredNotification{
+		{ClientLabel: "probe", AppName: "x", Title: "t", Content: "1", Timestamp: now.Format(time.RFC3339)},
+		{ClientLabel: "probe", AppName: "x", Title: "t", Content: "2", Timestamp: now.Format(time.RFC3339)},
+		{ClientLabel: "probe", AppName: "x", Title: "t", Content: "3", Timestamp: now.Format(time.RFC3339)},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
+	torn := full[:len(full)-10] // 掐掉最后一行的尾巴（含换行）
+	if err := os.WriteFile(dayFilePath(dir, dateKey), torn, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if entries := readDateFile(dir, dateKey); len(entries) != 2 {
+		t.Fatalf("半行应被跳过，读到 %d 条，期望 2", len(entries))
+	}
+
+	s := newTestStorage(t, dir)
+	res := s.Ingest([]RawNotification{
+		{ID: "n3", App: "x", Title: "t", Body: "3", Timestamp: now.Format(time.RFC3339)},
+	}, "probe")
+	if res.Ingested != 1 {
+		t.Fatalf("丢失的那条应能重新入库: %+v", res)
+	}
+
+	raw, err := os.ReadFile(dayFilePath(dir, dateKey))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 半行必须被换行了结成独立坏行，新数据不能接在它后面变成垃圾。
+	if bytes.Contains(raw, []byte(`}{`)) {
+		t.Fatalf("新行接在半行后面了: %q", raw)
+	}
+	entries := readDateFile(dir, dateKey)
 	if len(entries) != 3 {
-		t.Fatalf("当天文件 %d 条，期望 3 条", len(entries))
+		t.Fatalf("修复追加后 %d 条，期望 3（半行仍是坏行）", len(entries))
+	}
+	if entries[2].Content != "3" {
+		t.Fatalf("追加的应是丢失的那条: %+v", entries[2])
 	}
 }
 
@@ -118,17 +238,11 @@ func TestFailedFlushDoesNotPoisonIndexes(t *testing.T) {
 	dateKey := now.Format("2006-01-02")
 	s := newTestStorage(t, dir)
 
-	// 用一个非空目录占住当天文件路径，让原子写的 rename 失败。
-	// 顺带预热 dayCache：否则 loadDay 会把这个目录当成损坏文件隔离走，
-	// 路径反而腾空了——这里要验证的是落盘真的失败之后的回滚。
+	// 用一个目录占住当天 .jsonl 路径，让追加写 open 失败。
 	blocker := s.dayPath(dateKey)
 	if err := os.MkdirAll(blocker, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(blocker, "blocker"), []byte("x"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	s.dayCache[dateKey] = nil
 
 	items := []RawNotification{notifAt("a", now, "1"), notifAt("b", now, "2")}
 	res := s.Ingest(items, "probe")
@@ -140,7 +254,6 @@ func TestFailedFlushDoesNotPoisonIndexes(t *testing.T) {
 	if err := os.RemoveAll(blocker); err != nil {
 		t.Fatal(err)
 	}
-	delete(s.dayCache, dateKey)
 	res = s.Ingest(items, "probe")
 	if res.Ingested != 2 {
 		t.Fatalf("重发 ingested=%d dedupedById=%d dedupedByContent=%d，期望 2 条入库",
@@ -167,20 +280,17 @@ func TestIntraBatchDedupStillApplies(t *testing.T) {
 		t.Fatalf("dedupedById=%d dedupedByContent=%d，期望 1/1", res.DedupedByID, res.DedupedByContent)
 	}
 
-	entries, err := readStoredFile(filepath.Join(dir, now.Format("2006-01-02")+".json"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	entries := readDateFile(dir, now.Format("2006-01-02"))
 	if len(entries) != 1 {
 		t.Fatalf("当天落盘 %d 条，期望 1", len(entries))
 	}
 }
 
-// 落盘的仍然是合法 JSON 数组，且已有数据会被保留。
+// 落盘的是逐行合法 JSON 的 .jsonl，跨进程追加时已有数据会被保留。
 func TestIngestAppendsToExistingDay(t *testing.T) {
 	dir := t.TempDir()
 	now := time.Now()
-	dayFile := filepath.Join(dir, now.Format("2006-01-02")+".json")
+	dateKey := now.Format("2006-01-02")
 
 	s := newTestStorage(t, dir)
 	s.Ingest([]RawNotification{notifAt("a", now, "1")}, "probe")
@@ -188,18 +298,21 @@ func TestIngestAppendsToExistingDay(t *testing.T) {
 	s2 := newTestStorage(t, dir)
 	s2.Ingest([]RawNotification{notifAt("b", now, "2")}, "probe")
 
-	raw, err := os.ReadFile(dayFile)
+	raw, err := os.ReadFile(dayFilePath(dir, dateKey))
 	if err != nil {
 		t.Fatal(err)
 	}
-	var entries []StoredNotification
-	if err := json.Unmarshal(raw, &entries); err != nil {
-		t.Fatalf("落盘内容不是合法 JSON 数组: %v", err)
+	if !strings.HasSuffix(string(raw), "\n") {
+		t.Fatalf("落盘内容应以换行结尾")
 	}
-	if len(entries) != 2 {
-		t.Fatalf("当天 %d 条，期望 2 条（新旧都在）", len(entries))
+	lines := strings.Split(strings.TrimSuffix(string(raw), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("当天 %d 行，期望 2 行（新旧都在）", len(lines))
 	}
-	if !strings.HasSuffix(strings.TrimSpace(string(raw)), "]") {
-		t.Fatalf("落盘内容看起来被截断了")
+	for i, line := range lines {
+		var entry StoredNotification
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("第 %d 行不是合法 JSON: %v", i, err)
+		}
 	}
 }

--- a/internal/notif/types.go
+++ b/internal/notif/types.go
@@ -2,7 +2,8 @@
 // 对齐 phone-notifications 的 storage.ts / cli ntf-query.ts。
 package notif
 
-// StoredNotification 是落盘的通知条目（date-keyed JSON 数组的元素）。
+// StoredNotification 是落盘的通知条目（date-keyed JSONL 文件的一行；
+// 旧版是 JSON 数组的元素，只读兼容）。
 type StoredNotification struct {
 	// ClientLabel 来源客户端 label；旧数据无该字段，查询时视为 legacy。
 	ClientLabel string `json:"clientLabel,omitempty"`

--- a/internal/relay/client.go
+++ b/internal/relay/client.go
@@ -139,29 +139,19 @@ func (c *Client) connectOnce() error {
 	c.writeStatus("connecting", "")
 
 	dialer := websocket.Dialer{HandshakeTimeout: handshakeTimeout}
-	connCh := make(chan struct {
-		conn *websocket.Conn
-		resp *http.Response
-		err  error
-	}, 1)
+	connCh := make(chan dialResult, 1)
 	go func() {
 		conn, resp, err := dialer.Dial(wsURL.String(), headers)
-		connCh <- struct {
-			conn *websocket.Conn
-			resp *http.Response
-			err  error
-		}{conn: conn, resp: resp, err: err}
+		connCh <- dialResult{conn: conn, resp: resp, err: err}
 	}()
-	var result struct {
-		conn *websocket.Conn
-		resp *http.Response
-		err  error
-	}
+	var result dialResult
 	select {
 	case result = <-connCh:
 	case <-time.After(connectWatchdog):
+		go reapAbandonedDial(connCh)
 		return fmt.Errorf("connect-watchdog-timeout")
 	case <-c.stopCh:
+		go reapAbandonedDial(connCh)
 		return fmt.Errorf("stopped")
 	}
 	if result.err != nil {
@@ -189,7 +179,7 @@ func (c *Client) connectOnce() error {
 	heartbeatDone := make(chan error, 1)
 	conn.SetPongHandler(func(_ string) error {
 		c.markInbound()
-		c.opts.Logger.Info("Relay tunnel: <- pong received")
+		c.opts.Logger.Debug("Relay tunnel: <- pong received")
 		return nil
 	})
 	go c.readLoop(conn, readDone)
@@ -203,6 +193,21 @@ func (c *Client) connectOnce() error {
 	case <-c.stopCh:
 		_ = conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "client stopping"), time.Now().Add(time.Second))
 		return fmt.Errorf("stopped")
+	}
+}
+
+type dialResult struct {
+	conn *websocket.Conn
+	resp *http.Response
+	err  error
+}
+
+// reapAbandonedDial 关闭被放弃的 dial 迟到成功建立的连接。watchdog 超时或 stop
+// 之后 dial goroutine 仍可能成功返回，不关的话每次弱网重连都漏一个 fd，
+// 长期运行会把 fd 耗尽。
+func reapAbandonedDial(connCh <-chan dialResult) {
+	if result := <-connCh; result.conn != nil {
+		_ = result.conn.Close()
 	}
 }
 
@@ -240,7 +245,7 @@ func (c *Client) readLoop(conn *websocket.Conn, done chan<- error) {
 		if text == "pong" {
 			continue
 		}
-		c.opts.Logger.Info(fmt.Sprintf("Relay tunnel: received message (%d chars): %s", len(text), preview(text, 500)))
+		c.opts.Logger.Debug(fmt.Sprintf("Relay tunnel: received message (%d chars): %s", len(text), preview(text, 500)))
 		var frame Frame
 		if err := json.Unmarshal(data, &frame); err != nil {
 			c.opts.Logger.Warn("Relay tunnel: received invalid frame, ignoring")
@@ -249,18 +254,22 @@ func (c *Client) readLoop(conn *websocket.Conn, done chan<- error) {
 		c.handlersMu.Lock()
 		handlers := append([]func(Frame){}, c.inboundHandlers...)
 		c.handlersMu.Unlock()
+		// 同步分发，保证帧按到达顺序处理：ws_data 若每帧起一个 goroutine，
+		// 会乱序写入本地 WS，还可能对同一连接并发 WriteMessage（gorilla 直接
+		// panic）。慢操作（req/request/ws_open）由 dispatcher 自行异步化。
 		for _, handler := range handlers {
-			h := handler
-			go func() {
-				defer func() {
-					if rec := recover(); rec != nil {
-						c.opts.Logger.Error(fmt.Sprintf("Relay tunnel: handler panic: %v", rec))
-					}
-				}()
-				h(frame)
-			}()
+			c.invokeHandler(handler, frame)
 		}
 	}
+}
+
+func (c *Client) invokeHandler(handler func(Frame), frame Frame) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			c.opts.Logger.Error(fmt.Sprintf("Relay tunnel: handler panic: %v", rec))
+		}
+	}()
+	handler(frame)
 }
 
 func (c *Client) heartbeatLoop(conn *websocket.Conn, done chan<- error) {
@@ -291,7 +300,7 @@ func (c *Client) sendHeartbeat(conn *websocket.Conn) error {
 		_ = conn.Close()
 		return fmt.Errorf("heartbeat-timeout idleMs=%d", idle.Milliseconds())
 	}
-	c.opts.Logger.Info(`Relay tunnel: -> heartbeat "ping"`)
+	c.opts.Logger.Debug(`Relay tunnel: -> heartbeat "ping"`)
 	c.writeMu.Lock()
 	defer c.writeMu.Unlock()
 	if err := conn.WriteMessage(websocket.TextMessage, []byte("ping")); err != nil {

--- a/internal/relay/dispatcher.go
+++ b/internal/relay/dispatcher.go
@@ -21,6 +21,12 @@ type Dispatcher struct {
 	httpToken   string
 	clientLabel string
 	logger      Logger
+	// rpcClient 用于 gateway RPC 回环，带整体超时：本地 handler 一旦挂住，
+	// 没超时的话 goroutine 永远不回收，手机端重试还会不断叠新的。
+	rpcClient *http.Client
+	// proxyClient 用于 HTTP 代理回环，只限响应头超时——SSE 等流式响应
+	// 合法地长时间不结束，不能设整体超时。
+	proxyClient *http.Client
 
 	wsMu sync.Mutex
 	ws   map[string]*websocket.Conn
@@ -40,6 +46,8 @@ func NewDispatcher(opts DispatcherOptions) *Dispatcher {
 	return &Dispatcher{
 		client: opts.Client, httpBaseURL: strings.TrimRight(opts.HTTPBaseURL, "/"), httpToken: opts.HTTPToken,
 		clientLabel: opts.ClientLabel, logger: opts.Logger, ws: map[string]*websocket.Conn{},
+		rpcClient:   &http.Client{Timeout: 60 * time.Second},
+		proxyClient: &http.Client{Transport: &http.Transport{ResponseHeaderTimeout: 60 * time.Second}},
 	}
 }
 
@@ -69,7 +77,7 @@ func (d *Dispatcher) PushEvent(event string, payload any) {
 func (d *Dispatcher) handleFrame(frame Frame) {
 	typ, _ := frame["type"].(string)
 	id, _ := frame["id"].(string)
-	d.logger.Info(fmt.Sprintf("Relay dispatcher: handling frame type=%s id=%s", typ, firstNonEmpty(id, "N/A")))
+	d.logger.Debug(fmt.Sprintf("Relay dispatcher: handling frame type=%s id=%s", typ, firstNonEmpty(id, "N/A")))
 	switch typ {
 	case "req":
 		go d.handleReq(frame)
@@ -153,7 +161,7 @@ func (d *Dispatcher) handleRequest(frame Frame) {
 	for k, v := range headers {
 		req.Header.Set(k, v)
 	}
-	res, err := http.DefaultClient.Do(req)
+	res, err := d.proxyClient.Do(req)
 	if err != nil {
 		d.sendProxyError(id, 502, "daemon loopback failed: "+err.Error())
 		return
@@ -278,7 +286,7 @@ func (d *Dispatcher) loopbackJSON(method, path string, body any, extra map[strin
 	for k, v := range headers {
 		req.Header.Set(k, v)
 	}
-	res, err := http.DefaultClient.Do(req)
+	res, err := d.rpcClient.Do(req)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/relay/dispatcher_test.go
+++ b/internal/relay/dispatcher_test.go
@@ -13,6 +13,7 @@ import (
 
 type testLogger struct{ t *testing.T }
 
+func (l testLogger) Debug(msg string) { l.t.Log("[DEBUG] " + msg) }
 func (l testLogger) Info(msg string)  { l.t.Log("[INFO] " + msg) }
 func (l testLogger) Warn(msg string)  { l.t.Log("[WARN] " + msg) }
 func (l testLogger) Error(msg string) { l.t.Log("[ERROR] " + msg) }

--- a/internal/relay/supervisor.go
+++ b/internal/relay/supervisor.go
@@ -196,6 +196,7 @@ type prefixedLogger struct {
 	Prefix string
 }
 
+func (l prefixedLogger) Debug(msg string) { l.Logger.Debug(l.Prefix + msg) }
 func (l prefixedLogger) Info(msg string)  { l.Logger.Info(l.Prefix + msg) }
 func (l prefixedLogger) Warn(msg string)  { l.Logger.Warn(l.Prefix + msg) }
 func (l prefixedLogger) Error(msg string) { l.Logger.Error(l.Prefix + msg) }

--- a/internal/relay/types.go
+++ b/internal/relay/types.go
@@ -18,6 +18,7 @@ const (
 
 // Logger 是 relay 包依赖的最小日志接口。
 type Logger interface {
+	Debug(string)
 	Info(string)
 	Warn(string)
 	Error(string)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.6.0-beta.1",
+  "version": "0.6.0-beta.2",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {

--- a/skills/yoooclaw-notification-query/SKILL.md
+++ b/skills/yoooclaw-notification-query/SKILL.md
@@ -61,7 +61,7 @@ yoooclaw notification storage-path --format json
 # → {"ok":true,"path":"/abs/path/to/profiles/<profile>/notifications"}
 ```
 
-按日期文件存储：`<path>/2026-06-16.json` 为当天所有通知的 JSON 数组（append-only）。单条字段：`appName / appDisplayName / title / content / timestamp(ISO 8601 含时区) / senderName / conversationType / conversationName`。常见总结请求可直接调 `summary`，无需先查 storage-path。
+按日期文件存储：`<path>/2026-06-16.jsonl` 为当天通知，每行一条 JSON（append-only）；旧数据可能还是 `2026-06-16.json`（整天一个 JSON 数组，只读兼容）。单条字段：`appName / appDisplayName / title / content / timestamp(ISO 8601 含时区) / senderName / conversationType / conversationName`。常见总结请求可直接调 `summary`，无需先查 storage-path。
 
 ## 查询（非总结类：查某人 / 某 App / 某天 / 某关键词）
 


### PR DESCRIPTION
Release 0.6.0-beta.2. Merging this PR syncs master with the release branch; the publish itself was already triggered by tag `cli-v0.6.0-beta.2`.

## Changes

### Notification storage: per-day JSONL (`internal/notif`)
- Day files switch from a single JSON array (`YYYY-MM-DD.json`, fully rewritten via `MarshalIndent` + atomic replace on every batch) to append-only JSONL (`YYYY-MM-DD.jsonl`, one entry per line). Write cost is now O(batch) instead of O(day).
- Reads parse line by line and skip corrupt lines — a torn write loses at most the trailing line instead of quarantining the whole day. Appends repair a missing trailing newline first so new data never fuses with a torn half-line.
- Legacy `.json` arrays (incl. files copied by `yoooclaw migrate`) remain readable; a day is lazily migrated on its first flush (old entries + new batch written atomically as `.jsonl`, then the old file removed), preserving order for sync checkpoints. `.jsonl` wins if both exist.
- Quarantine is now legacy-only; failed appends invalidate the day's in-memory caches so resent batches dedupe against what actually reached disk. id/content-key dedupe semantics unchanged.
- query/sync/aggregate readers adapted via shared `dayfile.go`; skill doc updated.

### Daemon lifecycle & relay tunnel hardening (`internal/daemon`, `internal/relay`)
- OS-level singleton flock (`daemon.flock`) rejects concurrent daemon startup; `daemon.lock` removal is PID-guarded so a lingering old process can't delete a newer daemon's lock.
- `http.Server` gains `ReadHeaderTimeout`/`IdleTimeout` plus graceful shutdown with a 3s drain, preventing half-open connections from accumulating goroutines/fds.
- New `DAEMON_UNRESPONSIVE` error distinguishes a busy-but-alive daemon (timeout) from a dead one (refused/reset), so supervision backs off instead of restarting a live process.
- Relay tunnel: abandoned dials that succeed late are reaped (fd leak on flaky networks), frames dispatch synchronously to preserve ordering, and reload-swapped fields are guarded by an RWMutex.

## Test plan
- `go test ./...` green; `go test -race ./internal/notif ./internal/daemon` green.
- New tests cover legacy→JSONL migration (order + dedupe), stale legacy copy cleanup, corrupt legacy quarantine, torn-line skip/repair, and failed-flush index rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)