### PR TITLE
fix(light): 补齐 send 命令的上屏文案参数

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -3,11 +3,18 @@ package cli
 import (
 	"encoding/json"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 // execCLI 在隔离沙箱里执行一次 CLI（捕获 os.Stdout 与退出码）。
 // 因为 run() 直接写 os.Stdout 且 exitCode 是包级变量，这些测试不可并行。
@@ -161,6 +168,45 @@ func TestLightSendValidation(t *testing.T) {
 	}
 	if decode(t, out)["error"].(map[string]any)["code"] != "YOOOCLAW_INVALID_ARGUMENT" {
 		t.Errorf("expected INVALID_ARGUMENT: %s", out)
+	}
+}
+
+func TestLightSendForwardsTitleAndReason(t *testing.T) {
+	sandbox(t)
+	var requestBody map[string]any
+	originalTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if err := json.NewDecoder(req.Body).Decode(&requestBody); err != nil {
+			t.Fatalf("decode light request: %v", err)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body: io.NopCloser(strings.NewReader(
+				`{"code":"000000","msg":"成功","data":{"success":true}}`,
+			)),
+			Request: req,
+		}, nil
+	})
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	out, code := execCLI(t,
+		"light", "send",
+		"--preset", "red-strobe-3",
+		"--title", "测试灯效",
+		"--reason", "插件一次性亮灯",
+	)
+	if code != 0 {
+		t.Fatalf("light send failed (code %d): %s", code, out)
+	}
+	if got := requestBody["title"]; got != "测试灯效" {
+		t.Errorf("title = %v, want 测试灯效", got)
+	}
+	if got := requestBody["reason"]; got != "插件一次性亮灯" {
+		t.Errorf("reason = %v, want 插件一次性亮灯", got)
+	}
+	if _, ok := requestBody["idempotencyKey"]; ok {
+		t.Errorf("light send must not send the undeployed idempotencyKey contract: %+v", requestBody)
 	}
 }
 

--- a/internal/cli/cmd_light.go
+++ b/internal/cli/cmd_light.go
@@ -30,6 +30,8 @@ func newLightCmd() *cobra.Command {
 	send.Flags().String("segments", "", "灯效参数 JSON（原始段）")
 	send.Flags().String("preset", "", "内置预设 id（如 red-steady / red-strobe-3）")
 	send.Flags().String("rule", "", "已保存的 lightrule 名")
+	send.Flags().String("title", "", "推送标题（可选；未传时根据 reason 或灯效生成）")
+	send.Flags().String("reason", "", "亮灯原因/通知正文（可选）")
 	send.Flags().Bool("repeat", false, "无限循环播放（覆盖来源默认值）")
 	send.Flags().String("repeat-times", "", "整条组合重复次数（0=无限，覆盖来源默认值）")
 
@@ -69,6 +71,12 @@ func lightSend(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error)
 		if !flagBool(cmd, "repeat") && flagStr(cmd, "repeat-times") == "" {
 			body["repeat_times"] = resolved["repeat_times"]
 		}
+	}
+	if title := flagStr(cmd, "title"); title != "" {
+		body["title"] = title
+	}
+	if reason := flagStr(cmd, "reason"); reason != "" {
+		body["reason"] = reason
 	}
 	if flagBool(cmd, "repeat") {
 		body["repeat"] = true


### PR DESCRIPTION
## 背景

为配合 COne Pro 的通知上屏需求，一次性灯效除了结构化灯效参数，还需要携带推送标题和亮灯原因。底层 light gateway、sender 和 yclib 已经支持 title/reason，但公开的 `yc light send` 命令没有对应选项，导致 CLI skill 或用户直接调用时只能生成 `Effect: <mode>` 这类默认文案，无法传递上下文相关的通知内容。

## 修改内容

- 为 `yc light send` 增加 `--title`，用于传递推送标题。
- 为 `yc light send` 增加 `--reason`，用于传递亮灯原因和通知正文。
- 仅在参数非空时写入下发请求，未传参数时继续沿用现有默认标题和原因兜底行为。
- 增加命令级回归测试，拦截实际 HTTP 请求并验证 title/reason 已进入请求 JSON。

## 影响范围

- 原有 `--segments`、`--preset`、`--rule`、`--repeat` 和 `--repeat-times` 行为保持不变。
- 旧版 skill 不传新参数时仍可正常下发灯效，只是继续使用默认文案。
- 新版 skill 和用户可以显式提供适合 COne Pro 展示的上下文文案。

## 验证

- `go test ./...`
- `go build ./cmd/yc`
- 本机验证 `yc light send --help` 已展示 `--title` 和 `--reason`。