### PR TITLE
cli-0.6.2-beta.1

### DIFF
--- a/internal/creds/store.go
+++ b/internal/creds/store.go
@@ -418,30 +418,23 @@ func SetDefaultAPIKey(label string) (ApiKeyResolution, error) {
 	return writeAPIKeys(entries)
 }
 
-const (
-	// PluginAPIKeyPrefix 是插件侧 API Key 的前缀。灯效 / ASR 等 X-Api-Key-Id 接口
-	// 只认这类 key。
-	PluginAPIKeyPrefix = "ock-"
-	// cliAPIKeyPrefix 是 CLI 签发的 key 前缀。它能通过 Relay 隧道握手，却没有登记进
-	// 插件侧 API Key 表——用户会看到"隧道连着但灯效 401"，所以单独给一句提示。
-	cliAPIKeyPrefix = "ock-cli-"
-)
+// PluginAPIKeyPrefix 是插件侧 API Key 的前缀。灯效 / ASR 等 X-Api-Key-Id 接口只认
+// 这类 key；ock-cli-* 也属于其中一种，同样有效——别再按子前缀细分（见下）。
+const PluginAPIKeyPrefix = "ock-"
 
 // APIKeyShapeWarning 在 api-key 形态明显不是插件侧 API Key 时返回一句排障提示，
 // 否则返回空串。前缀规则由云端掌握且会变，所以这里只提示、不拦截。
+//
+// 这里刻意不对 ock-cli-* 单独报警：0.6.2-beta.0 曾断言它"只能连 Relay、插件侧必
+// 401"，实测是错的（同一把 ock-cli- key 在测试环境的 light-rules 接口返回 200），
+// 那条提示只会把人往错误方向带。key 与环境不匹配才是 401 的实际成因，交给
+// PluginAPIKeyRejectedHint 的环境话术处理。
 func APIKeyShapeWarning(apiKey string) string {
 	key := strings.TrimSpace(apiKey)
-	switch {
-	case key == "":
-		return ""
-	case strings.HasPrefix(key, cliAPIKeyPrefix):
-		return cliAPIKeyPrefix + "* 是 CLI 签发的 key：Relay 隧道能连上，但灯效 / ASR 等插件侧 API 会返回 " +
-			"401 Invalid plugin API Key；请改用 App / 控制台里 " + PluginAPIKeyPrefix + " 开头的 plugin API Key"
-	case !strings.HasPrefix(key, PluginAPIKeyPrefix):
-		return "api-key 不是 " + PluginAPIKeyPrefix + " 开头，灯效 / ASR 等插件侧 API 可能返回 401 Invalid plugin API Key"
-	default:
+	if key == "" || strings.HasPrefix(key, PluginAPIKeyPrefix) {
 		return ""
 	}
+	return "api-key 不是 " + PluginAPIKeyPrefix + " 开头，灯效 / ASR 等插件侧 API 可能返回 401 Invalid plugin API Key"
 }
 
 // PluginAPIKeyRejectedHint 组装插件侧 API 回 401 Invalid plugin API Key 时追加的排障

--- a/internal/creds/store_test.go
+++ b/internal/creds/store_test.go
@@ -261,29 +261,31 @@ func TestAPIKeyShapeWarning(t *testing.T) {
 		"":                    false,
 		"ock-jyGDxxxxxxxx":    false,
 		"  ock-jyGDxxxxxxxx ": false,
-		"ock-cli-abcdefgh":    true, // relay 认、插件侧不认，是本函数存在的理由
-		"sk-something":        true,
+		// ock-cli-* 是有效的插件侧 key（实测测试环境 light-rules 返回 200），
+		// 不能因为子前缀就报警——0.6.2-beta.0 犯过这个错。
+		"ock-cli-abcdefgh": false,
+		"sk-something":     true,
 	}
 	for key, want := range cases {
 		if got := APIKeyShapeWarning(key) != ""; got != want {
 			t.Errorf("APIKeyShapeWarning(%q) warned=%v, want %v", key, got, want)
 		}
 	}
-	if w := APIKeyShapeWarning("ock-cli-abcdefgh"); !strings.Contains(w, "ock-cli-") {
-		t.Errorf("CLI key warning should name the prefix: %s", w)
-	}
 }
 
 func TestPluginAPIKeyRejectedHint(t *testing.T) {
 	t.Setenv("PHONE_NOTIFICATIONS_ENV", "test")
-	hint := PluginAPIKeyRejectedHint("ock-cli-abcdefgh")
-	for _, want := range []string{"test", "openclaw-service-test.yoooclaw.com", "ock-cli-", MaskSecret("ock-cli-abcdefgh")} {
-		if !strings.Contains(hint, want) {
-			t.Errorf("hint missing %q: %s", want, hint)
+	// 形态正常的 key（含 ock-cli-*）一律走"环境不匹配"这一支——这才是 401 的实际成因。
+	for _, key := range []string{"ock-cli-abcdefgh", "ock-jyGDxxxxxxxx"} {
+		hint := PluginAPIKeyRejectedHint(key)
+		for _, want := range []string{"test", "openclaw-service-test.yoooclaw.com", MaskSecret(key), "PHONE_NOTIFICATIONS_ENV"} {
+			if !strings.Contains(hint, want) {
+				t.Errorf("hint for %q missing %q: %s", key, want, hint)
+			}
 		}
 	}
-	// 形态正常的 key 走环境不匹配那一支。
-	if h := PluginAPIKeyRejectedHint("ock-jyGDxxxxxxxx"); !strings.Contains(h, "PHONE_NOTIFICATIONS_ENV") {
-		t.Errorf("well-formed key should hint at env mismatch: %s", h)
+	// 形态确实可疑的 key 才给形态提示。
+	if h := PluginAPIKeyRejectedHint("sk-something"); !strings.Contains(h, "不是 "+PluginAPIKeyPrefix+" 开头") {
+		t.Errorf("odd-shaped key should hint at shape: %s", h)
 	}
 }

--- a/internal/light/sender_test.go
+++ b/internal/light/sender_test.go
@@ -110,11 +110,11 @@ func TestDecorateSendError(t *testing.T) {
 	body := `{"code":"401","msg":"Invalid plugin API Key"}`
 
 	decorated := decorateSendError(body, "ock-cli-abcdefgh")
-	// 原始响应体保留，后面追加环境与 key 形态的排障指引。
+	// 原始响应体保留，后面追加环境 + 遮罩 key + 下一步的排障指引。
 	if !strings.HasPrefix(decorated, body) {
 		t.Errorf("raw body should be kept as prefix: %s", decorated)
 	}
-	for _, want := range []string{"ock-cli-", "production", "openclaw-service.yoooclaw.com"} {
+	for _, want := range []string{"production", "openclaw-service.yoooclaw.com", "PHONE_NOTIFICATIONS_ENV"} {
 		if !strings.Contains(decorated, want) {
 			t.Errorf("401 message missing %q: %s", want, decorated)
 		}

--- a/internal/lightrule/client_test.go
+++ b/internal/lightrule/client_test.go
@@ -274,7 +274,7 @@ func TestInvalidPluginKeyErrorGetsDecorated(t *testing.T) {
 	if !ok || apiErr.Status != 401 {
 		t.Fatalf("expected 401 APIError, got %v", err)
 	}
-	for _, want := range []string{"Invalid plugin API Key", "ock-cli-", "test"} {
+	for _, want := range []string{"Invalid plugin API Key", "PHONE_NOTIFICATIONS_ENV", "test"} {
 		if !strings.Contains(apiErr.Message, want) {
 			t.Errorf("401 message missing %q: %s", want, apiErr.Message)
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.6.2-beta.0",
+  "version": "0.6.2-beta.1",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {


### PR DESCRIPTION
## 撤掉对 `ock-cli-*` 的错误告警

0.6.2-beta.0 里加了一条断言：`ock-cli-*` 是"能连 Relay、但插件侧 API 必 401"的 key，并据此在 `auth set-api-key` / `add-api-key` / `status` 和 401 提示里建议用户换成 `ock-` 开头的 key。

**这个结论是错的。** 它当时只基于一条前缀相关性（手头能用的 key 是 `ock-` 开头、报障用户的是 `ock-cli-` 开头），没有拿真 key 验证过。实测同一把 `ock-cli-` key：

```
GET …-test.yoooclaw.com/api/plugin/notification-intelligence/light-rules  → 200 {"code":"000000",…}
GET …yoooclaw.com/api/plugin/notification-intelligence/light-rules        → 401 Invalid plugin API Key
```

`ock-cli-*` 是完全有效的插件侧 key，只是**分环境签发**。401 的实际成因一直是 key 与环境不匹配，跟子前缀无关。

那条提示出现的时机恰好是用户最困惑的时候，会把人往"换一把 key"的错误方向带——比没有提示更糟，所以删掉该分支。形态正常的 key（含 `ock-cli-*`）现在一律走 `PluginAPIKeyRejectedHint` 的环境话术；非 `ock-` 开头的泛化提醒保留。

修改后，用真实 key 在 `env=production` 下得到的提示：

```
[ock-***9UWt]
  shape   = ""
  401 hint= 。当前环境=production（主机 openclaw-service.yoooclaw.com），api-key=ock-***9UWt：
            api-key 分环境签发，请确认这把 key 属于 production，或用 PHONE_NOTIFICATIONS_ENV 切到 key 所属环境
```

配合 0.6.2-beta.0 的 `cloud.host`，这类问题的处置就是一条命令：

```bash
yc config set cloud.host openclaw-service-test.yoooclaw.com
```

测试同步更正：`TestAPIKeyShapeWarning` 现在断言 `ock-cli-*` **不**告警（并注明原因，防止回归），`TestPluginAPIKeyRejectedHint` 覆盖"形态正常 → 环境话术"与"形态可疑 → 形态话术"两支。

全量 `go test ./...` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)