### PR TITLE
fix(update): 移除 update self 响应中的 hint

### DIFF
--- a/internal/cli/cmd_update.go
+++ b/internal/cli/cmd_update.go
@@ -121,15 +121,13 @@ func updateSelf(_ *clictx.Context, cmd *cobra.Command, _ []string) (any, error) 
 
 	updateAvailable := compareSemver(latest, version.Version) > 0
 	var command any
-	hint := "已是最新版本"
 	if updateAvailable {
 		command = upgradeCommand(tag, latest)
-		hint = "发现新版本；CLI 不做自动更新，请手动执行上面的命令"
 	}
 	return map[string]any{
 		"ok": true, "package": updatePackage, "channel": tag, "dist": version.Dist(),
 		"current": version.Version, "latest": latest, "updateAvailable": updateAvailable,
-		"command": command, "hint": hint,
+		"command": command,
 	}, nil
 }
 

--- a/internal/cli/cmd_update_test.go
+++ b/internal/cli/cmd_update_test.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+type updateRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f updateRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestUpdateSelfOmitsHint(t *testing.T) {
+	originalClient := http.DefaultClient
+	http.DefaultClient = &http.Client{Transport: updateRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"dist-tags":{"latest":"9999.0.0"}}`)),
+		}, nil
+	})}
+	t.Cleanup(func() { http.DefaultClient = originalClient })
+
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("beta", false, "")
+
+	result, err := updateSelf(nil, cmd, nil)
+	if err != nil {
+		t.Fatalf("updateSelf() error = %v", err)
+	}
+	payload, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("updateSelf() result type = %T, want map[string]any", result)
+	}
+	if _, exists := payload["hint"]; exists {
+		t.Fatalf("updateSelf() returned unexpected hint: %v", payload["hint"])
+	}
+}


### PR DESCRIPTION
## 背景

yoooclaw update self --format json 的成功响应会返回 hint，其中包含手动更新提示。该字段不是判断升级状态所必需，且可能干扰调用方对结构化检测结果的处理，甚至导致后续更新流程失败。

## 修改内容

- 移除 update self 成功响应中的 hint 字段
- 保留 command、current、latest、updateAvailable 等结构化字段
- 新增回归测试，确保成功响应不再包含 hint

## 基线

- 已拉取远端最新 master
- 本次提交基于 master 提交 2d61b06

## 验证

- go test ./internal/cli
- go test ./...