### PR TITLE
fix: 修复 CLI 与 Hermes 的 Relay owner 交接

### DIFF
--- a/internal/cli/cmd_owner.go
+++ b/internal/cli/cmd_owner.go
@@ -1,0 +1,249 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/YoooClaw/cli/internal/clictx"
+	"github.com/YoooClaw/cli/internal/config"
+	"github.com/YoooClaw/cli/internal/daemon"
+	"github.com/YoooClaw/cli/internal/errs"
+	"github.com/YoooClaw/cli/internal/paths"
+	"github.com/spf13/cobra"
+)
+
+const ownerHandoffTimeout = 20 * time.Second
+
+var (
+	findExecutable = exec.LookPath
+	runExecutable  = func(name string, args ...string) ([]byte, error) {
+		return exec.Command(name, args...).CombinedOutput()
+	}
+)
+
+func newOwnerCmd() *cobra.Command {
+	c := &cobra.Command{Use: "owner", Short: "Relay owner 交接"}
+	activate := &cobra.Command{
+		Use:   "activate cli",
+		Short: "停用 Hermes YoooClaw 插件并让 standalone CLI 接管 Relay",
+		Args:  cobra.ExactArgs(1),
+		RunE:  run(ownerActivate),
+	}
+	activate.Flags().String("hermes-profile", "", "要停用 YoooClaw 插件的 Hermes profile")
+	activate.Flags().Bool("no-start", false, "只释放 Hermes owner，不启动 CLI daemon")
+	c.AddCommand(activate)
+	return c
+}
+
+func ownerActivate(ctx *clictx.Context, cmd *cobra.Command, args []string) (any, error) {
+	if args[0] != "cli" {
+		return nil, errs.New(errs.CodeInvalidArgument, "当前只支持激活 cli owner")
+	}
+	return activateCLIOwner(ctx, flagStr(cmd, "hermes-profile"), !flagBool(cmd, "no-start"))
+}
+
+func activateCLIOwner(ctx *clictx.Context, hermesProfile string, start bool) (map[string]any, error) {
+	stoppedProfiles, err := stopAllProfileDaemons(ctx.Profile)
+	if err != nil {
+		return nil, err
+	}
+
+	heldBefore, ownerBefore, err := daemon.WriterLockStatus(ctx.Paths)
+	if err != nil {
+		return nil, errs.New(errs.CodeStorageUnavailable, "无法检查当前 writer owner："+err.Error())
+	}
+	relayHeldBefore, err := daemon.RelayConsumerLockHeld(ctx.Paths)
+	if err != nil {
+		return nil, errs.New(errs.CodeStorageUnavailable, "无法检查当前 Relay owner："+err.Error())
+	}
+	runtimeHeldBefore := heldBefore || relayHeldBefore
+
+	hermesBin, _ := findHermesExecutable()
+	disabled := []string{}
+	disableErrors := []string{}
+	if hermesBin != "" {
+		for _, plugin := range []string{"yoooclaw", "yoooclaw_app"} {
+			out, runErr := runExecutable(hermesBin, hermesArgs(hermesProfile, "plugins", "disable", plugin)...)
+			if runErr == nil {
+				disabled = append(disabled, plugin)
+				continue
+			}
+			disableErrors = append(disableErrors, plugin+": "+compactCommandError(out, runErr))
+		}
+	}
+
+	// Disabling a plugin changes the next Hermes process only. If a live
+	// runtime owns writer.lock or the account Relay lock, one controlled
+	// gateway restart is required to unload it while preserving every
+	// non-YoooClaw Hermes channel.
+	restartedGateway := false
+	if runtimeHeldBefore {
+		if hermesBin == "" {
+			return nil, ownerHandoffError(ownerBefore, "找不到 hermes 命令，无法让正在运行的插件释放 Relay")
+		}
+		if len(disableErrors) > 0 {
+			return nil, ownerHandoffError(ownerBefore, "停用 Hermes YoooClaw 插件失败："+strings.Join(disableErrors, "; "))
+		}
+		out, runErr := runExecutable(hermesBin, hermesArgs(hermesProfile, "gateway", "restart")...)
+		if runErr != nil {
+			return nil, ownerHandoffError(ownerBefore, "Hermes Gateway 重启失败："+compactCommandError(out, runErr))
+		}
+		restartedGateway = true
+	}
+
+	if err := waitForOwnerRelease(ctx.Paths, ownerHandoffTimeout); err != nil {
+		return nil, err
+	}
+
+	result := map[string]any{
+		"ok":               true,
+		"owner":            "standalone-daemon",
+		"profile":          ctx.Profile,
+		"stoppedProfiles":  stoppedProfiles,
+		"hermesExecutable": ownerNilIfEmpty(hermesBin),
+		"disabledPlugins":  disabled,
+		"gatewayRestarted": restartedGateway,
+		"daemonStarted":    false,
+	}
+	if len(disableErrors) > 0 {
+		// No live Hermes lock existed, so these errors do not block the current
+		// takeover. Keep them visible: a later Hermes launch could otherwise
+		// reclaim ownership unexpectedly.
+		result["warnings"] = disableErrors
+	}
+
+	if !start {
+		result["activation"] = "released"
+		return result, nil
+	}
+	if !config.Exists(ctx.Paths) {
+		result["activation"] = "pending-config"
+		result["hint"] = "运行 `yoooclaw config init`；配置完成后 daemon 会自动启动"
+		return result, nil
+	}
+	lock, err := daemon.Spawn(ctx, daemon.StartOpts{})
+	if err != nil {
+		return nil, errs.New(errs.CodeUnknown, "CLI owner 已释放，但 standalone daemon 启动失败："+err.Error()).
+			WithHint("检查 `yoooclaw daemon logs`，修复后运行 `yoooclaw daemon start`")
+	}
+	result["activation"] = "active"
+	result["daemonStarted"] = true
+	result["pid"] = lock.PID
+	return result, nil
+}
+
+func stopAllProfileDaemons(activeProfile string) ([]string, error) {
+	names := paths.ListProfileNames()
+	if len(names) == 0 {
+		names = []string{activeProfile}
+	}
+	seen := map[string]bool{}
+	stopped := []string{}
+	for _, profile := range append(names, activeProfile) {
+		if profile == "" || seen[profile] {
+			continue
+		}
+		seen[profile] = true
+		p := paths.For(profile)
+		state := daemon.State(p)
+		if !state.Running {
+			if state.Stale {
+				daemon.RemoveLock(p)
+			}
+			continue
+		}
+		if _, err := daemon.Stop(p); err != nil {
+			return nil, errs.New(errs.CodeDaemonUnresponsive,
+				fmt.Sprintf("无法停止 profile %s 的旧 daemon：%s", profile, err.Error()),
+				map[string]any{"profile": profile, "pid": state.Lock.PID}).
+				WithHint("旧 daemon 未确认退出，安装器不会继续造成双 owner")
+		}
+		stopped = append(stopped, profile)
+	}
+	return stopped, nil
+}
+
+func waitForOwnerRelease(p paths.Paths, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	var lastOwner string
+	for {
+		writerHeld, owner, writerErr := daemon.WriterLockStatus(p)
+		relayHeld, relayErr := daemon.RelayConsumerLockHeld(p)
+		if writerErr != nil {
+			return errs.New(errs.CodeStorageUnavailable, "无法检查 writer lock："+writerErr.Error())
+		}
+		if relayErr != nil {
+			return errs.New(errs.CodeStorageUnavailable, "无法检查 Relay lock："+relayErr.Error())
+		}
+		lastOwner = owner
+		if !writerHeld && !relayHeld {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return ownerHandoffError(lastOwner, "等待 writer/Relay owner 释放超时")
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+func findHermesExecutable() (string, error) {
+	if found, err := findExecutable("hermes"); err == nil {
+		return found, nil
+	}
+	home, _ := os.UserHomeDir()
+	candidates := []string{
+		filepath.Join(home, ".local", "bin", "hermes"),
+		filepath.Join(home, ".local", "bin", "hermes.exe"),
+		filepath.Join(home, ".hermes", "bin", "hermes"),
+		filepath.Join(home, ".hermes", "bin", "hermes.exe"),
+	}
+	if localAppData := os.Getenv("LOCALAPPDATA"); localAppData != "" {
+		candidates = append(candidates,
+			filepath.Join(localAppData, "hermes", "hermes-agent", "venv", "Scripts", "hermes.exe"))
+	}
+	for _, candidate := range candidates {
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate, nil
+		}
+	}
+	return "", exec.ErrNotFound
+}
+
+func hermesArgs(profile string, args ...string) []string {
+	profile = strings.TrimSpace(profile)
+	if profile == "" {
+		profile = strings.TrimSpace(os.Getenv("HERMES_PROFILE"))
+	}
+	if profile == "" || profile == "default" {
+		return args
+	}
+	return append([]string{"--profile", profile}, args...)
+}
+
+func compactCommandError(output []byte, err error) string {
+	text := strings.Join(strings.Fields(string(output)), " ")
+	if text == "" {
+		return err.Error()
+	}
+	if len(text) > 500 {
+		text = text[:500] + "…"
+	}
+	return text
+}
+
+func ownerHandoffError(owner, message string) error {
+	return errs.New(errs.CodeDaemonDisabledByPlugin, message,
+		map[string]any{"owner": owner}).
+		WithHint("确认 hermes 可执行后重试；若命令正由 Hermes 会话执行，请退出该会话再运行安装命令")
+}
+
+func ownerNilIfEmpty(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
+}

--- a/internal/cli/cmd_owner_test.go
+++ b/internal/cli/cmd_owner_test.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/YoooClaw/cli/internal/clictx"
+	"github.com/YoooClaw/cli/internal/paths"
+)
+
+func TestActivateCLIOwnerDisablesHermesAndLeavesUnconfiguredInstallPending(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("LOCALAPPDATA", "")
+	t.Setenv("YOOOCLAW_HOME", root)
+
+	oldFind, oldRun := findExecutable, runExecutable
+	t.Cleanup(func() { findExecutable, runExecutable = oldFind, oldRun })
+	findExecutable = func(name string) (string, error) {
+		if name != "hermes" {
+			t.Fatalf("unexpected executable lookup: %s", name)
+		}
+		return "/mock/hermes", nil
+	}
+	var calls [][]string
+	runExecutable = func(name string, args ...string) ([]byte, error) {
+		calls = append(calls, append([]string{name}, args...))
+		return []byte("ok"), nil
+	}
+
+	ctx := &clictx.Context{Profile: "default", Paths: paths.For("default")}
+	result, err := activateCLIOwner(ctx, "work", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantCalls := [][]string{
+		{"/mock/hermes", "--profile", "work", "plugins", "disable", "yoooclaw"},
+		{"/mock/hermes", "--profile", "work", "plugins", "disable", "yoooclaw_app"},
+	}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("Hermes calls = %#v, want %#v", calls, wantCalls)
+	}
+	if result["owner"] != "standalone-daemon" || result["activation"] != "pending-config" {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+	if result["gatewayRestarted"] != false || result["daemonStarted"] != false {
+		t.Fatalf("unheld/unconfigured install should not restart/start: %#v", result)
+	}
+}
+
+func TestFindHermesExecutableFallsBackToKnownUserPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("LOCALAPPDATA", "")
+	oldFind := findExecutable
+	t.Cleanup(func() { findExecutable = oldFind })
+	findExecutable = func(string) (string, error) { return "", errors.New("not on PATH") }
+
+	want := filepath.Join(home, ".local", "bin", "hermes")
+	if err := os.MkdirAll(filepath.Dir(want), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(want, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got, err := findHermesExecutable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("findHermesExecutable() = %q, want %q", got, want)
+	}
+}
+
+func TestHermesArgsUsesEnvironmentProfile(t *testing.T) {
+	t.Setenv("HERMES_PROFILE", "customer")
+	got := hermesArgs("", "gateway", "restart")
+	want := []string{"--profile", "customer", "gateway", "restart"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("hermesArgs = %#v, want %#v", got, want)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -30,6 +30,7 @@ func newRootCmd() *cobra.Command {
 		newConfigCmd(),
 		newProfileCmd(),
 		newAuthCmd(),
+		newOwnerCmd(),
 		newDaemonCmd(),
 		newNotificationCmd(),
 		newSyncCmd(),

--- a/internal/daemon/relaylock.go
+++ b/internal/daemon/relaylock.go
@@ -34,7 +34,7 @@ func relayConsumerConflict(p paths.Paths) error {
 // checkRelayConsumerLock 在父进程 spawn 前快速探测，避免子进程因全局锁冲突后让
 // 调用方等待 daemon ready 超时。真正的竞态互斥仍由 RunForeground 获取锁保证。
 func checkRelayConsumerLock(p paths.Paths) error {
-	held, err := probeFileLock(relayConsumerLockPath(p))
+	held, err := RelayConsumerLockHeld(p)
 	if err != nil {
 		return errs.New(errs.CodeStorageUnavailable, "无法检查账号级 Relay 消费者锁："+err.Error())
 	}
@@ -42,6 +42,13 @@ func checkRelayConsumerLock(p paths.Paths) error {
 		return relayConsumerConflict(p)
 	}
 	return nil
+}
+
+// RelayConsumerLockHeld reports whether another process currently owns the
+// account-level Relay consumer lock. It is exported for installer handoff and
+// post-install acceptance checks.
+func RelayConsumerLockHeld(p paths.Paths) (bool, error) {
+	return probeFileLock(relayConsumerLockPath(p))
 }
 
 // acquireRelayConsumerLock 获取并持有账号级 Relay 消费者锁直到 daemon 退出。

--- a/internal/daemon/spawn.go
+++ b/internal/daemon/spawn.go
@@ -230,6 +230,19 @@ func StopWithOptions(p paths.Paths, opts StopOpts) (map[string]any, error) {
 	if current := State(p); current.Running && current.Lock != nil && current.Lock.PID == lock.PID {
 		_ = forceKill(lock.PID)
 	}
+	// A successful forceKill call is not proof that the process has exited
+	// (notably with Windows endpoint/security races). Do not let installers
+	// continue with a false "stopped" result while the old owner still holds
+	// writer/Relay locks.
+	for i := 0; i < 20 && isProcessAlive(lock.PID); i++ {
+		time.Sleep(100 * time.Millisecond)
+	}
+	if isProcessAlive(lock.PID) {
+		return nil, errs.New(errs.CodeDaemonUnresponsive,
+			fmt.Sprintf("daemon 强制停止后仍在运行（pid %d）", lock.PID),
+			map[string]any{"pid": lock.PID, "profile": p.Profile}).
+			WithHint("查看进程权限和安全软件拦截记录；旧进程退出前不会切换 Relay owner")
+	}
 	if current := ReadLock(p); current != nil && current.PID == lock.PID {
 		RemoveLock(p)
 	}

--- a/internal/daemon/writerlock.go
+++ b/internal/daemon/writerlock.go
@@ -49,8 +49,7 @@ func PrecheckStartFor(p paths.Paths, opts StartOpts) error {
 // 探测失败时必须 fail closed：无法证明插件未持锁就启动 standalone daemon，
 // 会重新引入双写与双 Relay consumer。
 func checkWriterLock(p paths.Paths) error {
-	path := filepath.Join(p.Dir, writerLockFileName)
-	held, err := probeWriterFileLock(path)
+	held, owner, err := WriterLockStatus(p)
 	if err != nil {
 		return errs.New(errs.CodeStorageUnavailable, "无法检查 hermes 插件写者锁："+err.Error()).
 			WithHint("检查 writer.lock 的权限后重试；在锁状态未知时不会启动 standalone daemon")
@@ -59,8 +58,21 @@ func checkWriterLock(p paths.Paths) error {
 		return nil
 	}
 	return errs.New(errs.CodeDaemonDisabledByPlugin,
-		"通知存储由 "+writerLockOwnerHint(path)+" 独占，standalone daemon 已禁用").
+		"通知存储由 "+owner+" 独占，standalone daemon 已禁用").
 		WithHint("停用 hermes 插件后重试；插件运行期间的通知采集由插件直写完成")
+}
+
+// WriterLockStatus reports whether the profile writer lock is currently held
+// and returns the diagnostic owner stored beside the OS lock. Installers use
+// this to perform an explicit Hermes -> standalone ownership handoff without
+// guessing from a stale JSON file.
+func WriterLockStatus(p paths.Paths) (held bool, owner string, err error) {
+	path := filepath.Join(p.Dir, writerLockFileName)
+	held, err = probeWriterFileLock(path)
+	if err != nil {
+		return false, "", err
+	}
+	return held, writerLockOwnerHint(path), nil
 }
 
 // writerLockOwnerHint 读取锁文件元数据拼诊断信息；内容仅供展示，

--- a/internal/daemon/writerlock.go
+++ b/internal/daemon/writerlock.go
@@ -46,11 +46,16 @@ func PrecheckStartFor(p paths.Paths, opts StartOpts) error {
 }
 
 // checkWriterLock 探测写者锁；被其他进程持有时返回结构化错误。
-// 探测本身出错（权限等）按未持有处理——诊断逻辑不能把 daemon 卡死。
+// 探测失败时必须 fail closed：无法证明插件未持锁就启动 standalone daemon，
+// 会重新引入双写与双 Relay consumer。
 func checkWriterLock(p paths.Paths) error {
 	path := filepath.Join(p.Dir, writerLockFileName)
-	held, err := probeFileLock(path)
-	if err != nil || !held {
+	held, err := probeWriterFileLock(path)
+	if err != nil {
+		return errs.New(errs.CodeStorageUnavailable, "无法检查 hermes 插件写者锁："+err.Error()).
+			WithHint("检查 writer.lock 的权限后重试；在锁状态未知时不会启动 standalone daemon")
+	}
+	if !held {
 		return nil
 	}
 	return errs.New(errs.CodeDaemonDisabledByPlugin,

--- a/internal/daemon/writerlock_unix.go
+++ b/internal/daemon/writerlock_unix.go
@@ -29,3 +29,8 @@ func probeFileLock(path string) (bool, error) {
 	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
 	return false, nil
 }
+
+// Unix flock 锁整个文件，不区分字节偏移；writer 与其他进程锁复用同一探测。
+func probeWriterFileLock(path string) (bool, error) {
+	return probeFileLock(path)
+}

--- a/internal/daemon/writerlock_windows.go
+++ b/internal/daemon/writerlock_windows.go
@@ -20,11 +20,26 @@ const (
 	lockfileFailImmediately = 0x00000001
 	lockfileExclusiveLock   = 0x00000002
 	errorLockViolation      = 33 // ERROR_LOCK_VIOLATION
+
+	// Hermes writer_lock.py locks this sentinel byte so the JSON owner/PID
+	// metadata at offset 0 remains readable while the mandatory Windows lock
+	// is held. Keep this value in sync with _WINDOWS_LOCK_OFFSET there.
+	windowsWriterLockOffset = 0x7FFF_FFFF
 )
 
-// probeFileLock 非阻塞探测字节区间锁 [0,1)：与插件侧 writer_lock.py 的
-// msvcrt.locking(LK_NBLCK, 1) 同一锁命名空间（底层同为 LockFile 区间锁）。
+// probeFileLock 非阻塞探测字节区间锁 [0,1)。daemon singleton 与 account
+// Relay consumer 继续使用这个范围；不能为了 writer lock 改动它。
 func probeFileLock(path string) (bool, error) {
+	return probeFileLockAt(path, 0)
+}
+
+// probeWriterFileLock 探测 Hermes 插件持有的 writer sentinel byte。
+// Python msvcrt.locking 与 Windows LockFileEx 共用字节区间锁命名空间。
+func probeWriterFileLock(path string) (bool, error) {
+	return probeFileLockAt(path, windowsWriterLockOffset)
+}
+
+func probeFileLockAt(path string, offset uint32) (bool, error) {
 	f, err := os.OpenFile(path, os.O_RDWR, 0)
 	if errors.Is(err, fs.ErrNotExist) {
 		return false, nil
@@ -33,7 +48,7 @@ func probeFileLock(path string) (bool, error) {
 		return false, err
 	}
 	defer f.Close()
-	var overlapped syscall.Overlapped
+	overlapped := syscall.Overlapped{Offset: offset}
 	ret, _, callErr := procLockFileEx.Call(
 		f.Fd(),
 		uintptr(lockfileExclusiveLock|lockfileFailImmediately),

--- a/internal/daemon/writerlock_windows_test.go
+++ b/internal/daemon/writerlock_windows_test.go
@@ -1,0 +1,121 @@
+//go:build windows
+
+package daemon
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"unsafe"
+)
+
+const writerLockHelperEnv = "YOOOCLAW_TEST_HOLD_WRITER_LOCK"
+
+func TestWriterLockUsesHermesSentinelOffset(t *testing.T) {
+	// Cross-repository contract with
+	// yoooclaw_hermes/runtime/writer_lock.py:_WINDOWS_LOCK_OFFSET.
+	if windowsWriterLockOffset != 0x7FFF_FFFF {
+		t.Fatalf("writer lock offset = %#x, want %#x", windowsWriterLockOffset, 0x7FFF_FFFF)
+	}
+
+	path := filepath.Join(t.TempDir(), writerLockFileName)
+	metadata := []byte(`{"owner":"hermes-plugin","pid":4242}`)
+	if err := os.WriteFile(path, metadata, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestWriterLockHelperProcess$")
+	cmd.Env = append(os.Environ(), writerLockHelperEnv+"="+path)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	stopped := false
+	t.Cleanup(func() {
+		_ = stdin.Close()
+		if !stopped {
+			_ = cmd.Wait()
+		}
+	})
+	ready, err := bufio.NewReader(stdout).ReadString('\n')
+	if err != nil || strings.TrimSpace(ready) != "ready" {
+		t.Fatalf("lock helper did not become ready: ready=%q err=%v stderr=%s", ready, err, stderr.String())
+	}
+
+	held, err := probeWriterFileLock(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !held {
+		t.Fatal("writer probe did not observe the Hermes sentinel lock")
+	}
+
+	// Relay/daemon singleton probing must remain at offset 0 and therefore
+	// must not collide with the writer sentinel.
+	held, err = probeFileLock(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if held {
+		t.Fatal("generic offset-0 probe unexpectedly collided with writer sentinel")
+	}
+
+	// The reason for the sentinel is to leave owner/PID diagnostics readable.
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("writer metadata became unreadable while sentinel was held: %v", err)
+	}
+	if !bytes.Equal(raw, metadata) {
+		t.Fatalf("writer metadata changed: got %q want %q", raw, metadata)
+	}
+
+	if err := stdin.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("lock helper failed: %v stderr=%s", err, stderr.String())
+	}
+	stopped = true
+}
+
+func TestWriterLockHelperProcess(t *testing.T) {
+	path := os.Getenv(writerLockHelperEnv)
+	if path == "" {
+		return
+	}
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	overlapped := syscall.Overlapped{Offset: windowsWriterLockOffset}
+	ret, _, callErr := procLockFileEx.Call(
+		f.Fd(),
+		uintptr(lockfileExclusiveLock|lockfileFailImmediately),
+		0, 1, 0,
+		uintptr(unsafe.Pointer(&overlapped)),
+	)
+	if ret == 0 {
+		t.Fatalf("LockFileEx failed: %v", callErr)
+	}
+	defer procUnlockFileEx.Call(f.Fd(), 0, 1, 0, uintptr(unsafe.Pointer(&overlapped))) //nolint:errcheck
+
+	fmt.Println("ready")
+	_, _ = io.Copy(io.Discard, os.Stdin)
+}

--- a/npm/cli/bin/activate-owner.js
+++ b/npm/cli/bin/activate-owner.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+"use strict";
+
+// Restore the owner recorded by preinstall. Switching Hermes -> CLI is never
+// inferred from an update: it requires YOOOCLAW_ACTIVATE_OWNER=cli.
+
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const root = process.env.YOOOCLAW_HOME || path.join(os.homedir(), ".yoooclaw");
+const statePath = path.join(root, ".cli-install-handoff.json");
+let state = { activationRequested: false, runningProfiles: [] };
+try {
+  state = JSON.parse(fs.readFileSync(statePath, "utf8"));
+} catch {
+  // A first install or an npm client that skipped preinstall has no owner to restore.
+}
+const activationRequested =
+  process.env.YOOOCLAW_ACTIVATE_OWNER === "cli" || state.activationRequested === true;
+const runningProfiles = Array.isArray(state.runningProfiles) ? state.runningProfiles : [];
+
+if (!activationRequested && runningProfiles.length === 0) {
+  try {
+    fs.unlinkSync(statePath);
+  } catch {}
+  process.stderr.write("@yoooclaw/cli: installed; current Relay owner preserved\n");
+  process.exit(0);
+}
+
+function resolveBinary() {
+  const pkg = `@yoooclaw/cli-${process.platform}-${process.arch}`;
+  const binName = process.platform === "win32" ? "yc.exe" : "yc";
+  try {
+    return require.resolve(`${pkg}/bin/${binName}`);
+  } catch {
+    return null;
+  }
+}
+
+const bin = resolveBinary();
+if (!bin) {
+  process.stderr.write(
+    "@yoooclaw/cli: native binary is unavailable; cannot restore Relay owner\n",
+  );
+  process.exit(1);
+}
+
+function run(args) {
+  const result = spawnSync(bin, args, {
+    stdio: "inherit",
+    env: process.env,
+    windowsHide: true,
+  });
+  if (result.error || result.status !== 0) {
+    process.exit(typeof result.status === "number" ? result.status : 1);
+  }
+}
+
+if (activationRequested) {
+  const args = ["owner", "activate", "cli", "--format", "json"];
+  if (process.env.HERMES_PROFILE) {
+    args.push("--hermes-profile", process.env.HERMES_PROFILE);
+  }
+  run(args);
+} else {
+  for (const profile of runningProfiles) {
+    run(["--profile", profile, "daemon", "start", "--format", "json"]);
+  }
+}
+
+try {
+  fs.unlinkSync(statePath);
+} catch {}

--- a/npm/cli/bin/prepare-owner.js
+++ b/npm/cli/bin/prepare-owner.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+"use strict";
+
+// Record and drain only standalone daemons that are actually running before
+// npm replaces the native package. Hermes-owned installs have no standalone
+// daemon, so a normal npm update leaves Hermes and its Gateway untouched.
+
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const root = process.env.YOOOCLAW_HOME || path.join(os.homedir(), ".yoooclaw");
+const profilesRoot = path.join(root, "profiles");
+const statePath = path.join(root, ".cli-install-handoff.json");
+const activationRequested = process.env.YOOOCLAW_ACTIVATE_OWNER === "cli";
+let profiles = [];
+try {
+  profiles = fs
+    .readdirSync(profilesRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
+} catch {
+  profiles = ["default"];
+}
+
+function oldCLIFor(profile) {
+  try {
+    const lock = JSON.parse(
+      fs.readFileSync(path.join(profilesRoot, profile, "daemon.lock"), "utf8"),
+    );
+    if (lock.executable && fs.existsSync(lock.executable)) {
+      return lock.executable;
+    }
+  } catch {
+    // Missing/stale lock is normal when Hermes owns the runtime.
+  }
+  return process.platform === "win32" ? "yoooclaw.cmd" : "yoooclaw";
+}
+
+const runningProfiles = [];
+for (const profile of profiles) {
+  const oldCLI = oldCLIFor(profile);
+  const status = spawnSync(
+    oldCLI,
+    ["--profile", profile, "daemon", "status", "--format", "json"],
+    { stdio: "ignore", env: process.env, windowsHide: true },
+  );
+  if (status.status !== 0) continue;
+
+  const stopped = spawnSync(
+    oldCLI,
+    ["--profile", profile, "daemon", "stop", "--format", "json"],
+    { stdio: "inherit", env: process.env, windowsHide: true },
+  );
+  if (stopped.error || stopped.status !== 0) {
+    process.stderr.write(
+      `@yoooclaw/cli: failed to stop old daemon for profile ${profile}\n`,
+    );
+    process.exit(1);
+  }
+  runningProfiles.push(profile);
+}
+
+fs.mkdirSync(root, { recursive: true, mode: 0o700 });
+fs.writeFileSync(
+  statePath,
+  JSON.stringify({ activationRequested, runningProfiles, preparedAt: new Date().toISOString() }),
+  { mode: 0o600 },
+);

--- a/scripts/build-go.sh
+++ b/scripts/build-go.sh
@@ -71,6 +71,8 @@ done
 maindir="dist-npm/cli"
 mkdir -p "$maindir/bin"
 cp npm/cli/bin/yc.js "$maindir/bin/yc.js"
+cp npm/cli/bin/prepare-owner.js "$maindir/bin/prepare-owner.js"
+cp npm/cli/bin/activate-owner.js "$maindir/bin/activate-owner.js"
 cp npm/cli/README.md "$maindir/README.md"
 node scripts/gen-pkg.mjs main "$maindir" "$VERSION" "$PLATFORM_PKGS"
 

--- a/scripts/gen-pkg.mjs
+++ b/scripts/gen-pkg.mjs
@@ -44,7 +44,11 @@ if (mode === "platform") {
     description: "yoooclaw 独立 CLI（Go 实现，按平台分发原生二进制）",
     ...COMMON,
     bin: { yoooclaw: "bin/yc.js", yc: "bin/yc.js" },
-    files: ["bin/yc.js", "README.md"],
+    files: ["bin/yc.js", "bin/prepare-owner.js", "bin/activate-owner.js", "README.md"],
+    scripts: {
+      preinstall: "node bin/prepare-owner.js",
+      postinstall: "node bin/activate-owner.js",
+    },
     optionalDependencies,
     engines: { node: ">=18" },
     keywords: ["yoooclaw", "cli", "daemon", "notifications", "agent"],

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,6 +11,8 @@
 #   --beta          未指定 --version 时安装最新预发布版
 #   --dir <path>    安装目录（默认优先 ~/.local/bin，其次为可写的 /usr/local/bin）
 #   --force         覆盖已存在二进制
+#   --activate      安装后明确将 Relay owner 切换到 CLI（默认保留当前 owner）
+#   --hermes-profile <name>  指定需要停用 YoooClaw 插件的 Hermes profile
 #   --modify-path   将安装目录写入 shell 配置（默认不修改）
 #   --no-modify-path 不修改 shell 配置（默认行为，兼容旧调用）
 #
@@ -18,6 +20,8 @@
 #   - 检测 OS/Arch，下载 yoooclaw-<os>-<arch>（OSS 渲染版从 OSS 下载，源码版从 GitHub Release）
 #   - 校验 sha256（从同目录 checksums.txt 取）
 #   - 写入 <dir>/yoooclaw，并 symlink yc -> yoooclaw
+#   - 默认保留当前 Relay owner；CLI daemon 原本在运行时，更新后恢复原 profile
+#   - 仅 --activate 会停用 Hermes 的 YoooClaw 插件并切换到 CLI owner
 #   - 默认不修改 shell 配置；仅传入 --modify-path 时幂等写入 PATH
 
 set -eu
@@ -33,6 +37,15 @@ INSTALL_DIR=""
 FORCE=0
 BETA=0
 MODIFY_PATH=0
+ACTIVATE_OWNER=0
+HERMES_PROFILE=""
+STOPPED_PROFILES=""
+OLD_CLI=""
+HANDOFF_PENDING=0
+
+if [ "${YOOOCLAW_ACTIVATE_OWNER:-}" = "cli" ]; then
+  ACTIVATE_OWNER=1
+fi
 
 err() { printf '\033[31merror:\033[0m %s\n' "$*" >&2; exit 1; }
 info() { printf '\033[34m==>\033[0m %s\n' "$*"; }
@@ -44,10 +57,12 @@ while [ $# -gt 0 ]; do
     --beta)    BETA=1; shift ;;
     --dir)     INSTALL_DIR="${2:?--dir 需要值}"; shift 2 ;;
     --force)   FORCE=1; shift ;;
+    --activate) ACTIVATE_OWNER=1; shift ;;
+    --hermes-profile) HERMES_PROFILE="${2:?--hermes-profile 需要值}"; shift 2 ;;
     --modify-path) MODIFY_PATH=1; shift ;;
     --no-modify-path) MODIFY_PATH=0; shift ;;
     -h|--help)
-      sed -n '2,21p' "$0" | sed 's/^# \{0,1\}//'
+      sed -n '2,24p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     *) err "未知参数: $1" ;;
@@ -138,9 +153,60 @@ if [ -e "$TARGET" ] && [ "$FORCE" -ne 1 ]; then
   err "$TARGET 已存在；用 --force 覆盖，或先卸载旧版本"
 fi
 
+# ---------- stop existing standalone daemons ----------
+# Stop only daemons that are actually running before replacing the executable.
+# Their profile list is restored after a normal update. A Hermes-owned runtime
+# has no running standalone daemon, so it is left completely untouched.
+stop_existing_daemons() {
+  if [ -x "$TARGET" ]; then
+    OLD_CLI="$TARGET"
+  else
+    OLD_CLI=$(command -v yoooclaw 2>/dev/null || true)
+  fi
+  [ -n "$OLD_CLI" ] || return 0
+
+  runtime_root=${YOOOCLAW_HOME:-$HOME/.yoooclaw}
+  found_profile=0
+  for profile_dir in "$runtime_root"/profiles/*; do
+    [ -d "$profile_dir" ] || continue
+    found_profile=1
+    profile_name=${profile_dir##*/}
+    if "$OLD_CLI" --profile "$profile_name" daemon status >/dev/null 2>&1; then
+      "$OLD_CLI" --profile "$profile_name" daemon stop >/dev/null 2>&1 \
+        || err "无法停止旧 CLI daemon: $profile_name"
+      STOPPED_PROFILES="$STOPPED_PROFILES $profile_name"
+      info "已停止旧 CLI daemon: $profile_name"
+    fi
+  done
+  if [ "$found_profile" -eq 0 ]; then
+    if "$OLD_CLI" --profile default daemon status >/dev/null 2>&1; then
+      "$OLD_CLI" --profile default daemon stop >/dev/null 2>&1 \
+        || err "无法停止旧 CLI daemon: default"
+      STOPPED_PROFILES="$STOPPED_PROFILES default"
+      info "已停止旧 CLI daemon: default"
+    fi
+  fi
+}
+
 # ---------- download + verify ----------
 TMP=$(mktemp -d)
-trap 'rm -rf "$TMP"' EXIT
+
+cleanup() {
+  cleanup_status=$?
+  trap - EXIT
+  rm -rf "$TMP"
+  if [ "$cleanup_status" -ne 0 ] && [ "$HANDOFF_PENDING" -eq 1 ] && [ -n "$STOPPED_PROFILES" ]; then
+    recovery_cli="$OLD_CLI"
+    [ -x "$TARGET" ] && recovery_cli="$TARGET"
+    warn "安装未完成，正在恢复更新前运行的 CLI daemon…"
+    for recovery_profile in $STOPPED_PROFILES; do
+      "$recovery_cli" --profile "$recovery_profile" daemon start >/dev/null 2>&1 \
+        || warn "无法自动恢复 profile $recovery_profile；请运行 yoooclaw --profile $recovery_profile daemon start"
+    done
+  fi
+  exit "$cleanup_status"
+}
+trap cleanup EXIT
 
 info "下载 ${BASE}/${ASSET}"
 curl -fL --progress-bar -o "$TMP/$ASSET" "${BASE}/${ASSET}"
@@ -162,6 +228,10 @@ if curl -fsSL -o "$TMP/checksums.txt" "${BASE}/checksums.txt"; then
 else
   warn "未找到 checksums.txt，跳过校验"
 fi
+
+# 制品已经下载并校验完成，此时才短暂停掉旧 CLI daemon，避免下载失败影响现有 owner。
+stop_existing_daemons
+[ -n "$STOPPED_PROFILES" ] && HANDOFF_PENDING=1
 
 # ---------- install ----------
 chmod +x "$TMP/$ASSET"
@@ -294,3 +364,23 @@ resolved_yoooclaw=$(command -v yoooclaw 2>/dev/null || true)
 installed_version=$(yoooclaw --version 2>/dev/null) || err "已写入文件但 --version 执行失败"
 info "yoooclaw $installed_version ready"
 info "命令验证通过: $resolved_yoooclaw"
+
+# ---------- restore or explicitly activate owner ----------
+if [ "$ACTIVATE_OWNER" -eq 1 ]; then
+  info "切换 Relay owner 到 standalone CLI…"
+  if [ -n "$HERMES_PROFILE" ]; then
+    yoooclaw owner activate cli --hermes-profile "$HERMES_PROFILE" \
+      || err "CLI 已安装，但 Relay owner 交接失败；请根据上方诊断修复后运行: yoooclaw owner activate cli --hermes-profile $HERMES_PROFILE"
+  else
+    yoooclaw owner activate cli \
+      || err "CLI 已安装，但 Relay owner 交接失败；请根据上方诊断修复后运行: yoooclaw owner activate cli"
+  fi
+else
+  for profile_name in $STOPPED_PROFILES; do
+    yoooclaw --profile "$profile_name" daemon start >/dev/null \
+      || err "CLI 已更新，但无法恢复 profile $profile_name 的 daemon；请运行: yoooclaw --profile $profile_name daemon start"
+    info "已恢复 CLI daemon: $profile_name"
+  done
+  info "已保留当前 Relay owner（如需切换到 CLI，请重新运行并加 --activate）"
+fi
+HANDOFF_PENDING=0

--- a/scripts/install_test.go
+++ b/scripts/install_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -16,10 +17,12 @@ func TestInstallScriptResolvesGitHubVersionPortably(t *testing.T) {
 		args             []string
 		wantVersion      string
 		wantPathModified bool
+		wantActivated    bool
 	}{
 		{name: "stable", wantVersion: "0.7.2"},
 		{name: "prerelease with legacy opt-out", args: []string{"--beta", "--no-modify-path"}, wantVersion: "0.8.0-beta.1"},
 		{name: "explicit path opt-in", args: []string{"--modify-path"}, wantVersion: "0.7.2", wantPathModified: true},
+		{name: "explicit owner activation", args: []string{"--activate"}, wantVersion: "0.7.2", wantActivated: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -97,6 +100,13 @@ esac
 			if strings.Contains(logText, "tag_name") {
 				t.Fatalf("raw JSON leaked into download URL:\n%s", logText)
 			}
+			activated := strings.Contains(string(output), "切换 Relay owner 到 standalone CLI")
+			if activated != tc.wantActivated {
+				t.Fatalf("owner activation = %v, want %v:\n%s", activated, tc.wantActivated, output)
+			}
+			if !tc.wantActivated && !strings.Contains(string(output), "已保留当前 Relay owner") {
+				t.Fatalf("installer did not preserve owner by default:\n%s", output)
+			}
 			zshrc, err := os.ReadFile(filepath.Join(root, ".zshrc"))
 			if tc.wantPathModified {
 				if err != nil {
@@ -109,6 +119,204 @@ esac
 				t.Fatalf("default/--no-modify-path unexpectedly touched .zshrc: %v", err)
 			}
 		})
+	}
+}
+
+func TestInstallScriptRequiresExplicitOwnerActivation(t *testing.T) {
+	t.Parallel()
+	text, err := os.ReadFile(mustAbs(t, "install.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := string(text)
+	for _, want := range []string{"--activate", "YOOOCLAW_ACTIVATE_OWNER", "stop_existing_daemons", "yoooclaw owner activate cli", "已保留当前 Relay owner"} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("install.sh missing %q", want)
+		}
+	}
+}
+
+func TestInstallScriptUpdateRestoresRunningCLIOwner(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mockBin := filepath.Join(root, "mock-bin")
+	installDir := filepath.Join(root, "install-bin")
+	commandLog := filepath.Join(root, "commands.log")
+	mustMkdirAll(t, mockBin)
+	mustMkdirAll(t, installDir)
+	mustMkdirAll(t, filepath.Join(root, ".yoooclaw", "profiles", "default"))
+
+	writeExecutable(t, filepath.Join(mockBin, "uname"), `#!/bin/sh
+case "$1" in
+  -s) printf 'Darwin\n' ;;
+  -m) printf 'arm64\n' ;;
+  *) exit 2 ;;
+esac
+`)
+	writeExecutable(t, filepath.Join(installDir, "yoooclaw"), `#!/bin/sh
+printf 'old:%s\n' "$*" >> "$COMMAND_LOG"
+case "$*" in
+  *'daemon status'*) exit 0 ;;
+  *'daemon stop'*) exit 0 ;;
+esac
+printf '0.7.3\n'
+`)
+	writeExecutable(t, filepath.Join(mockBin, "curl"), `#!/bin/sh
+case "$*" in
+  *api.github.com*)
+    printf '%s\n' '[{"tag_name":"cli-v0.8.1"}]'
+    ;;
+  *checksums.txt*)
+    exit 22
+    ;;
+  *)
+    destination=''
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = '-o' ]; then
+        destination=$2
+        shift 2
+      else
+        shift
+      fi
+    done
+    {
+      printf '%s\n' '#!/bin/sh'
+      printf '%s\n' 'printf '\''new:%s\n'\'' "$*" >> "$COMMAND_LOG"'
+      printf '%s\n' 'printf '\''0.8.1\n'\'''
+    } > "$destination"
+    ;;
+esac
+`)
+
+	cmd := exec.Command("sh", mustAbs(t, "install.sh"), "--dir", installDir, "--force")
+	cmd.Env = append(os.Environ(),
+		"HOME="+root,
+		"SHELL=/bin/zsh",
+		"COMMAND_LOG="+commandLog,
+		"PATH="+mockBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("install.sh update failed: %v\n%s", err, output)
+	}
+	logBytes, err := os.ReadFile(commandLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logText := string(logBytes)
+	for _, want := range []string{
+		"old:--profile default daemon status",
+		"old:--profile default daemon stop",
+		"new:--profile default daemon start",
+	} {
+		if !strings.Contains(logText, want) {
+			t.Fatalf("update did not preserve CLI owner (%q missing):\n%s", want, logText)
+		}
+	}
+	if strings.Contains(logText, "owner activate cli") {
+		t.Fatalf("normal update unexpectedly switched owner:\n%s", logText)
+	}
+}
+
+func TestNpmPackagePreservesOwnerUnlessExplicitlyActivated(t *testing.T) {
+	t.Parallel()
+	gen, err := os.ReadFile(mustAbs(t, "gen-pkg.mjs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	activation, err := os.ReadFile(mustAbs(t, filepath.Join("..", "npm", "cli", "bin", "activate-owner.js")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(gen), `preinstall: "node bin/prepare-owner.js"`) {
+		t.Fatal("npm package has no daemon drain preinstall")
+	}
+	if !strings.Contains(string(gen), `postinstall: "node bin/activate-owner.js"`) {
+		t.Fatal("npm package has no owner activation postinstall")
+	}
+	if !strings.Contains(string(activation), `"owner", "activate", "cli"`) {
+		t.Fatal("npm postinstall does not activate CLI owner")
+	}
+	for _, want := range []string{"YOOOCLAW_ACTIVATE_OWNER", "runningProfiles", "current Relay owner preserved"} {
+		if !strings.Contains(string(activation), want) {
+			t.Fatalf("npm postinstall missing owner-preservation marker %q", want)
+		}
+	}
+}
+
+func TestNpmLifecycleRestoresRunningCLIOwnerWithoutSwitching(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is covered by the compiled Windows owner-lock tests")
+	}
+
+	root := t.TempDir()
+	profileDir := filepath.Join(root, "profiles", "default")
+	nodeModules := filepath.Join(root, "node_modules")
+	commandLog := filepath.Join(root, "commands.log")
+	mustMkdirAll(t, profileDir)
+
+	oldCLI := filepath.Join(root, "old-yoooclaw")
+	writeExecutable(t, oldCLI, `#!/bin/sh
+printf 'old:%s\n' "$*" >> "$COMMAND_LOG"
+case "$*" in
+  *'daemon status'*) exit 0 ;;
+  *'daemon stop'*) exit 0 ;;
+esac
+exit 1
+`)
+	if err := os.WriteFile(
+		filepath.Join(profileDir, "daemon.lock"),
+		[]byte(`{"pid":123,"executable":"`+oldCLI+`"}`),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	npmOS := runtime.GOOS
+	npmCPU := runtime.GOARCH
+	if npmCPU == "amd64" {
+		npmCPU = "x64"
+	}
+	nativeCLI := filepath.Join(nodeModules, "@yoooclaw", "cli-"+npmOS+"-"+npmCPU, "bin", "yc")
+	mustMkdirAll(t, filepath.Dir(nativeCLI))
+	writeExecutable(t, nativeCLI, `#!/bin/sh
+printf 'new:%s\n' "$*" >> "$COMMAND_LOG"
+exit 0
+`)
+
+	env := append(os.Environ(),
+		"YOOOCLAW_HOME="+root,
+		"NODE_PATH="+nodeModules,
+		"COMMAND_LOG="+commandLog,
+	)
+	for _, script := range []string{
+		filepath.Join("..", "npm", "cli", "bin", "prepare-owner.js"),
+		filepath.Join("..", "npm", "cli", "bin", "activate-owner.js"),
+	} {
+		cmd := exec.Command("node", mustAbs(t, script))
+		cmd.Env = env
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%s failed: %v\n%s", script, err, output)
+		}
+	}
+
+	logBytes, err := os.ReadFile(commandLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logText := string(logBytes)
+	for _, want := range []string{
+		"old:--profile default daemon status",
+		"old:--profile default daemon stop",
+		"new:--profile default daemon start",
+	} {
+		if !strings.Contains(logText, want) {
+			t.Fatalf("npm lifecycle did not restore CLI owner (%q missing):\n%s", want, logText)
+		}
+	}
+	if strings.Contains(logText, "owner activate cli") {
+		t.Fatalf("npm update unexpectedly switched owner:\n%s", logText)
 	}
 }
 


### PR DESCRIPTION
## 问题背景

Hermes 插件与 standalone CLI 共用同一个 `YOOOCLAW_HOME` 时，同一时刻只能有一个 Relay consumer。此前存在两类问题：

- Windows 的 writer lock 检测与 Hermes 插件不一致，可能把仍在使用的存储误判为可接管。
- CLI 安装/升级与 Hermes owner 切换缺少统一入口，容易出现二次连接、锁未释放或安装成功但实际未接入的状态。

## 本次修改

- 对齐 Windows writer lock 与 Hermes 插件的文件锁语义，并补充跨平台锁状态检查。
- 新增 `yoooclaw owner activate cli`，统一完成：停止旧 standalone daemon、停用 Hermes 的 YoooClaw 插件、按需重启 Gateway、等待 writer/Relay 锁释放、启动 CLI daemon。
- 原生安装器和 npm 安装流程默认保留当前 Relay owner；只有显式激活时才切换到 CLI。
- 安装/升级 CLI owner 时记录并恢复原来运行的 profile，失败时明确返回原因，避免静默假成功。
- 补充安装器、owner 交接和 Windows writer lock 测试。

## 验证

- `go test ./...`
- `go vet ./...`
- Node 脚本语法检查
- 五个平台构建验证通过
- 本机已实际验证 Hermes → CLI 交接，CLI daemon 成功持有 Relay 并连接生产环境。