### PR TITLE
feat(openharmony): 支持 OpenHarmony HNP 原生二进制解析与构建

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Test
         run: go test -race -coverprofile=coverage.out ./...
 
+      - name: Test npm launcher
+        run: node --test npm/cli/test/*.test.js
+
       - name: Coverage summary
         run: go tool cover -func=coverage.out | tail -1
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 # 构建产物
 dist-native
 dist-npm
+dist-openharmony
 *.tgz
 
 # Go（本地散落的二进制 + go mod vendor 目录）

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Service-oriented command tree, a three-tier command system, Agent-Native.
 
 Two distribution channels with **identical functionality** — pick whichever fits. The npm package is now a very thin Node launcher; the actual work is done by the native Go binary installed via optionalDependencies. The direct-install channel skips Node entirely and downloads the same Go binary.
 
-**Platform support**: the npm channel supports `darwin/linux` `x64+arm64` and `win32-x64` (the launcher needs Node ≥ 18); `install.sh` / GitHub Release direct install supports `darwin/linux` `x64+arm64`. On Windows, credentials are stored in plaintext at `~/.yoooclaw/credentials.json` (no OS keychain hardening — `yoooclaw doctor` will warn about this), and the daemon shuts down gracefully over HTTP.
+**Platform support**: the npm channel supports `darwin/linux` `x64+arm64` and `win32-x64` (the launcher needs Node ≥ 18); `install.sh` / GitHub Release direct install supports `darwin/linux` `x64+arm64`. OpenHarmony/HarmonyOS PC requires the host application to install the native CLI as an HNP embedded in its signed HAP; an app sandbox cannot execute an ELF downloaded only through `npm i -g`. See "OpenHarmony / HarmonyOS PC" below. On Windows, credentials are stored in plaintext at `~/.yoooclaw/credentials.json` (no OS keychain hardening — `yoooclaw doctor` will warn about this), and the daemon shuts down gracefully over HTTP.
 
 ### Channel A — npm (thin Node launcher + platform Go binary)
 
@@ -75,6 +75,34 @@ curl -fsSL https://raw.githubusercontent.com/YoooClaw/cli/master/scripts/install
 Direct-install supported platforms: `darwin-arm64` / `darwin-x64` / `linux-x64` / `linux-arm64`. The Windows Go binary currently ships only via the npm platform subpackage. You can also download manually from [GitHub Releases](https://github.com/YoooClaw/cli/releases?q=cli-v) (verify against the `checksums.txt` in the same release).
 
 > `yoooclaw update self` gives you the right upgrade command for how you installed (npm → `npm update -g`, binary → install.sh).
+
+### OpenHarmony / HarmonyOS PC
+
+The application sandbox rejects native ELF files downloaded into app data by npm. Changing file mode, copying the Linux ARM64 optional package, or mapping `process.platform` to `linux` does not bypass that policy. The supported delivery path is an OpenHarmony Native Package (HNP) embedded and signed into the WorkBuddy/OpenClaw host HAP.
+
+Build the `openharmony/arm64` binary with the OpenHarmony-SIG Go toolchain and pack it with the SDK's `hnpcli`:
+
+```bash
+OHOS_GO=/path/to/ohos_golang_go/bin/go \
+OHOS_HNPCLI=/path/to/openharmony-sdk/toolchains/hnpcli \
+scripts/build-openharmony.sh
+```
+
+The result is `dist-openharmony/hnp/arm64-v8a/yoooclaw.hnp`. Copy `dist-openharmony/hnp` into the HAP project root and declare it under the module in `entry/src/main/module.json5`:
+
+```json5
+"hnpPackages": [
+  {
+    "package": "yoooclaw.hnp",
+    "type": "private",
+    "independentSign": false
+  }
+]
+```
+
+The npm launcher discovers the versioned private HNP path automatically. A host can also set `YOOOCLAW_NATIVE_BIN` to the installed `bin/yoooclaw` path. Merely downloading the `.hnp` into a user directory does not install it; it must be packaged and signed with the HAP.
+
+For the complete WorkBuddy host integration procedure, see [docs/workbuddy-openharmony.md](docs/workbuddy-openharmony.md).
 
 ### Quickstart (Human Users)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -45,7 +45,7 @@ Service-oriented 命令树、三层命令体系、Agent-Native。
 
 两种分发渠道，二者**功能一致**，按需选择。npm 包现在是极薄 Node launcher，真正执行的是 optionalDependencies 安装的 Go 原生二进制；直接安装渠道则跳过 Node，直接下载同一套 Go binary。
 
-**平台支持**：npm 渠道支持 `darwin/linux` 的 `x64+arm64` 与 `win32-x64`（launcher 需 Node ≥ 18）；`install.sh` / GitHub Release 直装支持 `darwin/linux` 的 `x64+arm64`。Windows 上凭据以明文落 `~/.yoooclaw/credentials.json`（无系统 keychain 加固，`yoooclaw doctor` 会提示），daemon 停止经 HTTP 优雅退出。
+**平台支持**：npm 渠道支持 `darwin/linux` 的 `x64+arm64` 与 `win32-x64`（launcher 需 Node ≥ 18）；`install.sh` / GitHub Release 直装支持 `darwin/linux` 的 `x64+arm64`。OpenHarmony/鸿蒙 PC 需由宿主应用通过 HNP 随 HAP 安装，不能在应用沙箱中仅靠 `npm i -g` 落盘并执行原生 ELF，详见下方“OpenHarmony / 鸿蒙 PC”。Windows 上凭据以明文落 `~/.yoooclaw/credentials.json`（无系统 keychain 加固，`yoooclaw doctor` 会提示），daemon 停止经 HTTP 优雅退出。
 
 ### 渠道 A — npm（薄 Node launcher + 平台 Go 二进制）
 
@@ -75,6 +75,34 @@ curl -fsSL https://raw.githubusercontent.com/YoooClaw/cli/master/scripts/install
 直装支持平台：`darwin-arm64` / `darwin-x64` / `linux-x64` / `linux-arm64`。Windows Go binary 目前随 npm 平台子包发布。也可从 [GitHub Releases](https://github.com/YoooClaw/cli/releases?q=cli-v) 手动下载（同 release 内 `checksums.txt` 校验）。
 
 > `yoooclaw update self` 会按当前安装来源给出对应升级命令（npm 走 `npm update -g`，二进制走 install.sh）。
+
+### OpenHarmony / 鸿蒙 PC
+
+鸿蒙应用沙箱会拒绝执行 npm 在应用数据目录中新下载的原生 ELF，`chmod`、手工复制 Linux ARM64 子包或把 `process.platform` 映射成 `linux` 都不能绕过该限制。受支持的交付方式是把 Native CLI 打成 HNP，并由 WorkBuddy/OpenClaw 等宿主将 HNP 嵌入、签入 HAP。
+
+仓库提供 OpenHarmony-SIG Go 工具链的构建入口（目前支持 `openharmony/arm64`）：
+
+```bash
+OHOS_GO=/path/to/ohos_golang_go/bin/go \
+OHOS_HNPCLI=/path/to/openharmony-sdk/toolchains/hnpcli \
+scripts/build-openharmony.sh
+```
+
+产物位于 `dist-openharmony/hnp/arm64-v8a/yoooclaw.hnp`。将 `dist-openharmony/hnp` 复制到 HAP 工程根目录，并在 `entry/src/main/module.json5` 的 `module` 下声明：
+
+```json5
+"hnpPackages": [
+  {
+    "package": "yoooclaw.hnp",
+    "type": "private",
+    "independentSign": false
+  }
+]
+```
+
+npm launcher 会按当前 CLI 版本查找私有 HNP 路径，也可由宿主设置 `YOOOCLAW_NATIVE_BIN` 指向安装后的 `bin/yoooclaw`。HNP 必须随 HAP 打包和签名；把 `.hnp` 下载到用户目录本身仍不会完成安装。
+
+面向 WorkBuddy 宿主开发者的完整接入步骤见 [docs/workbuddy-openharmony.md](docs/workbuddy-openharmony.md)。
 
 ### 快速开始（人类用户）
 

--- a/docs/workbuddy-openharmony.md
+++ b/docs/workbuddy-openharmony.md
@@ -1,0 +1,123 @@
+# WorkBuddy 接入 Yoooclaw CLI（鸿蒙 PC）
+
+本文面向 WorkBuddy/HarmonyOS 宿主应用开发者。最终用户不能在已经安装的 WorkBuddy
+应用沙箱里直接安装 `.hnp`；必须把 HNP 嵌入 WorkBuddy 的 HAP，重新构建并签名发布。
+
+## 交付物
+
+- `yoooclaw.hnp`：OpenHarmony ARM64 原生包。
+- `launcher/yc.js`：能够发现私有/公共 HNP 的 Node launcher。
+- `SHA256SUMS`：HNP 包校验值。
+
+不要解压或通过 `npm i -g` 安装这个 HNP。npm 只能安装 JavaScript launcher，无法给
+运行时下载的 ELF 添加鸿蒙所需的执行标签。
+
+## 一、把 HNP 放入 WorkBuddy HAP 工程
+
+在 WorkBuddy 的 HAP 工程根目录创建以下结构：
+
+```text
+<workbuddy-hap-root>/
+├── entry/
+│   └── src/main/module.json5
+└── hnp/
+    └── arm64-v8a/
+        └── yoooclaw.hnp
+```
+
+也就是把交付的 `yoooclaw.hnp` 复制到：
+
+```text
+<workbuddy-hap-root>/hnp/arm64-v8a/yoooclaw.hnp
+```
+
+## 二、声明私有 HNP
+
+编辑 `entry/src/main/module.json5`，在现有的 `module` 对象中加入
+`hnpPackages`。不要新建第二个 `module` 对象。
+
+```json5
+{
+  "module": {
+    // WorkBuddy 原有配置保持不变
+    "hnpPackages": [
+      {
+        "package": "yoooclaw.hnp",
+        "type": "private",
+        "independentSign": false
+      }
+    ]
+  }
+}
+```
+
+推荐使用 `private`：CLI 只供 WorkBuddy 使用，可避免与其他 HAP 安装的同名公共 HNP
+冲突。`independentSign: false` 表示随 WorkBuddy HAP 一起签名。
+
+## 三、接入 Node launcher
+
+在构建 WorkBuddy HAP 前，用交付包内的 `launcher/yc.js` 替换/覆盖 WorkBuddy 源码中
+随应用打包的 `@yoooclaw/cli/bin/yc.js`。这是构建期操作，不要在已经安装的 WorkBuddy
+应用数据目录里手改文件。
+
+新版 launcher 会依次查找：
+
+1. 环境变量 `YOOOCLAW_NATIVE_BIN`；
+2. 私有 HNP 的版本路径；
+3. 公共 HNP 的 `yoooclaw-native` 链接。
+
+如果 WorkBuddy 不方便更新 npm launcher，可在启动 CLI 前显式设置：
+
+```bash
+export YOOOCLAW_NATIVE_BIN="${HNP_PRIVATE_HOME:-/data/app}/yoooclaw.org/yoooclaw_0.6.3/bin/yoooclaw"
+```
+
+也可以让 WorkBuddy 的 Node 进程直接设置同名环境变量，再调用 launcher。不要把 HNP
+中的二进制复制到 `node_modules`；复制后的文件会重新变成不可执行的应用数据文件。
+
+## 四、构建并签名 WorkBuddy HAP
+
+使用 WorkBuddy 原有的 DevEco/OpenHarmony 构建流程生成 HAP，并使用 WorkBuddy 的
+正式签名证书签名。HNP 必须出现在最终 HAP 中；仅把 `.hnp` 下载到设备用户目录不会
+触发安装。
+
+安装新版 WorkBuddy HAP 后，系统会随 HAP 安装私有 HNP。卸载 WorkBuddy 时，该私有
+HNP 也会一起卸载。
+
+## 五、设备验证
+
+在新版 WorkBuddy 的终端/Node 执行环境中运行：
+
+```bash
+export YOOOCLAW_NATIVE_BIN="${HNP_PRIVATE_HOME:-/data/app}/yoooclaw.org/yoooclaw_0.6.3/bin/yoooclaw"
+
+"$YOOOCLAW_NATIVE_BIN" --version
+"$YOOOCLAW_NATIVE_BIN" doctor
+```
+
+第一条应输出 `0.6.3`，并且不再出现 `spawnSync ... EACCES`。然后验证 launcher：
+
+```bash
+yoooclaw --version
+yc --version
+```
+
+最后验证需要子进程和本地监听的 daemon：
+
+```bash
+yoooclaw daemon start
+yoooclaw daemon status
+yoooclaw daemon stop
+```
+
+如果直接执行 HNP 路径成功、但 `yoooclaw --version` 失败，说明 Native 包已经正确安装，
+需要更新 WorkBuddy 内的 `yc.js` launcher 或为它注入 `YOOOCLAW_NATIVE_BIN`。
+
+## 六、不要采用的方案
+
+- 不要把 `process.platform === "openharmony"` 简单映射为 `linux`。
+- 不要手工下载 `@yoooclaw/cli-linux-arm64` 到全局 `node_modules`。
+- 不要依赖 `chmod`、`chcon` 或 `setfattr` 修改应用数据目录里的 ELF。
+- 不要把 `.hnp` 当普通压缩包解压到用户目录。
+
+这些方法都不能让运行时下载的二进制获得 HAP/HNP 安装阶段赋予的执行权限。

--- a/npm/cli/README.md
+++ b/npm/cli/README.md
@@ -16,6 +16,13 @@ yc --version
 
 ## 支持平台
 
+`darwin/linux` 的 `x64+arm64` 与 `win32-x64` 可直接通过 npm 安装。
+
+OpenHarmony/鸿蒙 PC 的应用沙箱不允许执行 npm 运行时下载到应用数据目录的原生
+ELF，因此不能只靠 `npm i -g` 安装。宿主应用需要把仓库生成的 `yoooclaw.hnp`
+嵌入并签入 HAP；launcher 会自动查找该 HNP 二进制，也可以通过
+`YOOOCLAW_NATIVE_BIN` 显式指定安装后的路径。
+
 | OS | Arch |
 |----|------|
 | macOS (darwin) | arm64, x64 |

--- a/npm/cli/bin/yc.js
+++ b/npm/cli/bin/yc.js
@@ -9,10 +9,65 @@
 
 const { spawnSync } = require("node:child_process");
 const fs = require("node:fs");
+const path = require("node:path");
 
-function resolveBinary() {
-  const platform = process.platform; // darwin | linux | win32
-  const arch = process.arch; // arm64 | x64
+function packageVersion() {
+  try {
+    return require("../package.json").version;
+  } catch {
+    return "";
+  }
+}
+
+function isFile(candidate) {
+  if (!candidate) return false;
+  try {
+    return fs.statSync(candidate).isFile();
+  } catch {
+    return false;
+  }
+}
+
+// OpenHarmony does not allow an application sandbox to execute an ELF that was
+// downloaded into app data by npm. Native commands must be installed as an HNP
+// inside the host HAP. Resolve that preinstalled binary instead of pretending the
+// Linux optionalDependency can be executed from node_modules.
+function resolveOpenHarmonyBinary(
+  env = process.env,
+  version = packageVersion(),
+  fileExists = isFile,
+) {
+  const candidates = [env.YOOOCLAW_NATIVE_BIN];
+
+  if (version) {
+    const relative = path.join(
+      "yoooclaw.org",
+      `yoooclaw_${version}`,
+      "bin",
+      "yoooclaw",
+    );
+    candidates.push(
+      path.join(env.HNP_PRIVATE_HOME || "/data/app", relative),
+      path.join(env.HNP_PUBLIC_HOME || "/data/service/hnp", relative),
+    );
+  }
+
+  // HNP links live under the private/public bin directories. Keep a unique name
+  // so it cannot resolve back to this npm launcher through a global symlink.
+  candidates.push(
+    path.join(env.HNP_PRIVATE_HOME || "/data/app", "bin", "yoooclaw-native"),
+    "/data/app/bin/yoooclaw-native",
+    path.join(env.HNP_PUBLIC_HOME || "/data/service/hnp", "bin", "yoooclaw-native"),
+    "/data/service/hnp/bin/yoooclaw-native",
+  );
+
+  return candidates.find(fileExists) || null;
+}
+
+function resolveBinary(platform = process.platform, arch = process.arch) {
+  if (platform === "openharmony") {
+    return resolveOpenHarmonyBinary();
+  }
   const pkg = `@yoooclaw/cli-${platform}-${arch}`;
   const binName = platform === "win32" ? "yc.exe" : "yc";
   try {
@@ -22,31 +77,60 @@ function resolveBinary() {
   }
 }
 
-const bin = resolveBinary();
-if (!bin) {
-  const target = `${process.platform}-${process.arch}`;
-  process.stderr.write(
-    `@yoooclaw/cli: 找不到当前平台的二进制（${target}）。\n` +
-      "可能原因：\n" +
-      "  - 该平台暂不支持（当前支持 darwin/linux 的 x64+arm64、win32 的 x64）\n" +
-      "  - 安装时跳过了 optionalDependencies（--no-optional / --omit=optional）\n" +
-      "请尝试重新安装： npm i -g @yoooclaw/cli\n",
-  );
-  process.exit(1);
-}
-
-if (process.platform !== "win32") {
-  try {
-    fs.chmodSync(bin, 0o755);
-  } catch {
-    // Best effort only: spawnSync will surface the real error if execution still fails.
+function missingBinaryMessage(platform = process.platform, arch = process.arch) {
+  const target = `${platform}-${arch}`;
+  if (platform === "openharmony") {
+    return (
+      `@yoooclaw/cli: 找不到宿主预装的 OpenHarmony HNP 二进制（${target}）。\n` +
+      "鸿蒙应用沙箱禁止执行 npm 下载到应用数据目录的原生 ELF；chmod 或重新安装无效。\n" +
+      "请让 WorkBuddy/OpenClaw 宿主把 yoooclaw.hnp 嵌入并签入 HAP，\n" +
+      "或用 YOOOCLAW_NATIVE_BIN 指向已经由 HNP 安装的 yoooclaw。\n"
+    );
   }
+  return (
+    `@yoooclaw/cli: 找不到当前平台的二进制（${target}）。\n` +
+    "可能原因：\n" +
+    "  - 该平台暂不支持（当前支持 darwin/linux 的 x64+arm64、win32 的 x64）\n" +
+    "  - 安装时跳过了 optionalDependencies（--no-optional / --omit=optional）\n" +
+    "请尝试重新安装： npm i -g @yoooclaw/cli\n"
+  );
 }
 
-const result = spawnSync(bin, process.argv.slice(2), { stdio: "inherit" });
-if (result.error) {
-  process.stderr.write(`@yoooclaw/cli: 启动二进制失败：${result.error.message}\n`);
-  process.exit(1);
+function main() {
+  const bin = resolveBinary();
+  if (!bin) {
+    process.stderr.write(missingBinaryMessage());
+    return 1;
+  }
+
+  if (process.platform !== "win32") {
+    try {
+      fs.chmodSync(bin, 0o755);
+    } catch {
+      // Best effort only: spawnSync will surface the real error if execution still fails.
+    }
+  }
+
+  const result = spawnSync(bin, process.argv.slice(2), { stdio: "inherit" });
+  if (result.error) {
+    process.stderr.write(`@yoooclaw/cli: 启动二进制失败：${result.error.message}\n`);
+    if (process.platform === "openharmony" && result.error.code === "EACCES") {
+      process.stderr.write(
+        "该文件不是由 HNP/HAP 安装的可执行文件；请勿从 node_modules 手工复制。\n",
+      );
+    }
+    return 1;
+  }
+  // 子进程被信号杀死时 status 为 null；统一以非零码退出。
+  return typeof result.status === "number" ? result.status : 1;
 }
-// 子进程被信号杀死时 status 为 null；统一以非零码退出。
-process.exit(typeof result.status === "number" ? result.status : 1);
+
+if (require.main === module) {
+  process.exit(main());
+}
+
+module.exports = {
+  missingBinaryMessage,
+  resolveBinary,
+  resolveOpenHarmonyBinary,
+};

--- a/npm/cli/test/yc.test.js
+++ b/npm/cli/test/yc.test.js
@@ -1,0 +1,52 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  missingBinaryMessage,
+  resolveOpenHarmonyBinary,
+} = require("../bin/yc.js");
+
+test("OpenHarmony prefers an explicitly configured HNP binary", () => {
+  const expected = "/data/app/custom/yoooclaw";
+  assert.equal(
+    resolveOpenHarmonyBinary(
+      { YOOOCLAW_NATIVE_BIN: expected },
+      "0.6.3",
+      (candidate) => candidate === expected,
+    ),
+    expected,
+  );
+});
+
+test("OpenHarmony resolves a private HNP installed for this version", () => {
+  const expected = "/private/yoooclaw.org/yoooclaw_0.6.3/bin/yoooclaw";
+  assert.equal(
+    resolveOpenHarmonyBinary(
+      { HNP_PRIVATE_HOME: "/private" },
+      "0.6.3",
+      (candidate) => candidate === expected,
+    ),
+    expected,
+  );
+});
+
+test("OpenHarmony resolves the private HNP bin link", () => {
+  const expected = "/private/bin/yoooclaw-native";
+  assert.equal(
+    resolveOpenHarmonyBinary(
+      { HNP_PRIVATE_HOME: "/private" },
+      "0.6.3",
+      (candidate) => candidate === expected,
+    ),
+    expected,
+  );
+});
+
+test("OpenHarmony error explains the HNP requirement", () => {
+  const message = missingBinaryMessage("openharmony", "arm64");
+  assert.match(message, /HNP/);
+  assert.match(message, /YOOOCLAW_NATIVE_BIN/);
+  assert.doesNotMatch(message, /请尝试重新安装/);
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "build": "scripts/build-go.sh",
     "build:current": "scripts/build-go.sh --current",
-    "test": "go test ./...",
+    "build:openharmony": "scripts/build-openharmony.sh",
+    "test": "go test ./... && node --test npm/cli/test/*.test.js",
+    "test:launcher": "node --test npm/cli/test/*.test.js",
     "vet": "go vet ./...",
     "release:patch": "./release.sh patch",
     "release:minor": "./release.sh minor"

--- a/scripts/build-openharmony.sh
+++ b/scripts/build-openharmony.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Build the OpenHarmony/arm64 CLI and optionally pack it as an HNP.
+#
+# Requirements:
+#   OHOS_GO      Go executable from OpenHarmony-SIG/ohos_golang_go
+#   OHOS_GOROOT  Optional toolchain root when OHOS_GO is not under <root>/bin
+#   OHOS_HNPCLI  Optional hnpcli from the OpenHarmony SDK. When omitted, the
+#                script emits the same ZIP-based HNP layout with the host zip.
+#
+# Usage:
+#   OHOS_GO=/path/to/ohos-go OHOS_HNPCLI=/path/to/hnpcli scripts/build-openharmony.sh
+#   OHOS_GO=/path/to/ohos-go scripts/build-openharmony.sh --stage-only 0.6.3
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+VERSION=""
+STAGE_ONLY=0
+for arg in "$@"; do
+  case "$arg" in
+    --stage-only) STAGE_ONLY=1 ;;
+    *) VERSION="$arg" ;;
+  esac
+done
+[ -n "$VERSION" ] || VERSION="$(node -p "require('./package.json').version")"
+
+OHOS_GO_BIN="${OHOS_GO:-}"
+if [ -z "$OHOS_GO_BIN" ] || [ ! -x "$OHOS_GO_BIN" ]; then
+  echo "error: 请用 OHOS_GO 指定 ohos_golang_go 的可执行文件" >&2
+  exit 1
+fi
+OHOS_GOROOT_DIR="${OHOS_GOROOT:-$(cd "$(dirname "$OHOS_GO_BIN")/.." && pwd)}"
+if [ ! -f "$OHOS_GOROOT_DIR/src/internal/goos/zgoos_openharmony.go" ]; then
+  echo "error: $OHOS_GOROOT_DIR 不是 ohos_golang_go GOROOT（可用 OHOS_GOROOT 显式指定）" >&2
+  exit 1
+fi
+if ! GOROOT="$OHOS_GOROOT_DIR" GOTOOLCHAIN=local \
+  "$OHOS_GO_BIN" tool dist list | grep -qx 'openharmony/arm64'; then
+  echo "error: $OHOS_GO_BIN 不支持 openharmony/arm64" >&2
+  exit 1
+fi
+
+OHOS_GO_VERSION="$(GOROOT="$OHOS_GOROOT_DIR" GOTOOLCHAIN=local \
+  "$OHOS_GO_BIN" env GOVERSION)"
+MODULE_GO_VERSION="${OHOS_GO_VERSION#go}"
+MODULE_GO_VERSION="${MODULE_GO_VERSION%%.*}.${MODULE_GO_VERSION#*.}"
+MODULE_GO_VERSION="${MODULE_GO_VERSION%.*}.0"
+
+BUILD_TMP="$(mktemp -d "${TMPDIR:-/tmp}/yoooclaw-openharmony.XXXXXX")"
+trap 'rm -rf "$BUILD_TMP"' EXIT
+MODFILE="$BUILD_TMP/yoooclaw.mod"
+cp go.mod "$MODFILE"
+cp go.sum "$BUILD_TMP/yoooclaw.sum"
+awk -v version="$MODULE_GO_VERSION" \
+  '$1 == "go" { $0 = "go " version } { print }' \
+  "$MODFILE" > "$BUILD_TMP/yoooclaw.mod.next"
+mv "$BUILD_TMP/yoooclaw.mod.next" "$MODFILE"
+
+OUT="dist-openharmony"
+STAGE="$OUT/stage/yoooclaw"
+rm -rf "$OUT"
+mkdir -p "$STAGE/bin"
+
+echo "==> go build openharmony/arm64 -> $STAGE/bin/yoooclaw"
+GOROOT="$OHOS_GOROOT_DIR" GOTOOLCHAIN=local \
+  GOOS=openharmony GOARCH=arm64 CGO_ENABLED=0 \
+  "$OHOS_GO_BIN" build \
+  -modfile="$MODFILE" \
+  -trimpath \
+  -ldflags "-s -w -X github.com/YoooClaw/cli/internal/version.Version=$VERSION" \
+  -o "$STAGE/bin/yoooclaw" \
+  ./cmd/yc
+chmod 755 "$STAGE/bin/yoooclaw"
+node scripts/gen-hnp.mjs "$STAGE" "$VERSION"
+
+if [ "$STAGE_ONLY" -eq 1 ]; then
+  echo "完成 OpenHarmony HNP staging: $STAGE"
+  exit 0
+fi
+
+HNP_OUT="$OUT/hnp/arm64-v8a"
+mkdir -p "$HNP_OUT"
+HNPCLI_BIN="${OHOS_HNPCLI:-}"
+if [ -z "$HNPCLI_BIN" ]; then
+  HNPCLI_BIN="$(command -v hnpcli || true)"
+fi
+if [ -n "$HNPCLI_BIN" ] && [ -x "$HNPCLI_BIN" ]; then
+  "$HNPCLI_BIN" pack -i "$STAGE" -o "$HNP_OUT"
+else
+  if ! command -v zip >/dev/null 2>&1; then
+    echo "error: 找不到 hnpcli 或 zip；也可加 --stage-only 只生成 staging" >&2
+    exit 1
+  fi
+  echo "warn: 未找到 hnpcli，按官方 HNP ZIP 布局打包" >&2
+  (
+    cd "$OUT/stage"
+    COPYFILE_DISABLE=1 zip -q -9 -r "$ROOT/$HNP_OUT/yoooclaw.hnp" yoooclaw
+  )
+fi
+test -f "$HNP_OUT/yoooclaw.hnp"
+echo "完成 OpenHarmony HNP: $HNP_OUT/yoooclaw.hnp"

--- a/scripts/gen-hnp.mjs
+++ b/scripts/gen-hnp.mjs
@@ -1,0 +1,31 @@
+// Generate the metadata consumed by OpenHarmony's hnpcli.
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const [dir, version] = process.argv.slice(2);
+if (!dir || !version) {
+  console.error("用法: node scripts/gen-hnp.mjs <stage-dir> <version>");
+  process.exit(1);
+}
+
+mkdirSync(dir, { recursive: true });
+writeFileSync(
+  join(dir, "hnp.json"),
+  JSON.stringify(
+    {
+      type: "hnp-config",
+      name: "yoooclaw",
+      version,
+      install: {
+        links: [
+          {
+            source: "/bin/yoooclaw",
+            target: "yoooclaw-native",
+          },
+        ],
+      },
+    },
+    null,
+    2,
+  ) + "\n",
+);


### PR DESCRIPTION
- yc.js 启动器在 OpenHarmony 沙箱下解析预装 HNP 原生二进制，而非执行 npm 下载的 ELF
- 新增 scripts/build-openharmony.sh 与 scripts/gen-hnp.mjs 构建产物
- 新增 npm/cli/test 启动器单测（node --test）
- CI 与文档同步更新