### PR TITLE
cli-0.6.2-beta.2

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,18 +32,53 @@ func DefaultRelayURL() string {
 	return "wss://" + envhost.Host() + RelayPath
 }
 
-// ResolveCloudHost 返回灯效 / 灯效规则 / ASR 共用的云端主机，是这三条链路唯一的
-// 主机来源：留空则跟随 PHONE_NOTIFICATIONS_ENV（见 internal/envhost），填了就用填的。
-//
-// 这里不套用 ResolveRelayURL 那条"值等于内置默认域名就重新解析"的规则——那条规则是
-// 为 relay.url 的历史包袱准备的（老 profile 里已经写死了一个具体域名，不重解析就跟不上
-// 环境切换）。cloud.host 默认就是空串，再套同一条规则只会让
-// `config set cloud.host openclaw-service-test.yoooclaw.com` 被当成默认值忽略掉。
+// ResolveCloudHost 返回灯效 / 灯效规则 / ASR 共用的云端主机（优先级见 resolveCloudHost）。
 func ResolveCloudHost(cfg Config) string {
-	if host := envhost.Normalize(cfg.Cloud.Host); host != "" {
-		return host
+	host, _ := resolveCloudHost(cfg)
+	return host
+}
+
+// ResolveCloudHostSource 返回主机及其来源（env|cloud.host|relay.url|default），
+// 供 daemon status / doctor 说清楚"为什么打到这台机器"。
+func ResolveCloudHostSource(cfg Config) (string, string) {
+	return resolveCloudHost(cfg)
+}
+
+// resolveCloudHost 是主机来源的唯一决策点，灯效 / 灯效规则 / ASR / Relay 共用：
+//
+//  1. PHONE_NOTIFICATIONS_ENV / OPENCLAW_HOST_* 显式设过 —— 环境变量说了算
+//  2. cloud.host
+//  3. relay.url 里那个域名，且它是某个内置环境的默认域名
+//  4. 内置默认（production）
+//
+// 第 3 条是回应一个真实故障：profile 里 relay.url 白纸黑字写着 -test，解析出来却是生产。
+// 此前的规则是"relay.url 的 host 等于内置默认域名就当它还是默认值、按环境变量重解析"，
+// 于是配置文件在骗读它的人，隧道和灯效一起跑去生产（灯效因此 401 Invalid plugin API Key）。
+// 现在没设环境变量时就认这个域名；反过来第 1 条保证 `PHONE_NOTIFICATIONS_ENV=x yc ...`
+// 这种临时翻环境仍然压得住配置。
+//
+// 第 3 条只认内置默认域名：relay.url 被改成自定义地址时（自建隧道 / 代理），那台机器未必
+// 提供插件侧 API，把灯效 / ASR 一起指过去只会把 401 换成 404，所以自定义值只对隧道生效。
+func resolveCloudHost(cfg Config) (string, string) {
+	if envhost.Explicit() {
+		return envhost.Host(), "env"
 	}
-	return envhost.Host()
+	if host := envhost.Normalize(cfg.Cloud.Host); host != "" {
+		return host, "cloud.host"
+	}
+	if host := relayHost(cfg.Relay.URL); envhost.IsDefaultHost(host) {
+		return host, "relay.url"
+	}
+	return envhost.Host(), "default"
+}
+
+// relayHost 从 Relay URL 中取出纯主机名（去 scheme 与路径）。
+func relayHost(url string) string {
+	host := envhost.Normalize(url)
+	if i := strings.Index(host, "/"); i >= 0 {
+		host = host[:i]
+	}
+	return host
 }
 
 // ResolveRelayURL 返回 daemon 实际应连接的 Relay 地址。
@@ -52,16 +87,10 @@ func ResolveCloudHost(cfg Config) string {
 // 401"；用户显式改过的自定义 URL 始终保留，仍可单独把隧道指向别处。
 func ResolveRelayURL(cfg Config) string {
 	url := cfg.Relay.URL
-	if url == "" || envhost.IsDefaultHost(stripRelayURL(url)) {
+	if url == "" || envhost.IsDefaultHost(relayHost(url)) {
 		return "wss://" + ResolveCloudHost(cfg) + RelayPath
 	}
 	return url
-}
-
-// stripRelayURL 从 Relay URL 中提取主机部分（去掉 scheme 与已知路径）供默认值判定。
-func stripRelayURL(url string) string {
-	host := envhost.Normalize(url)
-	return strings.TrimSuffix(host, RelayPath)
 }
 
 // SecretRefPaths 是 config.json 里需要遮罩展示的敏感引用字段（点号路径）。

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -206,17 +206,24 @@ func TestMask(t *testing.T) {
 }
 
 func TestResolveCloudHost(t *testing.T) {
+	// 环境变量显式设过 → 第 1 优先级，压过配置里的一切。
 	t.Setenv("PHONE_NOTIFICATIONS_ENV", "test")
 	t.Setenv("OPENCLAW_HOST_TEST", "")
-
-	// 未配置 → 跟随 PHONE_NOTIFICATIONS_ENV。
-	if got := ResolveCloudHost(Config{}); got != "openclaw-service-test.yoooclaw.com" {
-		t.Errorf("empty host should follow env, got %q", got)
+	overridden := Config{Cloud: CloudSection{Host: "my-cloud.example.com"}}
+	if got, src := ResolveCloudHostSource(overridden); got != "openclaw-service-test.yoooclaw.com" || src != "env" {
+		t.Errorf("explicit env should win over cloud.host, got %q from %q", got, src)
 	}
-	// 自定义主机 → 原样保留，环境变量不再有话语权。
-	custom := Config{Cloud: CloudSection{Host: "my-cloud.example.com"}}
-	if got := ResolveCloudHost(custom); got != "my-cloud.example.com" {
-		t.Errorf("custom host should win over env, got %q", got)
+
+	// 以下都在"环境变量没设"的前提下。
+	t.Setenv("PHONE_NOTIFICATIONS_ENV", "")
+	t.Setenv("OPENCLAW_HOST_PRODUCTION", "")
+
+	if got, src := ResolveCloudHostSource(Config{}); got != "openclaw-service.yoooclaw.com" || src != "default" {
+		t.Errorf("bare config should fall back to built-in default, got %q from %q", got, src)
+	}
+	// cloud.host → 第 2 优先级。
+	if got, src := ResolveCloudHostSource(overridden); got != "my-cloud.example.com" || src != "cloud.host" {
+		t.Errorf("cloud.host should win, got %q from %q", got, src)
 	}
 	// scheme / 尾斜杠会被归一化掉。
 	messy := Config{Cloud: CloudSection{Host: "https://my-cloud.example.com/"}}
@@ -230,8 +237,39 @@ func TestResolveCloudHost(t *testing.T) {
 	}
 }
 
+// 复现并锁住那个真实故障：relay.url 写着 -test、cloud.host 没设、环境变量没设，
+// 此前灯效与隧道双双跑去生产（灯效 401）。现在配置说什么就是什么。
+func TestResolveCloudHostFollowsRelayURL(t *testing.T) {
+	t.Setenv("PHONE_NOTIFICATIONS_ENV", "")
+	t.Setenv("OPENCLAW_HOST_PRODUCTION", "")
+
+	cfg := Config{Relay: RelaySection{URL: "wss://openclaw-service-test.yoooclaw.com" + RelayPath}}
+	if got, src := ResolveCloudHostSource(cfg); got != "openclaw-service-test.yoooclaw.com" || src != "relay.url" {
+		t.Errorf("cloud host should follow relay.url, got %q from %q", got, src)
+	}
+	if got := ResolveRelayURL(cfg); got != "wss://openclaw-service-test.yoooclaw.com"+RelayPath {
+		t.Errorf("relay should stay on the host its own config names, got %q", got)
+	}
+
+	// cloud.host 更高优先级，能压过 relay.url。
+	cfg.Cloud.Host = "openclaw-service-dev.yoooclaw.com"
+	if got, src := ResolveCloudHostSource(cfg); got != "openclaw-service-dev.yoooclaw.com" || src != "cloud.host" {
+		t.Errorf("cloud.host should outrank relay.url, got %q from %q", got, src)
+	}
+
+	// 自定义 relay 主机不外溢到灯效 / ASR：那台机器未必提供插件侧 API。
+	custom := Config{Relay: RelaySection{URL: "wss://my-relay.example.com/custom/path"}}
+	if got, src := ResolveCloudHostSource(custom); got != "openclaw-service.yoooclaw.com" || src != "default" {
+		t.Errorf("custom relay host must not leak into cloud host, got %q from %q", got, src)
+	}
+	// 但隧道自己仍然用它。
+	if got := ResolveRelayURL(custom); got != "wss://my-relay.example.com/custom/path" {
+		t.Errorf("custom relay URL should be preserved, got %q", got)
+	}
+}
+
 func TestResolveRelayURLFollowsCloudHost(t *testing.T) {
-	t.Setenv("PHONE_NOTIFICATIONS_ENV", "production")
+	t.Setenv("PHONE_NOTIFICATIONS_ENV", "")
 	t.Setenv("OPENCLAW_HOST_PRODUCTION", "")
 
 	// relay.url 还是内置默认形态 → 跟着 cloud.host 走，隧道与灯效/ASR 不会分家。

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -522,10 +522,11 @@ func (s *server) handleStatus(w http.ResponseWriter) {
 // cloudStatusPayload 暴露灯效 / 灯效规则 / ASR 实际打到的主机。这三条链路曾经只认
 // 环境变量、状态里也看不见，出问题时只能看到 relay 是绿的——所以在这里一并吐出来。
 func (s *server) cloudStatusPayload() map[string]any {
-	host := config.ResolveCloudHost(s.cfg)
+	host, source := config.ResolveCloudHostSource(s.cfg)
 	return map[string]any{
-		"env": envhost.Name(), "host": host,
-		"custom":       envhost.Normalize(s.cfg.Cloud.Host) != "",
+		// source 说明这台主机是谁定的（env|cloud.host|relay.url|default）——
+		// 光给 host 不够，排查时最费时间的恰恰是"配置写着 A 为什么打到 B"。
+		"env": envhost.Name(), "host": host, "source": source,
 		"lightApiUrl":  light.LightAPIURL(host),
 		"lightRuleApi": lightrule.APIURL(host),
 	}

--- a/internal/envhost/envhost.go
+++ b/internal/envhost/envhost.go
@@ -43,22 +43,38 @@ func Name() string {
 	}
 }
 
+// hostOverride 返回当前环境对应的 OPENCLAW_HOST_* 覆盖（已归一化，可能为空）。
+func hostOverride() string {
+	switch Name() {
+	case "development":
+		return Normalize(os.Getenv("OPENCLAW_HOST_DEVELOPMENT"))
+	case "test":
+		return Normalize(os.Getenv("OPENCLAW_HOST_TEST"))
+	default:
+		return Normalize(os.Getenv("OPENCLAW_HOST_PRODUCTION"))
+	}
+}
+
+// Explicit 报告调用方是否用环境变量显式指定过环境/主机：PHONE_NOTIFICATIONS_ENV
+// 被设成已知环境名，或当前环境的 OPENCLAW_HOST_* 覆盖非空。
+//
+// Name() 对「没设」和「显式设成 production」都返回 production，二者不可区分；
+// 而主机解析要让显式环境变量压过配置文件，就必须区分这两种情况——没设时配置说了算，
+// 设了才轮到环境变量。见 config.ResolveCloudHost。
+func Explicit() bool {
+	switch strings.TrimSpace(os.Getenv("PHONE_NOTIFICATIONS_ENV")) {
+	case "development", "test", "production":
+		return true
+	}
+	return hostOverride() != ""
+}
+
 // Host 返回当前环境主机：先看 OPENCLAW_HOST_* 覆盖，否则取默认域名。
 func Host() string {
-	env := Name()
-	var override string
-	switch env {
-	case "development":
-		override = os.Getenv("OPENCLAW_HOST_DEVELOPMENT")
-	case "test":
-		override = os.Getenv("OPENCLAW_HOST_TEST")
-	case "production":
-		override = os.Getenv("OPENCLAW_HOST_PRODUCTION")
-	}
-	if h := Normalize(override); h != "" {
+	if h := hostOverride(); h != "" {
 		return h
 	}
-	return defaultHosts[env]
+	return defaultHosts[Name()]
 }
 
 // IsDefaultHost 报告 host（归一化后）是否为某个环境的默认域名。

--- a/internal/envhost/envhost_test.go
+++ b/internal/envhost/envhost_test.go
@@ -56,3 +56,33 @@ func TestIsDefaultHost(t *testing.T) {
 		t.Error("empty host should not be default")
 	}
 }
+
+func TestExplicit(t *testing.T) {
+	// 没设 → 不算显式（Name() 此时也返回 production，二者必须能区分开）。
+	t.Setenv("PHONE_NOTIFICATIONS_ENV", "")
+	t.Setenv("OPENCLAW_HOST_PRODUCTION", "")
+	if Explicit() {
+		t.Error("unset env should not count as explicit")
+	}
+	if Name() != "production" {
+		t.Error("unset env still resolves to production for Name()")
+	}
+	// 显式设成 production → 算显式，尽管值与缺省相同。
+	t.Setenv("PHONE_NOTIFICATIONS_ENV", "production")
+	if !Explicit() {
+		t.Error("explicit production should count as explicit")
+	}
+	// 无效值不算。
+	t.Setenv("PHONE_NOTIFICATIONS_ENV", "bogus")
+	if Explicit() {
+		t.Error("unknown env name should not count as explicit")
+	}
+	// 只设主机覆盖也算显式。
+	t.Setenv("OPENCLAW_HOST_PRODUCTION", "my.example.com")
+	if !Explicit() {
+		t.Error("host override alone should count as explicit")
+	}
+	if Host() != "my.example.com" {
+		t.Errorf("host override should win: %q", Host())
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.6.2-beta.1",
+  "version": "0.6.2-beta.2",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {


### PR DESCRIPTION
## 主机解析改为 `env > cloud.host > relay.url > 内置默认`

修一个会直接导致灯效 401 的**配置失真**。

### 问题

profile 里 `relay.url` 白纸黑字写着 `openclaw-service-test`，解析出来却是生产：

```
config.relay.url   = wss://openclaw-service-test.yoooclaw.com/message/messages/ws/plugin
config.cloud.host  = ""
→ ResolveRelayURL  = wss://openclaw-service.yoooclaw.com/...    ← 隧道
→ 灯效/ASR 主机     = openclaw-service.yoooclaw.com             ← 401 从这来
```

根因是旧规则：*relay.url 的 host 等于内置默认域名 → 当它还是默认值、按 `PHONE_NOTIFICATIONS_ENV` 重解析*。本意是让老 profile 跟得上环境切换，代价是配置文件在骗读它的人。

值得强调的是**这不是"light 没跟着 relay 走"**——relay 自己也没跟着那个值走。报障用户的 daemon 能连上 test，不是因为 config 写着 test，而是因为启动 daemon 那个进程里恰好有 `PHONE_NOTIFICATIONS_ENV=test`（见 daemon.log 里连上 test 的那次）。

### 新优先级

1. `PHONE_NOTIFICATIONS_ENV` / `OPENCLAW_HOST_*` **显式**设过 —— 环境变量说了算
2. `cloud.host`
3. `relay.url` 里的域名，且它是某个内置环境的默认域名
4. 内置默认（production）

第 1 条保住 `PHONE_NOTIFICATIONS_ENV=x yc ...` 临时翻环境的工作流；第 3 条让配置文件不再说谎——**报障用户零配置变更即可恢复**：

```
→ ResolveRelayURL  = wss://openclaw-service-test.yoooclaw.com/...
→ 灯效/ASR 主机     = openclaw-service-test.yoooclaw.com  (source=relay.url)
```

第 3 条**只认内置默认域名**：`relay.url` 指向自建隧道 / 代理时，那台机器未必提供插件侧 API，把灯效 / ASR 一并指过去只会把 401 换成 404。自定义 relay 地址仍然只对隧道生效。

### 配套

- `envhost.Explicit()`：`Name()` 对"没设"和"显式 production"都返回 production，要让显式环境变量压过配置就必须区分这两者
- `daemon status` 的 `cloud` 段增加 `source`（`env|cloud.host|relay.url|default`）——排查时最费时间的恰恰是"配置写着 A 为什么打到 B"，现在直接告诉你是谁定的

### 测试

新增 `TestResolveCloudHostFollowsRelayURL`（复现并锁住该故障，含"自定义 relay 主机不外溢到灯效"）、`TestExplicit`；`TestResolveCloudHost` 改为逐条验证四级优先级并断言 `source`。全量 `go test ./...` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)