### PR TITLE
cli-0.6.3

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,7 +18,7 @@ const ConfigVersion = 1
 
 // 默认值常量。
 const (
-	DefaultPort         = 18789
+	DefaultPort         = 18365
 	DefaultBind         = "127.0.0.1"
 	DefaultImageMaxByte = 20 * 1024 * 1024
 )

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {


### PR DESCRIPTION
## What changed

- Bumped `@yoooclaw/cli` to `0.6.3`.
- Changed the daemon default port from `18789` to `18365` to avoid colliding with OpenClaw default port.

## Validation

- `go test ./...`
- `go vet ./...`
- `git diff --check`

## Release

- Pushed annotated tag `cli-v0.6.3`, which triggers the CLI release workflow.