### PR TITLE
cli-0.6.2

### DIFF
--- a/internal/lightrule/client.go
+++ b/internal/lightrule/client.go
@@ -204,7 +204,7 @@ func (c *Client) resolveIdentifier(identifier string) (id, name string, err erro
 func (c *Client) request(method, path string, body map[string]any) (map[string]any, error) {
 	apiKey := strings.TrimSpace(c.APIKey)
 	if apiKey == "" {
-		return nil, &APIError{Code: "AUTH_REQUIRED", Message: "API Key 未配置，请先 `yoooclaw auth login`"}
+		return nil, &APIError{Code: "AUTH_REQUIRED", Message: "API Key 未配置，请先 `yoooclaw auth set-api-key -`"}
 	}
 
 	base := c.BaseURL

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.6.2-beta.2",
+  "version": "0.6.2",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {

--- a/skills/yoooclaw-lightrule-create/SKILL.md
+++ b/skills/yoooclaw-lightrule-create/SKILL.md
@@ -8,7 +8,8 @@ description: 用 yoooclaw CLI 创建/管理"通知→灯效"规则。当用户�
 灯效规则是**持久**的：保存在云端 Notification Intelligence Service，通知到达后由云端评估是否命中，命中则播放灯效。
 和"立即放一次灯效测试"不同（那是 `yoooclaw light send`）。
 
-> 不需要 daemon。规则 CRUD 直接打云端 API（X-Api-Key-Id 鉴权），需要已 `yoooclaw auth login`。
+> 不需要 daemon。规则 CRUD 直接打云端 API（X-Api-Key-Id 鉴权），需要先配好 api-key（`yoooclaw auth set-api-key -` 从 stdin 读）。
+> 云端主机按 `env > cloud.host > relay.url > 内置默认` 解析，与灯效 / ASR 共用同一套环境。
 
 ## 何时激活
 
@@ -59,6 +60,7 @@ yoooclaw lightrule update <id> --segments '[{"mode":"strobe","duration_s":2,"bri
 
 ## 错误处理
 
-- `AUTH_REQUIRED`：先 `yoooclaw auth login` 配置 API Key。
+- `AUTH_REQUIRED`：api-key 未配置，先 `yoooclaw auth set-api-key -`（从 stdin 读取，不要把 key 写进命令行）；`yoooclaw auth status --format json` 可确认当前凭据。
 - `NOT_FOUND`：id/name 不存在，先 `lightrule list` 确认。
 - `VALIDATION_FAILED`：segments 不符合 light protocol，`error.message` 内有逐字段错误。
+- 规则创建成功但灯不亮：先 `yoooclaw light +blink` 验证硬件链路，再 `yoooclaw doctor --format json` 看本地环境；灯效走云端下发，规则命中与硬件连通是两件事。

--- a/skills/yoooclaw-notification-query/SKILL.md
+++ b/skills/yoooclaw-notification-query/SKILL.md
@@ -44,6 +44,22 @@ description: |
 
      基于 `run` 返回的 `markdown`（或 `resultFile`）总结。
 
+     `run` 用的是**抽取式**摘要（不过模型），够快够省。若用户明确要求更高质量的分片总结，
+     可以改走由你自己逐片总结的循环（每片只进上下文一次，仍然不会爆）：
+
+     ```bash
+     yoooclaw notification summary-job next <id> --format json
+     # → {done:false, chunk:{id,...}, notifications:[...], commitCommand:"..."}
+     # 你读 notifications 写出该片摘要，然后：
+     yoooclaw notification summary-job commit <id> --chunk-id <chunk_id> --summary-file <path>
+     # 重复 next/commit 直到 next 返回 done=true，再：
+     yoooclaw notification summary-job result <id> --format json
+     ```
+
+     `summary-job status <id> --format json` 看 `progress`（totalChunks/doneChunks/remainingChunks）；
+     `summary-job cancel <id>` 放弃任务。走这条路时**必须**每片 commit 完再取下一片，
+     不要把多片 `notifications` 攒在上下文里。默认仍用 `run`。
+
 5. **输出精简**：先一段整体概览，再按 App / 主要发送人分组，每组最多 3-5 条要点；不逐条罗列、不粘贴原始通知数组。`sample` / `topSenders` 只是代表性样例，不要当成完整列表复述。用户追问具体细节时，再 `yoooclaw notification search --sender "某某" --limit 20` 小范围补查。
 
 ## 大批量总结硬性规则
@@ -77,10 +93,15 @@ yoooclaw notification search --app 微信 --format ndjson
 yoooclaw notification search --sender 张三 --limit 20 --format json
 yoooclaw notification search --keyword 开会 --format ndjson
 
+# 按来源设备（clientLabel）过滤；all 为全部。search / summary / summary-job create / stats 都支持
+yoooclaw notification search --client work --limit 20 --format json
+
 # 快捷命令
 yoooclaw notification +today --format ndjson      # 今日全部
 yoooclaw notification +recent --format ndjson      # 最近一小时
 ```
+
+`notification +unread` 目前是预留命令，没有真实的已读/未读数据，不要用它回答「未读通知」，按「最近通知」处理。
 
 - 用户提到期望条数（「最近 20 条 / 约 30 条」）时，必须把该数字传给 `--limit`，不要用默认值。
 - `--app` 支持中英文别名：`微信/wechat`、`飞书/feishu/lark`、`钉钉/dingtalk`、`企业微信/wecom` 等；不要把应用名臆测成不确定的包名。

--- a/skills/yoooclaw-recording-entity-extraction/SKILL.md
+++ b/skills/yoooclaw-recording-entity-extraction/SKILL.md
@@ -63,6 +63,7 @@ yoooclaw recording list --status transcribed --format json
 等待用户输入序号（支持 `1,3` 或 `1-3` 或 `all`）。
 
 若用户表示找不到某条录音，说明该录音可能仍在转录中，告知用户稍后再试。
+用户追问「到底卡在哪一步」时，用 `yoooclaw recording events --since 24h --format json`（或 `--id <recording_id>`）看状态事件流：`synced` 及之前是音频还在传，`transcribing` 才是正在转写，`transcribe_failed` 为转写失败。
 
 ## 3. 读取文件内容
 

--- a/skills/yoooclaw-recording-interview/SKILL.md
+++ b/skills/yoooclaw-recording-interview/SKILL.md
@@ -43,6 +43,7 @@ yoooclaw recording list --status transcribed --format json
   `1. [名称] ([时间], [时长])`
   等待用户输入序号（支持 `1,3` 或 `1-3` 或 `all`）。
 - 若用户表示找不到某条录音，说明该录音可能仍在转录中，告知用户稍后再试。
+- 用户追问「到底卡在哪一步」时，用 `yoooclaw recording events --since 24h --format json`（或 `--id <recording_id>`）看状态事件流：`synced` 及之前是音频还在传，`transcribing` 才是正在转写，`transcribe_failed` 为转写失败。
 
 锁定录音后，对每条选中的录音执行：
 

--- a/skills/yoooclaw-recording-meeting-minutes/SKILL.md
+++ b/skills/yoooclaw-recording-meeting-minutes/SKILL.md
@@ -43,6 +43,7 @@ yoooclaw recording list --status transcribed --format json
   `1. [名称] ([时间], [时长])`
   等待用户输入序号（支持 `1,3` 或 `1-3` 或 `all`）。
 - 若用户表示找不到某条录音，说明该录音可能仍在转录中，告知用户稍后再试。
+- 用户追问「到底卡在哪一步」时，用 `yoooclaw recording events --since 24h --format json`（或 `--id <recording_id>`）看状态事件流：`synced` 及之前是音频还在传，`transcribing` 才是正在转写，`transcribe_failed` 为转写失败。
 
 锁定录音后，对每条选中的录音执行：
 

--- a/skills/yoooclaw-recording-mindmap/SKILL.md
+++ b/skills/yoooclaw-recording-mindmap/SKILL.md
@@ -72,6 +72,7 @@ yoooclaw recording list --status transcribed --format json
   `1. [名称] ([时间], [时长])`
   等待用户输入序号（支持 `1,3` 或 `1-3` 或 `all`）。
 - 若用户表示找不到某条录音，说明该录音可能仍在转录中，告知用户稍后再试。
+- 用户追问「到底卡在哪一步」时，用 `yoooclaw recording events --since 24h --format json`（或 `--id <recording_id>`）看状态事件流：`synced` 及之前是音频还在传，`transcribing` 才是正在转写，`transcribe_failed` 为转写失败。
 
 锁定录音后，对每条选中的录音执行：
 

--- a/skills/yoooclaw-recording-query/SKILL.md
+++ b/skills/yoooclaw-recording-query/SKILL.md
@@ -30,6 +30,7 @@ yoooclaw recording storage-path --format json
 ```bash
 yoooclaw recording list --format json
 # 只看已转写的：yoooclaw recording list --status transcribed --format json
+# 多设备时按 clientLabel 收窄：yoooclaw recording list --client work --format json（all 为全部）
 ```
 
 返回示例：
@@ -54,6 +55,12 @@ yoooclaw recording list --format json
   ]
 }
 ```
+
+`status` 取值是一条完整的传输 → 转写流水线，不是只有 `transcribed`：
+
+`receiving` → `pending_oss_upload` → `uploading_oss` → `oss_uploaded` → `synced` → `transcribing` → `transcribed`，
+另有两个失败态 `receiving_failed`（传输失败）与 `transcribe_failed`（转写失败）。
+向用户解释「为什么还没有转写」时按实际状态说：`synced` 及之前是**音频还在传**，`transcribing` 才是**正在转写**。
 
 处理规则：
 
@@ -135,10 +142,31 @@ AI 总结文件按需读取：
 
 若读取的是 `summaryFile` 总结文件，说明来源是总结文件；若没有总结文件但读取了转写文件，则基于转写生成简短摘要，并说明"未找到已有总结文件，以下根据转写整理"。
 
-## 6. 边界处理
+## 6. 排查「转写迟迟不出来」
 
-- **未转写**：`status != "transcribed"` 或 `has_transcript != true` 时，告知状态并建议稍后再试。
-- **转写失败**：展示 `error` 字段中的失败原因。
+用户追问进度、或某条录音长期停在非 `transcribed` 状态时，查状态事件流（JSONL，纯读磁盘）：
+
+```bash
+yoooclaw recording events --since 1h --format json          # 最近 1 小时全部状态流转
+yoooclaw recording events --id <recording_id> --format json # 只看某条录音
+yoooclaw recording events --since 24h --limit 500 --format json
+```
+
+`--since` 接受 `10m` / `1h` / `24h` / `7d` 形式；返回 `{ok, path, total, events}`。
+根据事件里最后一次流转判断卡在哪一环，再据此回复用户（还在传 / 正在转写 / 已失败及原因）。
+
+若**所有**录音都从未进入 `transcribing`，多半是 ASR 没配置，提示用户运行：
+
+```bash
+yoooclaw recording setup-asr          # 交互式向导（api 或 local 模式）
+```
+
+本 Skill 只查询，不要替用户执行 `setup-asr`（它会写配置），告知命令即可。
+
+## 7. 边界处理
+
+- **未转写**：`status != "transcribed"` 或 `has_transcript != true` 时，按第 2 节的状态语义告知当前进展并建议稍后再试；需要细节时用 `recording events` 佐证。
+- **转写失败**：`status = "transcribe_failed"`，展示 `error` 字段中的失败原因。
 - **文件不存在**：说明索引存在但本地文件缺失，可能被删除或尚未同步完成。
 - **大量录音**：若用户请求"全部"且数量很多，先展示数量并询问是否继续读取全文；列表查询不需要确认。
 - **只读约束**：本 skill 只查询和读取文件，不写入、不删除、不重命名录音。

--- a/skills/yoooclaw-recording-translation/SKILL.md
+++ b/skills/yoooclaw-recording-translation/SKILL.md
@@ -63,6 +63,7 @@ yoooclaw recording list --status transcribed --format json
 等待用户输入序号（支持 `1,3` 或 `1-3` 或 `all`）。
 
 若用户表示找不到某条录音，说明该录音可能仍在转录中，告知用户稍后再试。
+用户追问「到底卡在哪一步」时，用 `yoooclaw recording events --since 24h --format json`（或 `--id <recording_id>`）看状态事件流：`synced` 及之前是音频还在传，`transcribing` 才是正在转写，`transcribe_failed` 为转写失败。
 
 ## 3. 读取文件内容
 

--- a/skills/yoooclaw-tunnel-debug/SKILL.md
+++ b/skills/yoooclaw-tunnel-debug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: yoooclaw-tunnel-debug
-description: 用 yoooclaw CLI 排查手机端推送链路是否通。当用户说“手机推送收不到”“通知没同步过来”“检查一下隧道/连接”“daemon 还活着吗”“手机连不上”时激活。组合使用 auth status / daemon status / tunnel status / tunnel +test / gateway test / daemon logs 定位本地配置、daemon、本地 ingest 鉴权与 Relay WebSocket 状态。多数命令需要 daemon 在运行（🟡）。
+description: 用 yoooclaw CLI 排查手机端推送链路是否通。当用户说“手机推送收不到”“通知没同步过来”“检查一下隧道/连接”“daemon 还活着吗”“手机连不上”时激活。组合使用 doctor / auth status / daemon status / tunnel status / tunnel +test / gateway test / daemon logs 定位本地环境、daemon、本地 ingest 鉴权与 Relay WebSocket 状态。多数命令需要 daemon 在运行（🟡）。
 ---
 
 # yoooclaw Relay / 接收链路排查
@@ -10,6 +10,11 @@ description: 用 yoooclaw CLI 排查手机端推送链路是否通。当用户�
 ## 排查顺序
 
 ```bash
+# 0) 本地环境一把梭：运行时/目录/keychain/config/daemon
+yoooclaw doctor --format json
+# 每项 status 为 ok|warn|fail|skip；--fix 可自动修可修的（目录权限等）。
+# doctor 不做网络探测，网络问题继续往下走。
+
 # 1) 本地凭据是否存在；不调 daemon
 yoooclaw auth status --format json
 
@@ -35,12 +40,35 @@ yoooclaw log +errors --format json
 
 ## 判读
 
-- `auth status` 中 api-key 不存在：先用 `yoooclaw auth set-api-key -` 从 stdin 设置，再启动或 reload daemon。
+- `auth status` 中 api-key 不存在：先用 `yoooclaw auth set-api-key -` 从 stdin 设置，再 `yoooclaw daemon reload`（daemon 已在跑时优先 reload：重读凭据并增量刷新隧道，不中断已有连接；没在跑才 `daemon start`）。
 - `daemon status` 报 `YOOOCLAW_DAEMON_NOT_RUNNING`：运行 `yoooclaw daemon start`。
 - `tunnel status` 的 `mode=relay` 且 `connected=true`：daemon 当前已连上 Relay WebSocket。
 - `tunnel status` 的 `mode=relay` 但 `connected=false`：结合 `lastDisconnectReason`、`reconnectAttempt` 和 daemon 日志排查 api-key、网络与 Relay 服务。
-- `tunnel status` 的 `mode=standalone-http`：当前没有 Relay 隧道；按返回的 `note` 检查 `relay.enabled` 和 api-key。只有明确采用直连 fallback 时才检查防火墙、反代和手机端地址。
-- `tunnel +test` 或 `gateway test` 失败：先排查本地 gateway token。运行 `yoooclaw auth status`，必要时 `yoooclaw auth token-rotate`；daemon 已运行时随后执行 `yoooclaw daemon restart`。
+- `tunnel status` 的 `stale=true`：隧道实际拨的 `currentUrl` 与配置解析出的 `expectedUrl` 不一致，说明正在跟随环境切换重连——等一轮重连即可，不是故障。
+- `tunnel status` 的 `mode=standalone-http`：当前没有 Relay 隧道，**先读返回的 `note` 再下结论**，它区分了四种成因：
+  - `Relay 未启用，走直连 HTTP` → `relay.enabled` 为 false。
+  - `Relay 已启用但当前 CredentialSet 没有可用 api-key` → 补 api-key 后 `daemon reload`。
+  - `ingress=proxied：隧道由宿主代理，daemon 仅收 ingest` → 预期行为，隧道归宿主管，别在这儿查。
+  - `ingress=direct：隧道关闭，仅接受直接 POST` → 预期行为，走直连。
+  只有明确采用直连 fallback 时才检查防火墙、反代和手机端地址。
+- `tunnel +test` 或 `gateway test` 失败：先排查本地 gateway token。运行 `yoooclaw auth status`，必要时 `yoooclaw auth token-rotate`；daemon 已运行时随后执行 `yoooclaw daemon restart`（token 轮换必须 restart，reload 不够）。
+
+## 环境 / 主机对不上
+
+`tunnel status` 返回的 `env` 是当前环境名（development|test|production）。隧道、灯效、ASR 共用同一个云端主机，
+解析优先级为 **环境变量 > `cloud.host` > `relay.url` > 内置默认**：
+
+```bash
+yoooclaw config show --format json     # 看 cloud.host / relay.url 实际值（敏感字段已遮罩）
+yoooclaw config set cloud.host openclaw-service.yoooclaw.com
+yoooclaw config unset cloud.host       # 清掉后跟随 PHONE_NOTIFICATIONS_ENV
+```
+
+环境变量：`PHONE_NOTIFICATIONS_ENV`（development|test|production）与对应的
+`OPENCLAW_HOST_DEVELOPMENT` / `OPENCLAW_HOST_TEST` / `OPENCLAW_HOST_PRODUCTION` 覆盖。
+
+若用户报「隧道连着但灯效 / 转写报 401」，八成是手机端账号与本地 api-key 指向了不同环境：
+比对 `tunnel status` 的 `env` 与手机 App 所在环境，再改 `cloud.host` 或环境变量对齐，最后 `yoooclaw daemon reload`。
 
 ## 多 clientLabel
 


### PR DESCRIPTION
0.6.2 正式版（从 0.6.2-beta.2 转正），发布由 tag `cli-v0.6.2` 触发，本 PR 仅为同步主干。

## 本次带入主干的改动

**skills 对齐当前 CLI**（a0678bd）— 内置 SKILL.md 自 `db921c1` 起没跟过 CLI，Agent 照着读会给出过时或不存在的命令。

- 修失效命令：`yoooclaw auth login` 根本不存在，`lightrule-create` 引用了两处；同一句错误提示还硬编码在 `internal/lightrule/client.go` 的 `AUTH_REQUIRED` 分支里，一并改成 `auth set-api-key -`
- 补上 CLI 已有而 skills 只字未提的能力：`recording events`（录音卡在哪一环）、`recording setup-asr`、`doctor`、`daemon reload`、`--client` 过滤、`summary-job` 的 `next`/`commit`/`result` 循环
- 跟进 f63b303 的主机解析改动：tunnel-debug 新增「环境/主机对不上」一节，含 `env`/`stale`/`currentUrl`/`expectedUrl` 判读；`mode=standalone-http` 的 `note` 四种成因拆开处理
- 录音 `status` 从「transcribed / 非 transcribed」二分改为完整流水线语义

**版本号** — package.json `0.6.2-beta.2` → `0.6.2`

## 验证

- skills 里 44 处 `yoooclaw` 命令引用逐一对着二进制跑 `help` 校验，全部存在
- `go build ./...`、`go vet ./...`、`go test ./...` 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)