### PR TITLE
cli-0.6.1

### DIFF
--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -265,6 +265,24 @@ func (s *server) supervisor() *relay.Supervisor {
 	return s.tunnelSupervisor
 }
 
+// retargetRelayIfStale 把隧道重指到当前配置解析出的 relay 地址。环境切换（reload
+// 换 profile/env）之后 s.cfg 已经指向新地址，但既有 client 还拨着旧的；health 探针
+// 发现 stale 时调用这里补一次重连，App 下一次探测就能拿到 ok:true。
+func (s *server) retargetRelayIfStale() bool {
+	sup := s.supervisor()
+	if sup == nil {
+		return false
+	}
+	s.shareMu.RLock()
+	expected := config.ResolveRelayURL(s.cfg)
+	s.shareMu.RUnlock()
+	changed, restarted := sup.Retarget(expected)
+	if changed {
+		s.logger.Info(fmt.Sprintf("health 探针发现 relay 地址过期，已重指并重连隧道：%v", restarted))
+	}
+	return changed
+}
+
 func (s *server) currentEgress() Egress {
 	s.shareMu.RLock()
 	defer s.shareMu.RUnlock()
@@ -411,7 +429,7 @@ func (s *server) labelForAPIKey(apiKey string) string {
 }
 
 // secretEqual 常数时间比较 token/api-key，避免逐字节短路造成 timing 侧信道
-//（daemon 可经 Relay/非 loopback 暴露，鉴权比较不能用 ==）。
+// （daemon 可经 Relay/非 loopback 暴露，鉴权比较不能用 ==）。
 func secretEqual(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
 }
@@ -504,11 +522,13 @@ func (s *server) relayStatusPayload() map[string]any {
 		connected := false
 		reconnectAttempt := 0
 		lastDisconnectReason := ""
+		currentURL := ""
 		for _, tunnel := range status.Tunnels {
 			if tunnel.Default || status.DefaultLabel == "" {
 				connected = tunnel.Connected
 				reconnectAttempt = tunnel.ReconnectAttempt
 				lastDisconnectReason = tunnel.LastDisconnectReason
+				currentURL = tunnel.URL
 				break
 			}
 		}
@@ -516,9 +536,13 @@ func (s *server) relayStatusPayload() map[string]any {
 		if !connected {
 			note = "Relay 重连中"
 		}
+		expectedURL := config.ResolveRelayURL(s.cfg)
 		return map[string]any{
-			"mode": "relay", "connected": connected, "env": envhost.Name(), "url": config.ResolveRelayURL(s.cfg), "enabled": s.cfg.Relay.Enabled,
+			"mode": "relay", "connected": connected, "env": envhost.Name(), "url": expectedURL, "enabled": s.cfg.Relay.Enabled,
 			"reconnectAttempt": reconnectAttempt, "lastDisconnectReason": nilIfEmptyStr(lastDisconnectReason),
+			// stale：默认隧道实际拨的地址与配置解析出的地址不一致，说明正在跟随环境切换重连。
+			"stale":      currentURL != "" && currentURL != expectedURL,
+			"currentUrl": nilIfEmptyStr(currentURL), "expectedUrl": expectedURL,
 			"note": note, "tunnels": status.Tunnels,
 		}
 	}
@@ -536,6 +560,7 @@ func (s *server) relayStatusPayload() map[string]any {
 	return map[string]any{
 		"mode": "standalone-http", "connected": false, "env": envhost.Name(), "url": config.ResolveRelayURL(s.cfg), "enabled": s.cfg.Relay.Enabled,
 		"reconnectAttempt": 0, "note": note, "tunnels": []any{},
+		"stale": false, "currentUrl": nil, "expectedUrl": config.ResolveRelayURL(s.cfg),
 	}
 }
 

--- a/internal/daemon/server_gateway_compat.go
+++ b/internal/daemon/server_gateway_compat.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/YoooClaw/cli/internal/version"
 )
@@ -11,7 +12,17 @@ func (s *server) handleGatewayCompat(w http.ResponseWriter, r *http.Request, pat
 	method := strings.TrimPrefix(path, "/gateway/")
 	switch method {
 	case "health":
-		gatewayOK(w, s.gatewayHealthPayload())
+		var body map[string]any
+		if !decodeBody(w, r, &body) {
+			return
+		}
+		payload := s.gatewayHealthPayload(body["echo"])
+		gatewayOK(w, payload)
+		// 与 hermes 一致：探针发现隧道拨的还是旧地址时先如实回 ok:false，
+		// 再顺手把隧道重指到当前配置地址，App 稍后重试即可探到。
+		if healthy, _ := payload["ok"].(bool); !healthy {
+			s.retargetRelayIfStale()
+		}
 	case "channels.status":
 		gatewayOK(w, s.gatewayChannelsPayload())
 	case "agents.list":
@@ -36,20 +47,30 @@ func (s *server) handleGatewayCompat(w http.ResponseWriter, r *http.Request, pat
 	}
 }
 
-func (s *server) gatewayHealthPayload() map[string]any {
+// gatewayHealthPayload 是 App 探活口。字段与 hermes-plugin 的 `req`/`health`
+// 响应对齐（ok/time/sessionDb/lastInboundAt/relay.{stale,currentUrl,expectedUrl}/echo），
+// 其余 yoooclaw 自有字段作为超集保留，老消费者不受影响。
+func (s *server) gatewayHealthPayload(echo any) map[string]any {
 	relayStatus := s.relayStatusPayload()
+	stale, _ := relayStatus["stale"].(bool)
 	s.st.mu.Lock()
 	lastIngest := s.st.lastIngest
 	ingestCount := s.st.ingestCount
 	s.st.mu.Unlock()
-	return map[string]any{
-		"status": "ok", "healthy": true, "server": "yoooclaw", "version": version.Version,
+	payload := map[string]any{
+		"ok": !stale, "time": time.Now().UTC().Format(time.RFC3339), "sessionDb": false,
+		"lastInboundAt": nilIfEmptyStr(lastIngest),
+		"status":        "ok", "healthy": true, "server": "yoooclaw", "version": version.Version,
 		"protocol": ProtocolVersion, "capabilities": Capabilities, "profile": s.ctx.Profile,
 		"bind": s.bind, "port": s.port, "startedAt": s.st.startedAt,
 		"lastIngestAt": nilIfEmptyStr(lastIngest), "ingestCount": ingestCount,
 		"relay":    relayStatus,
 		"features": map[string]any{"methods": gatewayMethodNames(), "capabilities": Capabilities},
 	}
+	if echo != nil {
+		payload["echo"] = echo
+	}
+	return payload
 }
 
 func (s *server) gatewayChannelsPayload() map[string]any {

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/YoooClaw/cli/internal/config"
 	"github.com/YoooClaw/cli/internal/notif"
 	"github.com/YoooClaw/cli/internal/paths"
+	"github.com/YoooClaw/cli/internal/relay"
 )
 
 // newTestServer 构造一个最小可用的 server（无 relay、token 可配）。
@@ -156,6 +157,43 @@ func TestReloadConcurrentWithRequests(t *testing.T) {
 	<-done
 }
 
+// App 探活契约：/gateway/health 的响应字段必须与 hermes-plugin 的 req/health 对齐。
+func TestGatewayHealthMatchesHermesShape(t *testing.T) {
+	_, ts := newTestServer(t, "")
+	resp, err := http.Post(ts.URL+"/gateway/health", "application/json", strings.NewReader(`{"echo":"probe_01"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var body struct {
+		OK   bool           `json:"ok"`
+		Data map[string]any `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if !body.OK {
+		t.Fatalf("gateway envelope not ok: %+v", body)
+	}
+	if body.Data["ok"] != true {
+		t.Errorf("payload.ok = %v, want true", body.Data["ok"])
+	}
+	if body.Data["echo"] != "probe_01" {
+		t.Errorf("payload.echo = %v, want probe_01", body.Data["echo"])
+	}
+	for _, key := range []string{"time", "sessionDb", "lastInboundAt"} {
+		if _, ok := body.Data[key]; !ok {
+			t.Errorf("payload missing key %q: %+v", key, body.Data)
+		}
+	}
+	relay, _ := body.Data["relay"].(map[string]any)
+	for _, key := range []string{"stale", "currentUrl", "expectedUrl"} {
+		if _, ok := relay[key]; !ok {
+			t.Errorf("payload.relay missing key %q: %+v", key, relay)
+		}
+	}
+}
+
 func TestServerNotFound(t *testing.T) {
 	_, ts := newTestServer(t, "")
 	resp, err := http.Get(ts.URL + "/no/such/path")
@@ -225,5 +263,23 @@ func TestServerHelpers(t *testing.T) {
 	r.Header.Set("Authorization", "Basic xyz")
 	if bearerValue(r) != "" {
 		t.Error("non-bearer should be empty")
+	}
+}
+
+// health 探针发现 relay 地址过期时要把隧道重指到配置地址（hermes 的
+// _force_reconnect_if_relay_url_stale 对应实现）。
+func TestRetargetRelayIfStale(t *testing.T) {
+	srv, _ := newTestServer(t, "")
+	if srv.retargetRelayIfStale() {
+		t.Error("没有 supervisor 时不应重指")
+	}
+	srv.tunnelSupervisor = relay.NewSupervisor(relay.SupervisorOptions{
+		TunnelURL: "wss://stale.example.com/ws", StateDir: t.TempDir(), Logger: srv.logger,
+	})
+	if !srv.retargetRelayIfStale() {
+		t.Error("地址过期应触发重指")
+	}
+	if srv.retargetRelayIfStale() {
+		t.Error("地址已对齐后不应重复重指")
 	}
 }

--- a/internal/relay/helpers_test.go
+++ b/internal/relay/helpers_test.go
@@ -255,3 +255,36 @@ func TestSupervisorCleansDispatcherWSOnDisconnect(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 }
+
+func TestSupervisorRetarget(t *testing.T) {
+	t.Parallel()
+
+	supervisor := NewSupervisor(SupervisorOptions{
+		TunnelURL:          "ws://127.0.0.1:1/ws",
+		HTTPBaseURL:        "http://127.0.0.1:1",
+		ReconnectBackoffMs: 50,
+		StateDir:           t.TempDir(),
+		Logger:             testLogger{t},
+	})
+	supervisor.Apply(creds.CredentialSet{
+		Mode:    "single",
+		Entries: []creds.ApiKeyEntry{{Label: "default", Key: "relay-key"}},
+	})
+	defer supervisor.StopAll("test done")
+
+	if changed, _ := supervisor.Retarget("ws://127.0.0.1:1/ws"); changed {
+		t.Error("same URL should not retarget")
+	}
+	if changed, _ := supervisor.Retarget(""); changed {
+		t.Error("empty URL should not retarget")
+	}
+
+	changed, restarted := supervisor.Retarget("ws://127.0.0.1:2/ws")
+	if !changed || len(restarted) != 1 || restarted[0] != "default" {
+		t.Fatalf("retarget changed=%v restarted=%v", changed, restarted)
+	}
+	status := supervisor.Status()
+	if len(status.Tunnels) != 1 || status.Tunnels[0].URL != "ws://127.0.0.1:2/ws" {
+		t.Errorf("tunnel should dial the new URL: %+v", status.Tunnels)
+	}
+}

--- a/internal/relay/supervisor.go
+++ b/internal/relay/supervisor.go
@@ -120,6 +120,26 @@ func (s *Supervisor) Reconnect(label string) (reconnected []string, missing stri
 	return reconnected, ""
 }
 
+// Retarget 把隧道目标地址换成 url 并重连全部隧道；地址未变时返回 false 不动。
+// 环境切换后 daemon 的 config 已经指向新 relay，但已建的 client 仍拨着旧地址，
+// 靠这里把旧 socket 关掉让隧道重新按新地址建连（health 探针触发）。
+func (s *Supervisor) Retarget(url string) (changed bool, restarted []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if url == "" || url == s.opts.TunnelURL {
+		return false, nil
+	}
+	s.opts.Logger.Info("Relay retarget: " + redactURL(s.opts.TunnelURL) + " -> " + redactURL(url))
+	s.opts.TunnelURL = url
+	for label, managed := range s.tunnels {
+		managed.client.Stop("relay-retarget")
+		managed.dispatcher.Cleanup()
+		s.tunnels[label] = s.startLocked(managed.entry)
+		restarted = append(restarted, label)
+	}
+	return true, restarted
+}
+
 // PushEvent 给所有已管理隧道广播事件。
 func (s *Supervisor) PushEvent(event string, payload any) {
 	s.mu.Lock()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {


### PR DESCRIPTION
发布 0.6.1 后合回主干。

- health 探活对齐 hermes：`/gateway/health` 返回 `ok`/`time`/`sessionDb`/`lastInboundAt`/`relay.{stale,currentUrl,expectedUrl}`/`echo`，原有 yoooclaw 字段作为超集保留
- `Supervisor.Retarget`：health 探针发现隧道拨的是过期地址时先如实回 `ok:false`，再把隧道重指到当前配置地址
- package.json 0.6.0 → 0.6.1

npm 已发布 `@yoooclaw/cli@0.6.1`（latest），Release CLI / CI workflow 均 success。

🤖 Generated with [Claude Code](https://claude.com/claude-code)