### PR TITLE
cli-0.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {


### PR DESCRIPTION
## What changed

- Bump `@yoooclaw/cli` from 0.6.3 to 0.6.4.
- Publish the release from tag `cli-v0.6.4`.

## Why

Prepare the 0.6.4 patch release and sync the released version back to `master`.

## Impact

The stable CLI package, native binaries, GitHub Release, and OSS artifacts will be published as version 0.6.4 by the release workflow.

## Validation

- `go vet ./...`
- `go test -race -coverprofile=coverage.out ./...`
- Coverage gate: 63.9% (minimum 55%)
