### PR TITLE
cli-0.6.2-beta.0

### DIFF
--- a/internal/cli/cmd_auth.go
+++ b/internal/cli/cmd_auth.go
@@ -61,11 +61,15 @@ func authSetAPIKey(_ *clictx.Context, cmd *cobra.Command, args []string) (any, e
 	if err != nil {
 		return nil, err
 	}
-	return map[string]any{
+	out := map[string]any{
 		"ok": true, "source": result.Source, "location": result.Location, "label": result.Label,
 		"masked": creds.MaskSecret(result.Value),
 		"hint":   "插件 / CLI / daemon 共用同一份；daemon 在跑时会经文件 watch 热生效",
-	}, nil
+	}
+	if warning := creds.APIKeyShapeWarning(key); warning != "" {
+		out["warning"] = warning
+	}
+	return out, nil
 }
 
 func authAddAPIKey(_ *clictx.Context, cmd *cobra.Command, args []string) (any, error) {
@@ -84,13 +88,17 @@ func authAddAPIKey(_ *clictx.Context, cmd *cobra.Command, args []string) (any, e
 	}
 	after := creds.ResolveAPIKeyEntries()
 	isDefault := after.DefaultEntry != nil && after.DefaultEntry.Label == label
-	return map[string]any{
+	out := map[string]any{
 		"ok": true, "mode": after.Mode, "label": label, "default": isDefault,
 		"source": result.Source, "location": result.Location, "masked": creds.MaskSecret(key),
 		"shadowedKeychainPresent": after.ShadowedKeychainPresent,
 		"migratedLegacyApiKey":    before.Mode == "legacy-file-single",
 		"hint":                    "daemon 在跑时会经文件 watch 热生效；watch 不可靠时执行 yc daemon reload",
-	}, nil
+	}
+	if warning := creds.APIKeyShapeWarning(key); warning != "" {
+		out["warning"] = warning
+	}
+	return out, nil
 }
 
 func entryToItem(e creds.ApiKeyEntry) map[string]any {
@@ -169,10 +177,18 @@ func authStatus(ctx *clictx.Context, _ *cobra.Command, _ []string) (any, error) 
 	if state.Lock != nil {
 		daemonInfo["pid"] = state.Lock.PID
 	}
+	// key 形态可疑（如 CLI 签发的 ock-cli-*）时在这里就说破：它只在灯效 / ASR 这类
+	// 插件侧接口上炸，Relay 隧道照连，等到 401 才发现太晚。
+	warnings := apiKeys.Warnings
+	for _, e := range apiKeys.Entries {
+		if w := creds.APIKeyShapeWarning(e.Key); w != "" {
+			warnings = append(warnings, "api-key["+e.Label+"]："+w)
+		}
+	}
 	return map[string]any{
 		"ok": true, "profile": ctx.Profile, "mode": apiKeys.Mode, "defaultLabel": defaultLabelOrNil(apiKeys),
 		"apiKeys": entriesToItems(apiKeys.Entries), "legacyApiKeyPresent": apiKeys.LegacyAPIKeyPresent,
-		"shadowedKeychainPresent": apiKeys.ShadowedKeychainPresent, "warnings": apiKeys.Warnings,
+		"shadowedKeychainPresent": apiKeys.ShadowedKeychainPresent, "warnings": warnings,
 		"apiKey": map[string]any{
 			"present": apiKey.Value != "", "source": apiKey.Source, "location": apiKey.Location,
 			"label": apiKey.Label, "masked": creds.MaskSecret(apiKey.Value),

--- a/internal/cli/cmd_light.go
+++ b/internal/cli/cmd_light.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/YoooClaw/cli/internal/clictx"
+	"github.com/YoooClaw/cli/internal/config"
 	"github.com/YoooClaw/cli/internal/creds"
 	"github.com/YoooClaw/cli/internal/errs"
 	"github.com/YoooClaw/cli/internal/light"
@@ -60,7 +61,7 @@ func lightSend(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error)
 	}
 	if rule != "" {
 		// 规则存在云端，先解析成 segments 再下发（本地规则文件仅供 +gateway 兼容路径）。
-		resolved, err := lightruleFind(rule)
+		resolved, err := lightruleFind(ctx, rule)
 		if err != nil {
 			return nil, err
 		}
@@ -86,8 +87,18 @@ func lightBlink(ctx *clictx.Context, _ *cobra.Command, _ []string) (any, error) 
 	return lightSendDirect(ctx, map[string]any{"preset": "red-strobe-3"})
 }
 
+// cloudHost 解析当前 profile 的云端主机；profile 还没 init（config 读不到）时按
+// 零值走环境默认值，保证 light/lightrule 在裸装状态下仍可用。
+func cloudHost(ctx *clictx.Context) string {
+	cfg, err := config.Load(ctx.Paths)
+	if err != nil {
+		return config.ResolveCloudHost(config.Config{})
+	}
+	return config.ResolveCloudHost(cfg)
+}
+
 func lightSendDirect(ctx *clictx.Context, body map[string]any) (any, error) {
-	result, gerr := lightgw.Send(ctx.Paths.LightRules, body, creds.ResolveAPIKey().Value, noopLightLogger{})
+	result, gerr := lightgw.Send(ctx.Paths.LightRules, body, cloudHost(ctx), creds.ResolveAPIKey().Value, noopLightLogger{})
 	if gerr != nil {
 		return nil, errs.New(gerr.Code, gerr.Message)
 	}
@@ -109,7 +120,7 @@ func lightGateway(ctx *clictx.Context, _ *cobra.Command, args []string) (any, er
 	}
 	method := args[0]
 	if method == "light.send" {
-		result, gerr := lightgw.Send(ctx.Paths.LightRules, body, creds.ResolveAPIKey().Value, noopLightLogger{})
+		result, gerr := lightgw.Send(ctx.Paths.LightRules, body, cloudHost(ctx), creds.ResolveAPIKey().Value, noopLightLogger{})
 		if gerr != nil {
 			status := gerr.Status
 			if status == 0 {
@@ -172,8 +183,8 @@ func newLightruleCmd() *cobra.Command {
 	return c
 }
 
-func lightruleClient() *lightrule.Client {
-	return &lightrule.Client{APIKey: creds.ResolveAPIKey().Value, Logger: noopLightLogger{}}
+func lightruleClient(ctx *clictx.Context) *lightrule.Client {
+	return &lightrule.Client{APIKey: creds.ResolveAPIKey().Value, Host: cloudHost(ctx), Logger: noopLightLogger{}}
 }
 
 // lightruleErr 把云端 APIError 转成 CLI 结构化错误（code 原样透传）。
@@ -185,8 +196,8 @@ func lightruleErr(err error) error {
 }
 
 // lightruleFind 按 id/name 从云端解析单条规则。
-func lightruleFind(id string) (map[string]any, error) {
-	rules, err := lightruleClient().List()
+func lightruleFind(ctx *clictx.Context, id string) (map[string]any, error) {
+	rules, err := lightruleClient(ctx).List()
 	if err != nil {
 		return nil, lightruleErr(err)
 	}
@@ -198,28 +209,28 @@ func lightruleFind(id string) (map[string]any, error) {
 	return nil, errs.New(errs.CodeNotFound, "灯效规则不存在："+id)
 }
 
-func lightruleList(_ *clictx.Context, _ *cobra.Command, _ []string) (any, error) {
-	rules, err := lightruleClient().List()
+func lightruleList(ctx *clictx.Context, _ *cobra.Command, _ []string) (any, error) {
+	rules, err := lightruleClient(ctx).List()
 	if err != nil {
 		return nil, lightruleErr(err)
 	}
 	return map[string]any{"ok": true, "rules": rules}, nil
 }
 
-func lightruleShow(_ *clictx.Context, _ *cobra.Command, args []string) (any, error) {
-	rule, err := lightruleFind(args[0])
+func lightruleShow(ctx *clictx.Context, _ *cobra.Command, args []string) (any, error) {
+	rule, err := lightruleFind(ctx, args[0])
 	if err != nil {
 		return nil, err
 	}
 	return map[string]any{"ok": true, "rule": rule}, nil
 }
 
-func lightruleCreate(_ *clictx.Context, cmd *cobra.Command, _ []string) (any, error) {
+func lightruleCreate(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error) {
 	intent := flagStr(cmd, "intent")
 	if intent == "" {
 		return nil, errs.New(errs.CodeInvalidArgument, "需要 --intent（自然语言规则，云端 Agent 编译）")
 	}
-	result, err := lightruleClient().Create(intent)
+	result, err := lightruleClient(ctx).Create(intent)
 	if err != nil {
 		return nil, lightruleErr(err)
 	}
@@ -283,12 +294,12 @@ func buildRulePatch(cmd *cobra.Command) (map[string]any, error) {
 	return patch, nil
 }
 
-func lightruleUpdate(_ *clictx.Context, cmd *cobra.Command, args []string) (any, error) {
+func lightruleUpdate(ctx *clictx.Context, cmd *cobra.Command, args []string) (any, error) {
 	patch, err := buildRulePatch(cmd)
 	if err != nil {
 		return nil, err
 	}
-	result, err := lightruleClient().Update(args[0], patch)
+	result, err := lightruleClient(ctx).Update(args[0], patch)
 	if err != nil {
 		return nil, lightruleErr(err)
 	}
@@ -296,7 +307,7 @@ func lightruleUpdate(_ *clictx.Context, cmd *cobra.Command, args []string) (any,
 	return result, nil
 }
 
-func lightruleDelete(_ *clictx.Context, cmd *cobra.Command, args []string) (any, error) {
+func lightruleDelete(ctx *clictx.Context, cmd *cobra.Command, args []string) (any, error) {
 	if !flagBool(cmd, "yes") {
 		ok, err := prompt.Confirm("确认删除规则 `"+args[0]+"`？", false)
 		if err != nil {
@@ -306,7 +317,7 @@ func lightruleDelete(_ *clictx.Context, cmd *cobra.Command, args []string) (any,
 			return nil, errs.New(errs.CodeConfirmationRequired, "已取消")
 		}
 	}
-	result, err := lightruleClient().Delete(args[0])
+	result, err := lightruleClient(ctx).Delete(args[0])
 	if err != nil {
 		return nil, lightruleErr(err)
 	}
@@ -315,16 +326,16 @@ func lightruleDelete(_ *clictx.Context, cmd *cobra.Command, args []string) (any,
 	return result, nil
 }
 
-func lightruleEnable(_ *clictx.Context, _ *cobra.Command, args []string) (any, error) {
-	return lightruleSetEnabled(args[0], true)
+func lightruleEnable(ctx *clictx.Context, _ *cobra.Command, args []string) (any, error) {
+	return lightruleSetEnabled(ctx, args[0], true)
 }
 
-func lightruleDisable(_ *clictx.Context, _ *cobra.Command, args []string) (any, error) {
-	return lightruleSetEnabled(args[0], false)
+func lightruleDisable(ctx *clictx.Context, _ *cobra.Command, args []string) (any, error) {
+	return lightruleSetEnabled(ctx, args[0], false)
 }
 
-func lightruleSetEnabled(id string, enabled bool) (any, error) {
-	result, err := lightruleClient().Update(id, map[string]any{"enabled": enabled})
+func lightruleSetEnabled(ctx *clictx.Context, id string, enabled bool) (any, error) {
+	result, err := lightruleClient(ctx).Update(id, map[string]any{"enabled": enabled})
 	if err != nil {
 		return nil, lightruleErr(err)
 	}
@@ -332,16 +343,16 @@ func lightruleSetEnabled(id string, enabled bool) (any, error) {
 	return result, nil
 }
 
-func lightruleOn(_ *clictx.Context, _ *cobra.Command, _ []string) (any, error) {
-	return lightruleToggleAll(true)
+func lightruleOn(ctx *clictx.Context, _ *cobra.Command, _ []string) (any, error) {
+	return lightruleToggleAll(ctx, true)
 }
 
-func lightruleOff(_ *clictx.Context, _ *cobra.Command, _ []string) (any, error) {
-	return lightruleToggleAll(false)
+func lightruleOff(ctx *clictx.Context, _ *cobra.Command, _ []string) (any, error) {
+	return lightruleToggleAll(ctx, false)
 }
 
-func lightruleToggleAll(enabled bool) (any, error) {
-	client := lightruleClient()
+func lightruleToggleAll(ctx *clictx.Context, enabled bool) (any, error) {
+	client := lightruleClient(ctx)
 	rules, err := client.List()
 	if err != nil {
 		return nil, lightruleErr(err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,14 +32,28 @@ func DefaultRelayURL() string {
 	return "wss://" + envhost.Host() + RelayPath
 }
 
+// ResolveCloudHost 返回灯效 / 灯效规则 / ASR 共用的云端主机，是这三条链路唯一的
+// 主机来源：留空则跟随 PHONE_NOTIFICATIONS_ENV（见 internal/envhost），填了就用填的。
+//
+// 这里不套用 ResolveRelayURL 那条"值等于内置默认域名就重新解析"的规则——那条规则是
+// 为 relay.url 的历史包袱准备的（老 profile 里已经写死了一个具体域名，不重解析就跟不上
+// 环境切换）。cloud.host 默认就是空串，再套同一条规则只会让
+// `config set cloud.host openclaw-service-test.yoooclaw.com` 被当成默认值忽略掉。
+func ResolveCloudHost(cfg Config) string {
+	if host := envhost.Normalize(cfg.Cloud.Host); host != "" {
+		return host
+	}
+	return envhost.Host()
+}
+
 // ResolveRelayURL 返回 daemon 实际应连接的 Relay 地址。
-// 若配置里持久化的仍是某个环境的内置默认主机（而非用户自定义 URL），则按当前
-// PHONE_NOTIFICATIONS_ENV 重新解析，使已初始化的 profile 也能跟随环境切换；
-// 用户显式改过的自定义 URL 始终保留。
+// 若配置里持久化的仍是某个环境的内置默认主机（而非用户自定义 URL），则回落到
+// cloud.host —— 这样隧道与灯效 / ASR 天然指向同一套环境，不会出现"隧道连着但灯效
+// 401"；用户显式改过的自定义 URL 始终保留，仍可单独把隧道指向别处。
 func ResolveRelayURL(cfg Config) string {
 	url := cfg.Relay.URL
 	if url == "" || envhost.IsDefaultHost(stripRelayURL(url)) {
-		return DefaultRelayURL()
+		return "wss://" + ResolveCloudHost(cfg) + RelayPath
 	}
 	return url
 }
@@ -68,6 +82,12 @@ type DaemonSection struct {
 type AuthSection struct {
 	Mode     string `json:"mode"`
 	TokenRef string `json:"tokenRef"`
+}
+
+// CloudSection 云端接口主机配置。空字符串表示跟随 PHONE_NOTIFICATIONS_ENV
+// （见 internal/envhost），填了自定义主机则灯效 / 灯效规则 / ASR / Relay 一起改指。
+type CloudSection struct {
+	Host string `json:"host"`
 }
 
 // RelaySection Relay 隧道配置。
@@ -155,6 +175,7 @@ type Config struct {
 	Version      int                 `json:"version"`
 	Daemon       DaemonSection       `json:"daemon"`
 	Auth         AuthSection         `json:"auth"`
+	Cloud        CloudSection        `json:"cloud"`
 	Relay        RelaySection        `json:"relay"`
 	Ingress      IngressSection      `json:"ingress"`
 	Notification NotificationSection `json:"notification"`
@@ -178,6 +199,8 @@ func Default(credentialsPath string) Config {
 			Mode:     "token",
 			TokenRef: "file:" + credentialsPath + "#gatewayToken",
 		},
+		// Cloud.Host 留空：新 profile 默认跟随环境变量，不把当时的域名焊死进配置。
+		Cloud: CloudSection{},
 		Relay: RelaySection{
 			URL:                DefaultRelayURL(),
 			HeartbeatSec:       10,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -204,3 +204,51 @@ func TestMask(t *testing.T) {
 		t.Error("Mask must not mutate input")
 	}
 }
+
+func TestResolveCloudHost(t *testing.T) {
+	t.Setenv("PHONE_NOTIFICATIONS_ENV", "test")
+	t.Setenv("OPENCLAW_HOST_TEST", "")
+
+	// 未配置 → 跟随 PHONE_NOTIFICATIONS_ENV。
+	if got := ResolveCloudHost(Config{}); got != "openclaw-service-test.yoooclaw.com" {
+		t.Errorf("empty host should follow env, got %q", got)
+	}
+	// 自定义主机 → 原样保留，环境变量不再有话语权。
+	custom := Config{Cloud: CloudSection{Host: "my-cloud.example.com"}}
+	if got := ResolveCloudHost(custom); got != "my-cloud.example.com" {
+		t.Errorf("custom host should win over env, got %q", got)
+	}
+	// scheme / 尾斜杠会被归一化掉。
+	messy := Config{Cloud: CloudSection{Host: "https://my-cloud.example.com/"}}
+	if got := ResolveCloudHost(messy); got != "my-cloud.example.com" {
+		t.Errorf("host should be normalized, got %q", got)
+	}
+	// 显式写成某个内置默认域名也必须生效（不能被当成"还是默认值"忽略掉）。
+	pinned := Config{Cloud: CloudSection{Host: "openclaw-service.yoooclaw.com"}}
+	if got := ResolveCloudHost(pinned); got != "openclaw-service.yoooclaw.com" {
+		t.Errorf("explicitly pinned default domain should be honored, got %q", got)
+	}
+}
+
+func TestResolveRelayURLFollowsCloudHost(t *testing.T) {
+	t.Setenv("PHONE_NOTIFICATIONS_ENV", "production")
+	t.Setenv("OPENCLAW_HOST_PRODUCTION", "")
+
+	// relay.url 还是内置默认形态 → 跟着 cloud.host 走，隧道与灯效/ASR 不会分家。
+	cfg := Config{
+		Cloud: CloudSection{Host: "openclaw-service-test.yoooclaw.com"},
+		Relay: RelaySection{URL: "wss://openclaw-service.yoooclaw.com" + RelayPath},
+	}
+	if got := ResolveRelayURL(cfg); got != "wss://openclaw-service-test.yoooclaw.com"+RelayPath {
+		t.Errorf("relay should derive from cloud.host, got %q", got)
+	}
+	if got := ResolveCloudHost(cfg); !strings.Contains(got, "-test.") {
+		t.Errorf("cloud host mismatch: %q", got)
+	}
+
+	// relay.url 被显式改成自定义地址 → 仍然覆盖 cloud.host（保留单独指向的能力）。
+	cfg.Relay.URL = "wss://my-relay.example.com/custom/path"
+	if got := ResolveRelayURL(cfg); got != "wss://my-relay.example.com/custom/path" {
+		t.Errorf("custom relay URL should still win, got %q", got)
+	}
+}

--- a/internal/creds/store.go
+++ b/internal/creds/store.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/YoooClaw/cli/internal/config"
+	"github.com/YoooClaw/cli/internal/envhost"
 	"github.com/YoooClaw/cli/internal/errs"
 	"github.com/YoooClaw/cli/internal/fsutil"
 	"github.com/YoooClaw/cli/internal/paths"
@@ -415,6 +416,45 @@ func SetDefaultAPIKey(label string) (ApiKeyResolution, error) {
 		entries[i].Default = entries[i].Label == label
 	}
 	return writeAPIKeys(entries)
+}
+
+const (
+	// PluginAPIKeyPrefix 是插件侧 API Key 的前缀。灯效 / ASR 等 X-Api-Key-Id 接口
+	// 只认这类 key。
+	PluginAPIKeyPrefix = "ock-"
+	// cliAPIKeyPrefix 是 CLI 签发的 key 前缀。它能通过 Relay 隧道握手，却没有登记进
+	// 插件侧 API Key 表——用户会看到"隧道连着但灯效 401"，所以单独给一句提示。
+	cliAPIKeyPrefix = "ock-cli-"
+)
+
+// APIKeyShapeWarning 在 api-key 形态明显不是插件侧 API Key 时返回一句排障提示，
+// 否则返回空串。前缀规则由云端掌握且会变，所以这里只提示、不拦截。
+func APIKeyShapeWarning(apiKey string) string {
+	key := strings.TrimSpace(apiKey)
+	switch {
+	case key == "":
+		return ""
+	case strings.HasPrefix(key, cliAPIKeyPrefix):
+		return cliAPIKeyPrefix + "* 是 CLI 签发的 key：Relay 隧道能连上，但灯效 / ASR 等插件侧 API 会返回 " +
+			"401 Invalid plugin API Key；请改用 App / 控制台里 " + PluginAPIKeyPrefix + " 开头的 plugin API Key"
+	case !strings.HasPrefix(key, PluginAPIKeyPrefix):
+		return "api-key 不是 " + PluginAPIKeyPrefix + " 开头，灯效 / ASR 等插件侧 API 可能返回 401 Invalid plugin API Key"
+	default:
+		return ""
+	}
+}
+
+// PluginAPIKeyRejectedHint 组装插件侧 API 回 401 Invalid plugin API Key 时追加的排障
+// 后缀（环境 + 遮罩 key + 下一步动作）。这类失败下 Relay 隧道仍连得上、云端只回一句
+// msg，用户无从判断是 key 拿错了还是环境不对，故灯效下发与灯效规则两条链路共用此话术。
+func PluginAPIKeyRejectedHint(apiKey string) string {
+	action := APIKeyShapeWarning(apiKey)
+	if action == "" {
+		action = "api-key 分环境签发，请确认这把 key 属于 " + envhost.Name() +
+			"，或用 PHONE_NOTIFICATIONS_ENV 切到 key 所属环境"
+	}
+	return "。当前环境=" + envhost.Name() + "（主机 " + envhost.Host() + "），api-key=" +
+		MaskSecret(apiKey) + "：" + action
 }
 
 // MaskSecret 遮罩密钥用于展示。

--- a/internal/creds/store_test.go
+++ b/internal/creds/store_test.go
@@ -1,6 +1,7 @@
 package creds
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/YoooClaw/cli/internal/keychain"
@@ -251,5 +252,38 @@ func TestNormalizeStoredEntriesWarnings(t *testing.T) {
 	}
 	if len(set.Warnings) == 0 {
 		t.Error("expected warnings for skipped entries")
+	}
+}
+
+func TestAPIKeyShapeWarning(t *testing.T) {
+	t.Parallel()
+	cases := map[string]bool{ // key -> 是否应给出警告
+		"":                    false,
+		"ock-jyGDxxxxxxxx":    false,
+		"  ock-jyGDxxxxxxxx ": false,
+		"ock-cli-abcdefgh":    true, // relay 认、插件侧不认，是本函数存在的理由
+		"sk-something":        true,
+	}
+	for key, want := range cases {
+		if got := APIKeyShapeWarning(key) != ""; got != want {
+			t.Errorf("APIKeyShapeWarning(%q) warned=%v, want %v", key, got, want)
+		}
+	}
+	if w := APIKeyShapeWarning("ock-cli-abcdefgh"); !strings.Contains(w, "ock-cli-") {
+		t.Errorf("CLI key warning should name the prefix: %s", w)
+	}
+}
+
+func TestPluginAPIKeyRejectedHint(t *testing.T) {
+	t.Setenv("PHONE_NOTIFICATIONS_ENV", "test")
+	hint := PluginAPIKeyRejectedHint("ock-cli-abcdefgh")
+	for _, want := range []string{"test", "openclaw-service-test.yoooclaw.com", "ock-cli-", MaskSecret("ock-cli-abcdefgh")} {
+		if !strings.Contains(hint, want) {
+			t.Errorf("hint missing %q: %s", want, hint)
+		}
+	}
+	// 形态正常的 key 走环境不匹配那一支。
+	if h := PluginAPIKeyRejectedHint("ock-jyGDxxxxxxxx"); !strings.Contains(h, "PHONE_NOTIFICATIONS_ENV") {
+		t.Errorf("well-formed key should hint at env mismatch: %s", h)
 	}
 }

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -23,6 +23,8 @@ import (
 	"github.com/YoooClaw/cli/internal/envhost"
 	"github.com/YoooClaw/cli/internal/errs"
 	"github.com/YoooClaw/cli/internal/fsutil"
+	"github.com/YoooClaw/cli/internal/light"
+	"github.com/YoooClaw/cli/internal/lightrule"
 	"github.com/YoooClaw/cli/internal/notif"
 	"github.com/YoooClaw/cli/internal/recording"
 	"github.com/YoooClaw/cli/internal/relay"
@@ -509,11 +511,24 @@ func (s *server) handleStatus(w http.ResponseWriter) {
 		},
 		"lastIngestAt": nilIfEmptyStr(lastIngest), "ingestCount": ingestCount,
 		"ingressMode":    s.ingressMode,
+		"cloud":          s.cloudStatusPayload(),
 		"relay":          relayStatus,
 		"tunnels":        relayStatus["tunnels"],
 		"credentialMode": set.Mode, "defaultLabel": defaultLabel,
 		"credentialWarnings": set.Warnings,
 	})
+}
+
+// cloudStatusPayload 暴露灯效 / 灯效规则 / ASR 实际打到的主机。这三条链路曾经只认
+// 环境变量、状态里也看不见，出问题时只能看到 relay 是绿的——所以在这里一并吐出来。
+func (s *server) cloudStatusPayload() map[string]any {
+	host := config.ResolveCloudHost(s.cfg)
+	return map[string]any{
+		"env": envhost.Name(), "host": host,
+		"custom":       envhost.Normalize(s.cfg.Cloud.Host) != "",
+		"lightApiUrl":  light.LightAPIURL(host),
+		"lightRuleApi": lightrule.APIURL(host),
+	}
 }
 
 func (s *server) relayStatusPayload() map[string]any {

--- a/internal/daemon/server_ingest.go
+++ b/internal/daemon/server_ingest.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/YoooClaw/cli/internal/config"
 	"github.com/YoooClaw/cli/internal/fsutil"
 	imgstore "github.com/YoooClaw/cli/internal/image"
 	"github.com/YoooClaw/cli/internal/recording"
@@ -244,7 +245,8 @@ func (s *server) resolveConfiguredASR(caller *recording.AsrConfig) *recording.As
 	if set := s.snapshotCreds(); set.DefaultEntry != nil {
 		fallback = set.DefaultEntry.Key
 	}
-	return recording.ResolveAsrConfig(caller, recording.LoadLocalAsrConfig(s.ctx.Paths.Recordings), fallback)
+	return recording.ResolveAsrConfig(caller, recording.LoadLocalAsrConfig(s.ctx.Paths.Recordings), fallback,
+		config.ResolveCloudHost(s.cfg))
 }
 
 func (s *server) notifyRecordingStatus(event recording.StatusEvent) {

--- a/internal/daemon/server_light.go
+++ b/internal/daemon/server_light.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/YoooClaw/cli/internal/config"
 	"github.com/YoooClaw/cli/internal/creds"
 	"github.com/YoooClaw/cli/internal/lightgw"
 )
@@ -15,7 +16,7 @@ func (s *server) handleLightSend(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	apiKey := creds.ResolveAPIKey().Value
-	result, gerr := lightgw.Send(s.ctx.Paths.LightRules, body, apiKey, s.logger)
+	result, gerr := lightgw.Send(s.ctx.Paths.LightRules, body, config.ResolveCloudHost(s.cfg), apiKey, s.logger)
 	if gerr != nil {
 		status := gerr.Status
 		if status == 0 {

--- a/internal/light/env.go
+++ b/internal/light/env.go
@@ -2,9 +2,14 @@ package light
 
 import "github.com/YoooClaw/cli/internal/envhost"
 
-// LightAPIURL 返回灯效云 API 端点（主机随 PHONE_NOTIFICATIONS_ENV 切换，见 internal/envhost）。
+// LightAPIURL 返回灯效云 API 端点。host 由调用方从 config.ResolveCloudHost 解析后传入；
+// 传空则回落到 PHONE_NOTIFICATIONS_ENV 的环境默认值（见 internal/envhost）。
 // 一次性亮灯走 Notification Intelligence Service 的插件侧 Facade，
 // 由服务端负责 LightSegment 校验、线协议编码与 message-service 调用。
-func LightAPIURL() string {
-	return "https://" + envhost.Host() + "/api/plugin/notification-intelligence/light-effects/send"
+func LightAPIURL(host string) string {
+	resolved := envhost.Normalize(host)
+	if resolved == "" {
+		resolved = envhost.Host()
+	}
+	return "https://" + resolved + "/api/plugin/notification-intelligence/light-effects/send"
 }

--- a/internal/light/env_test.go
+++ b/internal/light/env_test.go
@@ -8,7 +8,7 @@ import (
 func TestLightAPIURL(t *testing.T) {
 	t.Setenv("PHONE_NOTIFICATIONS_ENV", "production")
 	t.Setenv("OPENCLAW_HOST_PRODUCTION", "")
-	url := LightAPIURL()
+	url := LightAPIURL("")
 	if !strings.HasPrefix(url, "https://") || !strings.HasSuffix(url, "/api/plugin/notification-intelligence/light-effects/send") {
 		t.Errorf("LightAPIURL = %q", url)
 	}
@@ -17,7 +17,7 @@ func TestLightAPIURL(t *testing.T) {
 func TestLightAPIURLFollowsEnv(t *testing.T) {
 	t.Setenv("PHONE_NOTIFICATIONS_ENV", "test")
 	t.Setenv("OPENCLAW_HOST_TEST", "")
-	if got := LightAPIURL(); !strings.Contains(got, "openclaw-service-test.yoooclaw.com") {
+	if got := LightAPIURL(""); !strings.Contains(got, "openclaw-service-test.yoooclaw.com") {
 		t.Errorf("test env LightAPIURL = %q", got)
 	}
 }

--- a/internal/light/sender.go
+++ b/internal/light/sender.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/YoooClaw/cli/internal/creds"
 )
 
 // Logger 是 sender 依赖的最小日志接口。
@@ -28,8 +30,9 @@ type SendResult struct {
 
 // SendLightEffect 把结构化 segments POST 到 Notification Intelligence Service 的
 // 插件侧一次性亮灯 Facade（线协议编码与 message-service 调用由服务端完成）。
-func SendLightEffect(apiKey string, segments []map[string]any, repeatInput RepeatInput, reason, title string, logger Logger) SendResult {
-	apiURL := LightAPIURL()
+// host 见 LightAPIURL。
+func SendLightEffect(host, apiKey string, segments []map[string]any, repeatInput RepeatInput, reason, title string, logger Logger) SendResult {
+	apiURL := LightAPIURL(host)
 	resolvedTitle := resolveLightTitle(title, reason, segments)
 
 	if logger != nil {
@@ -86,7 +89,7 @@ func SendLightEffect(apiKey string, segments []map[string]any, repeatInput Repea
 		if logger != nil {
 			logger.Warn(fmt.Sprintf("Light sender: FAILED %d, url=%s, resBody=%s", res.StatusCode, apiURL, truncate(string(resBody), 500)))
 		}
-		return SendResult{OK: false, Status: res.StatusCode, Error: string(resBody)}
+		return SendResult{OK: false, Status: res.StatusCode, Error: decorateSendError(string(resBody), apiKey)}
 	}
 
 	// 响应外壳：{code, msg, date, data:{success, requestId, bizUniqueId, message}}，code=000000 为成功。
@@ -108,6 +111,15 @@ func SendLightEffect(apiKey string, segments []map[string]any, repeatInput Repea
 		parsed = string(resBody)
 	}
 	return SendResult{OK: true, BizUniqueID: bizUniqueID, Response: parsed}
+}
+
+// decorateSendError 为 “Invalid plugin API Key” 401 补一句排障指引（话术见
+// creds.PluginAPIKeyRejectedHint，与灯效规则链路保持一致）。
+func decorateSendError(body, apiKey string) string {
+	if !strings.Contains(strings.ToLower(body), "invalid plugin api key") {
+		return body
+	}
+	return body + creds.PluginAPIKeyRejectedHint(apiKey)
 }
 
 func resolveLightTitle(title, reason string, segments []map[string]any) string {

--- a/internal/light/sender_test.go
+++ b/internal/light/sender_test.go
@@ -85,7 +85,7 @@ func TestSendLightEffectConnectionError(t *testing.T) {
 	t.Setenv("PHONE_NOTIFICATIONS_ENV", "production")
 	t.Setenv("OPENCLAW_HOST_PRODUCTION", "127.0.0.1:1")
 	segs := []map[string]any{{"mode": "steady", "brightness": 100.0, "color": color(255, 0, 0)}}
-	res := SendLightEffect("test-key", segs, RepeatInput{}, "reason", "title", nil)
+	res := SendLightEffect("", "test-key", segs, RepeatInput{}, "reason", "title", nil)
 	if res.OK {
 		t.Error("connection to refused port should fail")
 	}
@@ -98,8 +98,29 @@ func TestSendLightEffectBadBody(t *testing.T) {
 	t.Setenv("PHONE_NOTIFICATIONS_ENV", "production")
 	t.Setenv("OPENCLAW_HOST_PRODUCTION", "127.0.0.1:1")
 	// 空 segments 在发送前被本地校验拦下，不发起请求。
-	res := SendLightEffect("k", nil, RepeatInput{}, "r", "t", nil)
+	res := SendLightEffect("", "k", nil, RepeatInput{}, "r", "t", nil)
 	if res.OK {
 		t.Error("empty segments should fail before send")
+	}
+}
+
+// LightAPIURL 恒定 https://，httptest 服务器进不来，故直接测装饰逻辑本身。
+func TestDecorateSendError(t *testing.T) {
+	t.Setenv("PHONE_NOTIFICATIONS_ENV", "production")
+	body := `{"code":"401","msg":"Invalid plugin API Key"}`
+
+	decorated := decorateSendError(body, "ock-cli-abcdefgh")
+	// 原始响应体保留，后面追加环境与 key 形态的排障指引。
+	if !strings.HasPrefix(decorated, body) {
+		t.Errorf("raw body should be kept as prefix: %s", decorated)
+	}
+	for _, want := range []string{"ock-cli-", "production", "openclaw-service.yoooclaw.com"} {
+		if !strings.Contains(decorated, want) {
+			t.Errorf("401 message missing %q: %s", want, decorated)
+		}
+	}
+
+	if got := decorateSendError(`{"msg":"boom"}`, "ock-cli-abcdefgh"); got != `{"msg":"boom"}` {
+		t.Errorf("non-401 body should pass through untouched: %s", got)
 	}
 }

--- a/internal/lightgw/gateway.go
+++ b/internal/lightgw/gateway.go
@@ -116,8 +116,8 @@ func Rules(base, method string, body map[string]any) (map[string]any, *Err) {
 }
 
 // Send 处理 /light/send 核心（原 daemon handleLightSend）：segments / preset /
-// rule 三选一，编码后下发灯效云 API。
-func Send(base string, body map[string]any, apiKey string, logger light.Logger) (any, *Err) {
+// rule 三选一，编码后下发灯效云 API。host 见 light.LightAPIURL。
+func Send(base string, body map[string]any, host, apiKey string, logger light.Logger) (any, *Err) {
 	repeatInput := light.RepeatInputFromAny(body["repeat"], body["repeat_times"])
 	reason, _ := body["reason"].(string)
 	title, _ := body["title"].(string)
@@ -154,7 +154,7 @@ func Send(base string, body map[string]any, apiKey string, logger light.Logger) 
 		return nil, &Err{Code: "INVALID_PARAMS", Message: "需要 segments / preset / rule 之一", Status: 400}
 	}
 
-	return light.SendLightEffect(apiKey, segments, repeatInput, reason, title, logger), nil
+	return light.SendLightEffect(host, apiKey, segments, repeatInput, reason, title, logger), nil
 }
 
 func ruleErr(err error) *Err {

--- a/internal/lightrule/client.go
+++ b/internal/lightrule/client.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/YoooClaw/cli/internal/creds"
 	"github.com/YoooClaw/cli/internal/envhost"
 )
 
@@ -23,9 +24,14 @@ import (
 // APIPath 是插件侧灯效规则 API 前缀（与 plugin env.ts 的常量一致）。
 const APIPath = "/api/plugin/notification-intelligence/light-rules"
 
-// APIURL 返回云端灯效规则 API 端点（主机随 PHONE_NOTIFICATIONS_ENV 切换）。
-func APIURL() string {
-	return "https://" + envhost.Host() + APIPath
+// APIURL 返回云端灯效规则 API 端点。host 由调用方从 config.ResolveCloudHost 解析后
+// 传入；传空则回落到 PHONE_NOTIFICATIONS_ENV 的环境默认值（见 internal/envhost）。
+func APIURL(host string) string {
+	resolved := envhost.Normalize(host)
+	if resolved == "" {
+		resolved = envhost.Host()
+	}
+	return "https://" + resolved + APIPath
 }
 
 // APIError 是云端请求的结构化错误。Code 可能是业务码（INVALID_PARAMS /
@@ -47,7 +53,8 @@ type ClientLogger interface {
 // Client 是云端灯效规则 client。零值不可用，APIKey 必填。
 type Client struct {
 	APIKey     string
-	BaseURL    string       // 空则用 APIURL()
+	Host       string       // 空则回落到环境默认主机；BaseURL 非空时忽略
+	BaseURL    string       // 空则用 APIURL(Host)
 	Logger     ClientLogger // 可为 nil
 	HTTPClient *http.Client // 可为 nil，默认 30s 超时
 }
@@ -202,7 +209,7 @@ func (c *Client) request(method, path string, body map[string]any) (map[string]a
 
 	base := c.BaseURL
 	if base == "" {
-		base = APIURL()
+		base = APIURL(c.Host)
 	}
 	url := base + path
 
@@ -240,7 +247,7 @@ func (c *Client) request(method, path string, body map[string]any) (map[string]a
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
 		message := remoteErrorMessage(parsed, string(text), res.StatusCode)
 		c.logWarn(fmt.Sprintf("Light rules API: %s %s failed status=%d message=%s", method, url, res.StatusCode, message))
-		return nil, &APIError{Code: strconv.Itoa(res.StatusCode), Message: decorateRemoteErrorMessage(message, url), Status: res.StatusCode}
+		return nil, &APIError{Code: strconv.Itoa(res.StatusCode), Message: decorateRemoteErrorMessage(message, url, apiKey), Status: res.StatusCode}
 	}
 	if parseErr != nil || parsed == nil {
 		return nil, &APIError{Code: "INVALID_RESPONSE", Message: "empty or invalid JSON response"}
@@ -332,8 +339,14 @@ func remoteErrorMessage(parsed map[string]any, text string, status int) string {
 	return "HTTP " + strconv.Itoa(status)
 }
 
-// decorateRemoteErrorMessage 为 “jwt is missing” 401 补充排障指引（对齐 TS 同名函数）。
-func decorateRemoteErrorMessage(message, url string) string {
+// decorateRemoteErrorMessage 为两类 401 补充排障指引：
+// “jwt is missing” 说明网关没把插件前缀放行到 API Key 鉴权（对齐 TS 同名函数）；
+// “Invalid plugin API Key” 说明 key 本身不被插件侧接受——多半是环境不对或拿了非
+// plugin key（如 CLI 签发的 ock-cli-*），此时 Relay 隧道照样连得上，极难自查。
+func decorateRemoteErrorMessage(message, url, apiKey string) string {
+	if strings.Contains(strings.ToLower(message), "invalid plugin api key") {
+		return message + creds.PluginAPIKeyRejectedHint(apiKey)
+	}
 	if !strings.Contains(strings.ToLower(message), "jwt is missing") {
 		return message
 	}

--- a/internal/lightrule/client_test.go
+++ b/internal/lightrule/client_test.go
@@ -260,3 +260,23 @@ func TestJwtMissingErrorGetsDecorated(t *testing.T) {
 		t.Errorf("jwt error should be decorated: %s", apiErr.Message)
 	}
 }
+
+func TestInvalidPluginKeyErrorGetsDecorated(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(401)
+		w.Write([]byte(`{"code":"401","msg":"Invalid plugin API Key"}`))
+	}))
+	defer server.Close()
+	t.Setenv("PHONE_NOTIFICATIONS_ENV", "test")
+
+	_, err := (&Client{APIKey: "ock-cli-abcdefgh", BaseURL: server.URL + APIPath}).List()
+	apiErr, ok := err.(*APIError)
+	if !ok || apiErr.Status != 401 {
+		t.Fatalf("expected 401 APIError, got %v", err)
+	}
+	for _, want := range []string{"Invalid plugin API Key", "ock-cli-", "test"} {
+		if !strings.Contains(apiErr.Message, want) {
+			t.Errorf("401 message missing %q: %s", want, apiErr.Message)
+		}
+	}
+}

--- a/internal/recording/asr.go
+++ b/internal/recording/asr.go
@@ -107,8 +107,12 @@ func LoadLocalAsrConfig(recordingsDir string) *AsrConfig {
 	return &cfg
 }
 
-// ResolveAsrConfig 优先使用 caller ASR，再回退本地配置；apiKey 为空时注入 account fallback。
-func ResolveAsrConfig(caller, local *AsrConfig, fallbackAPIKey string) *AsrConfig {
+// ResolveAsrConfig 优先使用 caller ASR，再回退本地配置；apiKey 为空时注入 account
+// fallback，endpoint 为空时按 host 注入默认端点。这里是 ASR 配置的唯一收敛点
+// （InitializeAsr 与 TriggerTranscription 都走它），所以主机只需在此落一次。
+// host 由调用方从 config.ResolveCloudHost 解析后传入，传空则回落到环境默认值；
+// 调用方显式传入的 api.endpoint 优先级最高，不被覆盖。
+func ResolveAsrConfig(caller, local *AsrConfig, fallbackAPIKey, host string) *AsrConfig {
 	chosen := caller
 	if chosen == nil {
 		chosen = local
@@ -123,6 +127,9 @@ func ResolveAsrConfig(caller, local *AsrConfig, fallbackAPIKey string) *AsrConfi
 	}
 	if strings.TrimSpace(api.APIKey) == "" {
 		api.APIKey = strings.TrimSpace(fallbackAPIKey)
+	}
+	if strings.TrimSpace(api.Endpoint) == "" {
+		api.Endpoint = submitEndpointForHost(host)
 	}
 	out.API = &api
 	return &out
@@ -540,11 +547,22 @@ func buildStatusError(data statusResponse, status string) string {
 	return "Model Proxy ASR " + status
 }
 
+// submitEndpointForHost 由 host 拼出提交端点；host 为空时回落到环境默认主机。
+func submitEndpointForHost(host string) string {
+	resolved := envhost.Normalize(host)
+	if resolved == "" {
+		resolved = envhost.Host()
+	}
+	return "https://" + resolved + "/api/model-proxy/long-recording/submit-task"
+}
+
+// resolveSubmitEndpoint 里的 envhost 回退只对没走 ResolveAsrConfig 的直接调用方生效
+// （正常链路上 endpoint 已在 ResolveAsrConfig 注入好）。resolveQueryBaseURL 同理。
 func resolveSubmitEndpoint(apiConfig *AsrAPIConfig) string {
 	if apiConfig != nil && strings.TrimSpace(apiConfig.Endpoint) != "" {
 		return strings.TrimSpace(apiConfig.Endpoint)
 	}
-	return "https://" + envhost.Host() + "/api/model-proxy/long-recording/submit-task"
+	return submitEndpointForHost("")
 }
 
 func resolveQueryBaseURL(apiConfig *AsrAPIConfig) string {

--- a/internal/recording/asr_state_test.go
+++ b/internal/recording/asr_state_test.go
@@ -2,6 +2,7 @@ package recording
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/YoooClaw/cli/internal/testutil"
@@ -86,28 +87,28 @@ func TestResolveAsrConfig(t *testing.T) {
 	// caller 优先
 	caller := &AsrConfig{Mode: "api", API: &AsrAPIConfig{APIKey: "caller-key"}}
 	local := &AsrConfig{Mode: "api", API: &AsrAPIConfig{APIKey: "local-key"}}
-	got := ResolveAsrConfig(caller, local, "fallback")
+	got := ResolveAsrConfig(caller, local, "fallback", "")
 	if got.API.APIKey != "caller-key" {
 		t.Errorf("caller key should win: %q", got.API.APIKey)
 	}
 	// caller nil -> local
-	got = ResolveAsrConfig(nil, local, "fallback")
+	got = ResolveAsrConfig(nil, local, "fallback", "")
 	if got.API.APIKey != "local-key" {
 		t.Errorf("local key should be used: %q", got.API.APIKey)
 	}
 	// 空 apiKey -> 注入 fallback
 	noKey := &AsrConfig{Mode: "api", API: &AsrAPIConfig{}}
-	got = ResolveAsrConfig(noKey, nil, "fallback-key")
+	got = ResolveAsrConfig(noKey, nil, "fallback-key", "")
 	if got.API.APIKey != "fallback-key" {
 		t.Errorf("fallback key should be injected: %q", got.API.APIKey)
 	}
 	// 非 api mode 原样返回
 	non := &AsrConfig{Mode: "yoooclaw"}
-	if ResolveAsrConfig(non, nil, "x").Mode != "yoooclaw" {
+	if ResolveAsrConfig(non, nil, "x", "").Mode != "yoooclaw" {
 		t.Error("non-api mode should pass through")
 	}
 	// 全 nil
-	if ResolveAsrConfig(nil, nil, "x") != nil {
+	if ResolveAsrConfig(nil, nil, "x", "") != nil {
 		t.Error("all nil -> nil")
 	}
 }
@@ -157,5 +158,33 @@ func TestParseTranscriptDocument(t *testing.T) {
 	// 非法 JSON
 	if _, ok := ParseTranscriptDocument([]byte(`{bad`)); ok {
 		t.Error("invalid json should fail")
+	}
+}
+
+func TestResolveAsrConfigInjectsEndpoint(t *testing.T) {
+	t.Setenv("PHONE_NOTIFICATIONS_ENV", "production")
+	t.Setenv("OPENCLAW_HOST_PRODUCTION", "")
+
+	// endpoint 空 → 按 host 注入（host 就是 config.ResolveCloudHost 的结果）。
+	cfg := &AsrConfig{Mode: "api", API: &AsrAPIConfig{APIKey: "k"}}
+	got := ResolveAsrConfig(cfg, nil, "", "openclaw-service-test.yoooclaw.com")
+	want := "https://openclaw-service-test.yoooclaw.com/api/model-proxy/long-recording/submit-task"
+	if got.API.Endpoint != want {
+		t.Errorf("endpoint = %q, want %q", got.API.Endpoint, want)
+	}
+	// host 空 → 回落环境默认。
+	got = ResolveAsrConfig(cfg, nil, "", "")
+	if !strings.Contains(got.API.Endpoint, "openclaw-service.yoooclaw.com") {
+		t.Errorf("empty host should fall back to env default: %q", got.API.Endpoint)
+	}
+	// 调用方显式传的 endpoint 优先级最高，不被 host 覆盖。
+	explicit := &AsrConfig{Mode: "api", API: &AsrAPIConfig{APIKey: "k", Endpoint: "https://caller.example.com/submit-task"}}
+	got = ResolveAsrConfig(explicit, nil, "", "openclaw-service-test.yoooclaw.com")
+	if got.API.Endpoint != "https://caller.example.com/submit-task" {
+		t.Errorf("caller endpoint should win: %q", got.API.Endpoint)
+	}
+	// 查询端点由 submit 端点派生，跟着一起走。
+	if base := resolveQueryBaseURL(got.API); base != "https://caller.example.com/query-task-result" {
+		t.Errorf("query base should derive from submit endpoint: %q", base)
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.6.1",
+  "version": "0.6.2-beta.0",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {


### PR DESCRIPTION
## 灯效/ASR 主机统一到 `config.cloud.host`

起因：用户反馈灯效 401。排查下来是同一把 api-key 在 Relay 握手（test 通、prod 403）和插件侧灯效 API（401 `Invalid plugin API Key`）之间的环境/类型错配，而 CLI 当时既看不出来、也没法只改一处修好。

### 主机来源统一

新增 `cloud.host`：**留空 = 跟随 `PHONE_NOTIFICATIONS_ENV`，填了就以它为准**。灯效 / 灯效规则 / ASR 共用它；`relay.url` 仍是内置默认形态时也从它派生，所以「隧道 test、灯效 prod」这种组合从机制上不再存在。用户显式改过的 `relay.url` 仍然覆盖，保留单独指向别处的能力。

```jsonc
{
  "cloud": { "host": "" },                    // 改这一处，四条链路一起走
  "relay": { "url": "wss://…/ws/plugin" }     // 非默认形态时仍单独覆盖
}
```

**没有照搬 `ResolveRelayURL` 的「值等于内置默认域名就重新解析」**——那条是给 `relay.url` 的历史包袱准备的（老 profile 里写死了具体域名，不重解析跟不上环境切换）。`cloud.host` 默认为空，套同一条规则会让 `config set cloud.host openclaw-service-test.yoooclaw.com` 被当成默认值忽略。理由写在代码注释里，防止以后被"顺手对齐"回去。

ASR 的主机在 `ResolveAsrConfig` 这个唯一收敛点注入（`InitializeAsr` 与 `TriggerTranscription` 都走它），调用方显式传的 `api.endpoint` 优先级不变，下游签名一个没动。

### 401 说人话

- `Invalid plugin API Key` 追加：当前环境 + 主机 + 遮罩 key + 下一步动作
- `auth set-api-key` / `add-api-key` / `status` 提示 `ock-cli-*` 这类非 plugin key —— 它能连上 Relay，但插件侧 API 一律 401，是最难自查的一种失败
- `daemon status` 增加 `cloud` 段（`env`/`host`/`custom`/`lightApiUrl`/`lightRuleApi`），此前只暴露了 relay 那一半

### 验证

全量 `go test ./...` 通过；新增 4 个测试覆盖 `ResolveCloudHost`（含"显式写成默认域名必须生效"）、relay 派生、ASR 注入与 endpoint 优先级。

真机端到端（配置已逐字节还原）：

```
# cloud.host 留空，env=production → 401
$ PHONE_NOTIFICATIONS_ENV=production yc lightrule list
{"error":{"code":"401","message":"Invalid plugin API Key。当前环境=production…"}}

# config set cloud.host openclaw-service-test.yoooclaw.com → env 说 prod，配置说 test，配置赢
$ PHONE_NOTIFICATIONS_ENV=production yc lightrule list
{"ok":true,"rules":[{"id":"lr_ae8ceff3…"}]}
```

### 兼容性

老 `config.json` 没有 `cloud` 键 → 零值空串 → 跟随 env，行为与改动前完全一致，不需要迁移。

🤖 Generated with [Claude Code](https://claude.com/claude-code)