### PR TITLE
cli-0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.8.0-beta.1",
+  "version": "0.8.0",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {


### PR DESCRIPTION
正式发布 0.8.0：将版本从 0.8.0-beta.1 提升为稳定版 0.8.0（仅 package.json 一行变更）。发布已通过 CI（tag `cli-v0.8.0`）。