### PR TITLE
cli-0.8.0-beta.1

### DIFF
--- a/internal/recording/asr.go
+++ b/internal/recording/asr.go
@@ -229,7 +229,7 @@ func RunTranscriptionWorkflow(storage *Storage, entry Entry, cfg AsrConfig, logg
 	logger.Info("[asr] 转写 JSON 已写入: " + filepath.Join(storage.TranscriptDataDir(), transcriptDataFilename))
 
 	markdown := BuildTranscriptMarkdown(result, entry.Metadata.Markers, entry.Metadata.Name, entry.Metadata.DurationSec, entry.Metadata.CreatedAt)
-	transcriptFilename := TranscriptFilename(entry.ID, title)
+	transcriptFilename := TranscriptFilename(entry.ID, title, entry.Metadata.CreatedAt)
 	if err := fsutil.WriteAtomic(filepath.Join(storage.TranscriptsDir(), transcriptFilename), []byte(markdown), fsutil.ConfigFileMode); err != nil {
 		return WorkflowResult{OK: false, Error: err.Error()}
 	}
@@ -237,7 +237,7 @@ func RunTranscriptionWorkflow(storage *Storage, entry Entry, cfg AsrConfig, logg
 
 	summaryFilename := ""
 	if strings.TrimSpace(summary) != "" {
-		summaryFilename = SummaryFilename(entry.ID)
+		summaryFilename = SummaryFilename(entry.ID, title, entry.Metadata.CreatedAt)
 		if err := fsutil.WriteAtomic(filepath.Join(storage.SummariesDir(), summaryFilename), []byte(strings.TrimSpace(summary)), fsutil.ConfigFileMode); err != nil {
 			return WorkflowResult{OK: false, Error: err.Error()}
 		}

--- a/internal/recording/result_writer.go
+++ b/internal/recording/result_writer.go
@@ -323,7 +323,7 @@ func writeResultTranscript(recordingID string, meta Metadata, t ResultTranscript
 	if strings.TrimSpace(markdown) == "" {
 		markdown = buildResultTranscriptMarkdown(meta, title, text, segments)
 	}
-	mdName := TranscriptFilename(recordingID, title)
+	mdName := TranscriptFilename(recordingID, title, meta.CreatedAt)
 	if err := fsutil.WriteAtomic(filepath.Join(storage.TranscriptsDir(), mdName), []byte(ensureTrailingNewline(markdown)), fsutil.ConfigFileMode); err != nil {
 		return "", nil, err
 	}
@@ -342,7 +342,10 @@ func writeResultSummary(recordingID string, sm ResultSummary, storage *Storage, 
 	if strings.TrimSpace(markdown) == "" {
 		return "", nil
 	}
-	name := SummaryFilename(recordingID)
+	// 摘要文件名要带标题和时间，而这两者都在索引条目上：transcript 先写，SetTitle
+	// 已经落过标题；只写摘要时回退到录音名。查不到条目就退化成裸 ID 命名。
+	entry, _ := storage.FindByID(recordingID)
+	name := SummaryFilename(recordingID, firstNonEmpty(entry.Title, entry.Metadata.Name), entry.Metadata.CreatedAt)
 	if err := fsutil.WriteAtomic(filepath.Join(storage.SummariesDir(), name), []byte(ensureTrailingNewline(markdown)), fsutil.ConfigFileMode); err != nil {
 		return "", err
 	}
@@ -563,8 +566,14 @@ func appendSummarySection(lines *[]string, title string, value any) {
 	*lines = append(*lines, "")
 }
 
+// readSummaryFile 以索引里记录的 entry.SummaryFile 为准，而不是按 ID 重算文件名，
+// 这样摘要文件改名后仍能读到内容。
 func readSummaryFile(storage *Storage, recordingID string) string {
-	data, err := os.ReadFile(filepath.Join(storage.SummariesDir(), SummaryFilename(recordingID)))
+	entry, ok := storage.FindByID(recordingID)
+	if !ok || entry.SummaryFile == "" {
+		return ""
+	}
+	data, err := os.ReadFile(filepath.Join(storage.dir, entry.SummaryFile))
 	if err != nil {
 		return ""
 	}

--- a/internal/recording/result_writer_test.go
+++ b/internal/recording/result_writer_test.go
@@ -63,6 +63,18 @@ func TestResultWriteTranscriptAndSummary(t *testing.T) {
 		t.Fatalf("missing stored files: %+v", result.Stored)
 	}
 
+	// 转写和摘要落在各自目录，但用同一个 <时间>_<标题>_<ID>.md 文件名：
+	// 摘要写入时从索引读回 transcript 刚落下的标题。
+	stamp := time.Date(2026, 6, 9, 20, 30, 0, 0, time.FixedZone("CST", 8*3600)).
+		In(time.Local).Format("2006010215")
+	wantName := stamp + "_产品方案讨论_rec_1.md"
+	if got := filepath.Base(result.Stored.TranscriptFile); got != wantName {
+		t.Fatalf("transcript filename = %q, want %q", got, wantName)
+	}
+	if got := filepath.Base(result.Stored.SummaryFile); got != wantName {
+		t.Fatalf("summary filename = %q, want %q", got, wantName)
+	}
+
 	// transcript-data 落盘并标记 delivery=result-write
 	raw, err := os.ReadFile(filepath.Join(storage.dir, result.Stored.TranscriptDataFile))
 	if err != nil {
@@ -96,6 +108,54 @@ func TestResultWriteTranscriptAndSummary(t *testing.T) {
 	}
 	if len(events) == 0 || events[len(events)-1].TransferStatus != StatusTranscribed {
 		t.Fatalf("missing transcribed status event: %+v", events)
+	}
+}
+
+func TestResultWriteReadsRenamedSummaryFile(t *testing.T) {
+	t.Parallel()
+	storage := newResultStorage(t)
+	if _, err := storage.Ingest("rec_2", Metadata{Name: "会议", CreatedAt: "2026-06-09T20:30:00+08:00"}, "phone-a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := HandleRecordingResultWrite(ResultWriteParams{
+		RecordingID: "rec_2",
+		Summary:     &ResultSummary{Markdown: "# 总结\n\n- 摘要正文。"},
+	}, storage, testLogger{t}, SyncOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	// 摘要文件改名（磁盘 + 索引），文件名不再是 ID 的纯函数。
+	renamed := "rec_2_产品方案讨论.md"
+	entry, _ := storage.FindByID("rec_2")
+	if err := os.Rename(filepath.Join(storage.dir, entry.SummaryFile), filepath.Join(storage.SummariesDir(), renamed)); err != nil {
+		t.Fatal(err)
+	}
+	if err := storage.SetSummaryFile("rec_2", renamed); err != nil {
+		t.Fatal(err)
+	}
+
+	// 第二次只写 transcript，摘要正文要从索引记录的路径读回，而不是按 ID 重算。
+	var events []StatusEvent
+	if _, err := HandleRecordingResultWrite(ResultWriteParams{
+		RecordingID: "rec_2",
+		Transcript: &ResultTranscript{
+			Title:    "产品方案讨论",
+			Segments: []ResultTranscriptSegment{{Text: "第一段。", StartMS: ptrF(0), EndMS: ptrF(1000)}},
+		},
+	}, storage, testLogger{t}, SyncOptions{
+		NotifyStatus: func(e StatusEvent) { events = append(events, e) },
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(events) == 0 {
+		t.Fatal("missing status event")
+	}
+	last := events[len(events)-1]
+	if !strings.Contains(last.Summary, "摘要正文") {
+		t.Fatalf("summary not read from renamed file: %q", last.Summary)
+	}
+	if last.SummaryFile != summariesDirName+"/"+renamed {
+		t.Fatalf("unexpected summaryFile: %q", last.SummaryFile)
 	}
 }
 

--- a/internal/recording/store.go
+++ b/internal/recording/store.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/YoooClaw/cli/internal/fsutil"
 )
@@ -658,16 +659,32 @@ func AudioFilename(recordingID, ossURL string) string {
 func TranscriptDataFilename(recordingID string) string { return recordingID + ".json" }
 
 // TranscriptFilename 生成转写 Markdown 文件名。
-func TranscriptFilename(recordingID, title string) string {
-	safe := sanitizeFilename(title)
-	if safe != "" {
-		return recordingID + "_" + safe + ".md"
-	}
-	return recordingID + ".md"
+func TranscriptFilename(recordingID, title, createdAt string) string {
+	return artifactFilename(recordingID, title, createdAt)
 }
 
 // SummaryFilename 生成摘要文件名。
-func SummaryFilename(recordingID string) string { return recordingID + ".md" }
+func SummaryFilename(recordingID, title, createdAt string) string {
+	return artifactFilename(recordingID, title, createdAt)
+}
+
+// artifactFilename 按 <YYYYMMDDHH>_<标题>_<ID>.md 组装文件名：时间和标题在前，
+// 按文件名排序即按时间排序，搜索时打头的也是有区分度的字段；ID 收尾，仍能把文件
+// 对回 index.json 里的条目。时间戳取宿主本地时区，小时粒度用于区分同一天的多场会议。
+//
+// 注意这只是写入时的命名，读取一律以 entry.TranscriptFile / entry.SummaryFile 为准，
+// 没有任何地方反解析文件名。时间无法解析或标题为空时各自省略该段，最差退回 <ID>.md。
+func artifactFilename(recordingID, title, createdAt string) string {
+	parts := make([]string, 0, 3)
+	if parsed, ok := parseRecordingTime(createdAt); ok {
+		parts = append(parts, parsed.In(time.Local).Format("2006010215"))
+	}
+	if safe := sanitizeFilename(title); safe != "" {
+		parts = append(parts, safe)
+	}
+	parts = append(parts, recordingID)
+	return strings.Join(parts, "_") + ".md"
+}
 
 // AudioFilePath 返回音频文件绝对路径。
 func (s *Storage) AudioFilePath(recordingID, ossURL string) string {
@@ -699,11 +716,20 @@ func validExt(ext string) bool {
 
 var badFilenameChars = strings.NewReplacer("/", "", "\\", "", ":", "", "*", "", "?", "", `"`, "", "<", "", ">", "", "|", "")
 
+// sanitizeFilename 剥掉文件名非法字符和控制字符，并按码点（而非字节）截断，
+// 避免把多字节字符切成半个。60 码点即使全是 CJK 也约 180 字节，加上时间戳、ID
+// 和分隔符仍在 255 字节的文件名上限内。
 func sanitizeFilename(s string) string {
 	out := strings.TrimSpace(badFilenameChars.Replace(s))
-	runes := []rune(out)
-	if len(runes) > 20 {
-		runes = runes[:20]
+	runes := make([]rune, 0, len(out))
+	for _, r := range out {
+		if unicode.IsControl(r) {
+			continue
+		}
+		runes = append(runes, r)
+		if len(runes) == 60 {
+			break
+		}
 	}
 	return strings.TrimSpace(string(runes))
 }

--- a/internal/recording/store_extra_test.go
+++ b/internal/recording/store_extra_test.go
@@ -3,7 +3,10 @@ package recording
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
+	"unicode/utf8"
 )
 
 func newStore(t *testing.T) *Storage {
@@ -298,5 +301,68 @@ func TestLoadIndexMarksMissingAudioForRecovery(t *testing.T) {
 	}
 	if got := storage.ListMissingAudio(); len(got) != 1 || got[0].ID != "r1" {
 		t.Fatalf("missing audio list: %+v", got)
+	}
+}
+
+func TestArtifactFilenameIsTimeFirst(t *testing.T) {
+	t.Parallel()
+	// 用 time.Date 独立算出期望值，不复用 artifactFilename 自己的解析逻辑，
+	// 同时不依赖跑测试的机器处在哪个时区。
+	stamp := time.Date(2026, 6, 9, 20, 30, 0, 0, time.FixedZone("CST", 8*3600)).
+		In(time.Local).Format("2006010215")
+
+	cases := []struct {
+		name      string
+		id        string
+		title     string
+		createdAt string
+		want      string
+	}{
+		{"完整字段", "rec_1", "产品方案讨论", "2026-06-09T20:30:00+08:00", stamp + "_产品方案讨论_rec_1.md"},
+		{"无标题退化", "rec_1", "  ", "2026-06-09T20:30:00+08:00", stamp + "_rec_1.md"},
+		{"时间不可解析退化", "rec_1", "产品方案讨论", "not-a-time", "产品方案讨论_rec_1.md"},
+		{"两者都缺退回裸 ID", "rec_1", "", "", "rec_1.md"},
+		{"非法字符被剥掉", "rec_1", `a/b\c:d*e?f"g<h>i|j`, "2026-06-09T20:30:00+08:00", stamp + "_abcdefghij_rec_1.md"},
+		{"控制字符被剥掉", "rec_1", "上半\n下半\t尾", "2026-06-09T20:30:00+08:00", stamp + "_上半下半尾_rec_1.md"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := TranscriptFilename(c.id, c.title, c.createdAt); got != c.want {
+				t.Fatalf("TranscriptFilename = %q, want %q", got, c.want)
+			}
+			if got := SummaryFilename(c.id, c.title, c.createdAt); got != c.want {
+				t.Fatalf("SummaryFilename = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestArtifactFilenameStaysWithinNameLimit(t *testing.T) {
+	t.Parallel()
+	// 全 CJK 标题按码点截断到 60，且整体不越过 255 字节的文件名上限。
+	name := TranscriptFilename(
+		"1f2e3d4c-1234-5678-9abc-def012345678",
+		strings.Repeat("会", 200),
+		"2026-06-09T20:30:00+08:00",
+	)
+	title := strings.TrimSuffix(name, ".md")
+	title = title[strings.Index(title, "_")+1 : strings.LastIndex(title, "_")]
+	if got := len([]rune(title)); got != 60 {
+		t.Fatalf("title truncated to %d code points, want 60", got)
+	}
+	if len(name) > 255 {
+		t.Fatalf("filename is %d bytes, over the 255-byte limit: %s", len(name), name)
+	}
+}
+
+func TestSanitizeFilenameDoesNotSplitMultibyte(t *testing.T) {
+	t.Parallel()
+	// 按字节截断会把 4 字节字符切成半个，产生非法 UTF-8；按码点截断不会。
+	got := sanitizeFilename(strings.Repeat("🎧", 80))
+	if !utf8.ValidString(got) {
+		t.Fatalf("sanitized title is not valid UTF-8: %q", got)
+	}
+	if n := len([]rune(got)); n != 60 {
+		t.Fatalf("got %d code points, want 60", n)
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.8.0-beta.0",
+  "version": "0.8.0-beta.1",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {


### PR DESCRIPTION
发布 0.8.0-beta.1，合回主干。内含 issue #64 的两项修复。

## 1. `readSummaryFile()` 以索引为准，不再重算文件名

原实现按录音 ID 重算摘要文件名，只在「文件名是 ID 的纯函数」这个前提下成立。一旦文件被改名就静默返回空串，而文件就在盘上。影响面是 `StatusEvent.Summary` 少了正文，路径字段本身仍然正确。

改为读 `entry.SummaryFile`。注意该字段存的是含目录前缀的相对路径，要 join `storage.dir` 而不是 `SummariesDir()`。

## 2. 产物文件名改为时间在前

`transcripts/` 和 `summaries/` 统一为：

```
<YYYYMMDDHH>_<标题>_<ID>.md
```

改之前 `summaries/` 只有裸 UUID，整个目录不可读；`transcripts/` 虽然带标题但 UUID 打头，按名排序等于随机序。时间和标题前置后，按名排序即按时间排序，搜索时打头的也是有区分度的字段。ID 收尾，仍能把文件对回 `index.json`。

- 时间戳取宿主本地时区，小时粒度用于区分同一天的多场会议
- `created_at` 是元数据里唯一可用的时间源（没有真实的会议开始时间字段）
- `sanitizeFilename` 上调到 60 码点并剥离控制字符；仍按码点而非字节截断，全 CJK 标题约 180 字节，整体不越过 255 字节上限

同一条录音的转写和摘要会拿到完全相同的文件名（分处两个目录）—— 摘要写入时从索引读回 transcript 刚落下的标题。

### 为什么安全

Go 侧没有任何地方反解析文件名，读取一律走 `entry.TranscriptFile` / `entry.SummaryFile`（TS 插件里的 `deriveTitleFromTranscriptPath()` 在 Go 侧没有对应物）。`SetTranscriptFile` / `SetSummaryFile` 在路径变化时会删掉旧文件，存量记录下次写入时自然收敛，不留重复。

**不再被写入的老记录会保持旧名，没有做批量迁移**，所以短期内目录里会新旧混排。

## 测试

新增 4 个测试。其中回归测试先把修复临时还原跑过一遍，确认它确实会失败（报 `""`，正是 issue 预测的失败模式）。命名测试用 `time.Date` 独立算期望时间戳，不复用被测代码自己的解析逻辑，也不依赖跑测试的机器在哪个时区。

`go build ./...`、`go vet ./...`、全量 `go test ./...` 通过。

## 未覆盖

issue 第 1 节提到的 TS 插件侧（`buildSummaryFilename`）改不了，源码库 `YoooClaw/openclaw-plugin` 是私有的。故用 Refs 而非 Closes，#64 需要人工判断是否关闭。

🤖 Generated with [Claude Code](https://claude.com/claude-code)