### PR TITLE
cli-0.6.0-beta.3

### DIFF
--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -378,11 +379,11 @@ func (s *server) authContext(r *http.Request, path string) (authResult, bool) {
 	bearer := bearerValue(r)
 	internalRelay := r.Header.Get(relay.InternalHTTPHeader) == "1"
 	internalLabel := strings.TrimSpace(r.Header.Get(relay.InternalClientLabelHeader))
-	gatewayTokenOK := s.token == "" || bearer == s.token
+	gatewayTokenOK := s.token == "" || secretEqual(bearer, s.token)
 	if internalRelay && internalLabel != "" && gatewayTokenOK {
 		return authResult{clientLabel: internalLabel, authKind: "relay-api-key"}, true
 	}
-	if s.token != "" && bearer == s.token {
+	if s.token != "" && secretEqual(bearer, s.token) {
 		return authResult{clientLabel: "local", authKind: "gateway-token"}, true
 	}
 	if isIngestPath(path) {
@@ -402,11 +403,17 @@ func (s *server) labelForAPIKey(apiKey string) string {
 	}
 	raw := strings.TrimPrefix(apiKey, "Bearer ")
 	for _, e := range s.snapshotCreds().Entries {
-		if strings.TrimPrefix(e.Key, "Bearer ") == raw {
+		if secretEqual(strings.TrimPrefix(e.Key, "Bearer "), raw) {
 			return e.Label
 		}
 	}
 	return ""
+}
+
+// secretEqual 常数时间比较 token/api-key，避免逐字节短路造成 timing 侧信道
+//（daemon 可经 Relay/非 loopback 暴露，鉴权比较不能用 ==）。
+func secretEqual(a, b string) bool {
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
 }
 
 func (s *server) handleIngest(w http.ResponseWriter, r *http.Request, auth authResult, field string) {

--- a/internal/daemon/server_ingest.go
+++ b/internal/daemon/server_ingest.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/YoooClaw/cli/internal/fsutil"
 	imgstore "github.com/YoooClaw/cli/internal/image"
 	"github.com/YoooClaw/cli/internal/recording"
 )
@@ -29,6 +30,12 @@ func (s *server) handleRecordingGateway(w http.ResponseWriter, r *http.Request, 
 		recordingID := strings.TrimSpace(body.RecordingID)
 		if recordingID == "" {
 			gatewayErr(w, "INVALID_PARAMS", "recordingId is required")
+			return
+		}
+		// recordingID 直接拼进 transcript/summary/audio 的落盘文件名，
+		// 必须在入口挡掉 ../ 之类的穿越。
+		if !fsutil.IsSafeName(recordingID) {
+			gatewayErr(w, "INVALID_PARAMS", "recordingId 含非法字符（不允许路径分隔符等）")
 			return
 		}
 		if body.Transcript == nil && body.Summary == nil {
@@ -60,6 +67,10 @@ func (s *server) handleRecordingGateway(w http.ResponseWriter, r *http.Request, 
 		recordingID := strings.TrimSpace(body.RecordingID)
 		if recordingID == "" {
 			gatewayErr(w, "INVALID_PARAMS", "recordingId is required")
+			return
+		}
+		if !fsutil.IsSafeName(recordingID) {
+			gatewayErr(w, "INVALID_PARAMS", "recordingId 含非法字符（不允许路径分隔符等）")
 			return
 		}
 		if body.ASR != nil {

--- a/internal/fsutil/fsutil.go
+++ b/internal/fsutil/fsutil.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/YoooClaw/cli/internal/errs"
 )
@@ -86,6 +87,15 @@ func ReadJSON(path string, out any) (exists bool, err error) {
 			WithHint("可手动修复或删除后重新生成")
 	}
 	return true, nil
+}
+
+// IsSafeName 报告 s 能否安全地用作单层文件/目录名（外部输入拼进 filepath.Join 前必须过此检查）：
+// 拒绝空串、"."、".."、路径分隔符、NUL 与冒号（Windows 盘符/ADS），防止目录穿越。
+func IsSafeName(s string) bool {
+	if s == "" || s == "." || s == ".." || len(s) > 200 {
+		return false
+	}
+	return !strings.ContainsAny(s, "/\\:\x00")
 }
 
 // Exists 报告路径是否存在。

--- a/internal/fsutil/safename_test.go
+++ b/internal/fsutil/safename_test.go
@@ -1,0 +1,28 @@
+package fsutil
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsSafeName(t *testing.T) {
+	t.Parallel()
+	valid := []string{"rec-123", "a", "UUID_0f3.ogg", "中文规则名", ".hidden", "a b"}
+	for _, s := range valid {
+		if !IsSafeName(s) {
+			t.Errorf("IsSafeName(%q) = false, want true", s)
+		}
+	}
+	invalid := []string{
+		"", ".", "..",
+		"../evil", "..\\evil", "a/b", `a\b`,
+		"/abs", "C:evil", "a:b",
+		"nul\x00byte",
+		strings.Repeat("x", 201),
+	}
+	for _, s := range invalid {
+		if IsSafeName(s) {
+			t.Errorf("IsSafeName(%q) = true, want false", s)
+		}
+	}
+}

--- a/internal/image/store.go
+++ b/internal/image/store.go
@@ -114,6 +114,10 @@ func Ingest(imagesDir string, payload SyncPayload, clientLabel string, maxBytes 
 	if imageID == "" || strings.TrimSpace(payload.Image.OssImageURL) == "" || strings.TrimSpace(payload.Image.CreatedAt) == "" {
 		return IngestResult{}, fmt.Errorf("imageId / image.oss_image_url / image.created_at 必填")
 	}
+	// imageID 会拼进 files/<id>.<ext> 落盘路径，必须挡掉 ../ 之类的穿越。
+	if !fsutil.IsSafeName(imageID) {
+		return IngestResult{}, fmt.Errorf("imageId 含非法字符（不允许路径分隔符等）")
+	}
 	if clientLabel == "" {
 		clientLabel = "default"
 	}

--- a/internal/image/store_traversal_test.go
+++ b/internal/image/store_traversal_test.go
@@ -1,0 +1,21 @@
+package image
+
+import (
+	"strings"
+	"testing"
+)
+
+// 回归：imageId 会拼进 files/<id>.<ext> 落盘路径，穿越形式必须在入口被拒。
+func TestIngestRejectsTraversalImageID(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	for _, id := range []string{"../evil", "..", "a/b", `a\b`, "c:evil"} {
+		_, err := Ingest(dir, SyncPayload{
+			ImageID: id,
+			Image:   Metadata{OssImageURL: "https://oss/x.png", CreatedAt: "2026-06-04T17:16:50+08:00"},
+		}, "phone-a", 1024, testLogger{t})
+		if err == nil || !strings.Contains(err.Error(), "imageId") {
+			t.Errorf("Ingest(imageId=%q) err = %v, want imageId 非法错误", id, err)
+		}
+	}
+}

--- a/internal/lightrule/storage.go
+++ b/internal/lightrule/storage.go
@@ -149,8 +149,12 @@ func resolve(base, name string) *resolved {
 		return nil
 	}
 	dir := tasksDir(base)
-	if meta := readMeta(filepath.Join(dir, norm)); meta != nil {
-		return &resolved{taskDir: filepath.Join(dir, norm), meta: meta}
+	// 直接按目录名探测仅限安全名；带路径分隔符的 name 只能命中下面按 meta.Name
+	// 的扫描（taskDir 恒在 tasks/ 之内），否则 delete 的 RemoveAll 会被穿越出去。
+	if fsutil.IsSafeName(norm) {
+		if meta := readMeta(filepath.Join(dir, norm)); meta != nil {
+			return &resolved{taskDir: filepath.Join(dir, norm), meta: meta}
+		}
 	}
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -203,6 +207,9 @@ func Create(base string, p CreateParams) (*Meta, error) {
 	writeMu.Lock()
 	defer writeMu.Unlock()
 
+	if !fsutil.IsSafeName(p.Name) {
+		return nil, &Error{Code: "INVALID_PARAMS", Message: "灯效规则名含非法字符（不允许路径分隔符等）：" + p.Name}
+	}
 	if resolve(base, p.Name) != nil {
 		return nil, &Error{Code: "ALREADY_EXISTS", Message: "灯效规则 '" + p.Name + "' 已存在"}
 	}

--- a/internal/lightrule/storage_traversal_test.go
+++ b/internal/lightrule/storage_traversal_test.go
@@ -1,0 +1,44 @@
+package lightrule
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// 回归：name 带路径分隔符不得穿越出 tasks/（Create 写 meta.json、Delete RemoveAll）。
+func TestCreateRejectsTraversalName(t *testing.T) {
+	base := t.TempDir()
+	for _, name := range []string{"../evil", "..", "a/b", `a\b`, "/abs"} {
+		_, err := Create(base, CreateParams{Name: name, Title: "t", Description: "d", Segments: segs()})
+		e, ok := err.(*Error)
+		if !ok || e.Code != "INVALID_PARAMS" {
+			t.Errorf("Create(%q) err = %v, want INVALID_PARAMS", name, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(base, "evil")); !os.IsNotExist(err) {
+		t.Error("traversal create escaped tasks/")
+	}
+}
+
+func TestResolveDoesNotProbeOutsideTasksDir(t *testing.T) {
+	base := t.TempDir()
+	// 在 tasks/ 之外放一份合法 meta.json，穿越名不得命中它。
+	outside := filepath.Join(base, "outside")
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "meta.json"),
+		[]byte(`{"type":"light-rule","name":"outside","segments":[{"mode":"static","color":[255,0,0]}]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if Get(base, "../outside") != nil {
+		t.Error("lookup with ../ escaped tasks/")
+	}
+	if _, err := Delete(base, "../outside"); err == nil {
+		t.Error("Delete with ../ should report NOT_FOUND")
+	}
+	if _, err := os.Stat(outside); err != nil {
+		t.Error("outside dir must survive traversal delete attempt")
+	}
+}

--- a/internal/recording/result_writer.go
+++ b/internal/recording/result_writer.go
@@ -79,6 +79,10 @@ func HandleRecordingResultWrite(params ResultWriteParams, storage *Storage, logg
 	if recordingID == "" {
 		return ResultWriteResult{}, errors.New("recordingId is required")
 	}
+	// 兜底（daemon 入口已校验）：recordingID 会拼进落盘文件名。
+	if !fsutil.IsSafeName(recordingID) {
+		return ResultWriteResult{}, errors.New("recordingId is invalid")
+	}
 	if params.Transcript == nil && params.Summary == nil {
 		return ResultWriteResult{}, errors.New("transcript or summary is required")
 	}

--- a/internal/recording/result_writer_traversal_test.go
+++ b/internal/recording/result_writer_traversal_test.go
@@ -1,0 +1,21 @@
+package recording
+
+import (
+	"testing"
+)
+
+// 回归：recordingId 会拼进 transcript-data/transcripts/summaries 文件名，
+// 穿越形式必须在写入前被拒。
+func TestResultWriteRejectsTraversalRecordingID(t *testing.T) {
+	t.Parallel()
+	storage := newResultStorage(t)
+	for _, id := range []string{"../evil", "..", "a/b", `a\b`} {
+		_, err := HandleRecordingResultWrite(ResultWriteParams{
+			RecordingID: id,
+			Summary:     &ResultSummary{Markdown: "# x"},
+		}, storage, testLogger{t}, SyncOptions{})
+		if err == nil || err.Error() != "recordingId is invalid" {
+			t.Errorf("HandleRecordingResultWrite(id=%q) err = %v, want invalid", id, err)
+		}
+	}
+}

--- a/internal/recording/store.go
+++ b/internal/recording/store.go
@@ -463,11 +463,13 @@ func extractAudioExt(rawURL string) string {
 	return ".ogg"
 }
 
+var extRE = regexp.MustCompile(`^\.[A-Za-z0-9]+$`)
+
 func validExt(ext string) bool {
 	if ext == "" || len(ext) > 12 {
 		return false
 	}
-	return regexp.MustCompile(`^\.[A-Za-z0-9]+$`).MatchString(ext)
+	return extRE.MatchString(ext)
 }
 
 var badFilenameChars = strings.NewReplacer("/", "", "\\", "", ":", "", "*", "", "?", "", `"`, "", "<", "", ">", "", "|", "")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.6.0-beta.2",
+  "version": "0.6.0-beta.3",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {


### PR DESCRIPTION
## Summary
- daemon 鉴权 token/api-key 比较改用常数时间比较（subtle.ConstantTimeCompare），避免 timing 侧信道
- recordingId / imageId / 灯效规则名新增 fsutil.IsSafeName 校验，拦截拼接落盘路径前的目录穿越（../）
- 版本号 bump 至 0.6.0-beta.3

## Test plan
- [x] go build ./...
- [x] go test ./internal/fsutil/... ./internal/image/... ./internal/lightrule/... ./internal/recording/... ./internal/daemon/...