### PR TITLE
cli-0.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {


### PR DESCRIPTION
## 变更

- 将 `@yoooclaw/cli` 版本从 0.7.2 更新到 0.7.3。

## 原因与影响

- 同步已通过 `cli-v0.7.3` 标签发布的版本号回主干。
- 不包含运行时代码变更。

## 验证

- `npm test`
- `npm run vet`
- Release CLI workflow 已成功完成 npm、GitHub Release、OSS 与通知步骤。
