### PR TITLE
cli-0.9.0-beta.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,30 @@ yoooclaw auth token-rotate
 yoooclaw daemon restart
 ```
 
+## Daemon autostart
+
+Initializing the active profile enables per-user login autostart by default
+(launchd on macOS, systemd user services on Linux, and Task Scheduler on
+Windows) and starts the daemon immediately. It never requires a system service
+or administrator privileges.
+
+```bash
+yoooclaw daemon autostart status
+yoooclaw daemon stop                 # stop for this login; autostart stays enabled
+yoooclaw daemon start                # start now; does not change the saved preference
+yoooclaw daemon autostart disable    # stop now and opt out of future login starts
+yoooclaw daemon autostart enable     # opt in and start now
+yoooclaw daemon logs --supervisor    # inspect OS service startup failures
+
+yoooclaw config init --no-start      # enable autostart, but do not start now
+yoooclaw config init --no-autostart  # start now without enabling autostart
+```
+
+Autostart always follows the active profile. `profile use` transfers a running
+daemon to the new profile while preserving a manually stopped state. On Linux,
+autostart begins with the user service manager; enabling pre-login boot via
+`loginctl enable-linger` remains an explicit system-administration choice.
+
 ## Daemon lifecycle protocol
 
 `yoooclaw daemon` exposes lifecycle metadata so external orchestrators such as

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -184,6 +184,28 @@ yoooclaw auth token-rotate
 yoooclaw daemon restart
 ```
 
+## Daemon 开机自启
+
+初始化 active profile 时，默认注册用户登录自启并立即启动 daemon：macOS 使用
+launchd，Linux 使用 systemd user service，Windows 使用计划任务。整个流程不安装
+系统级服务，也不需要管理员权限。
+
+```bash
+yoooclaw daemon autostart status
+yoooclaw daemon stop                 # 只停止本次登录，自启保持开启
+yoooclaw daemon start                # 立即启动，不改变自启偏好
+yoooclaw daemon autostart disable    # 立即停止，并关闭以后登录自启
+yoooclaw daemon autostart enable     # 开启自启并立即启动
+yoooclaw daemon logs --supervisor    # 查看系统服务启动失败日志
+
+yoooclaw config init --no-start      # 开启自启，但当前不启动
+yoooclaw config init --no-autostart  # 当前启动，但不开启自启
+```
+
+自启服务始终跟随 active profile；`profile use` 会在 profile 间转移正在运行的
+daemon，但会保留用户手动 stop 后的停止状态。Linux 默认随用户服务管理器启动；是否
+通过 `loginctl enable-linger` 扩展为登录前启动，仍由系统管理员显式决定。
+
 ## Daemon lifecycle protocol
 
 `yoooclaw daemon` exposes lifecycle metadata so external orchestrators such as

--- a/docs/design/ingress-layering.md
+++ b/docs/design/ingress-layering.md
@@ -128,7 +128,7 @@ L1/L2 几乎不动，主要是把传输从 server 里抽出去：
 
 待办（hermes-plugin 侧，见第 6 节第 5 项）：`DaemonSupervisor` spawn 传 `--ingress=proxied` + egress 回调；provision `hermes` api-key；app_transport 入站改为 POST cli ingest API、订阅 egress 回调转发。
 
-> 注意：`config init` 收尾会自动 `Spawn` 一个 **standalone** daemon（`startDaemonForInit`）。嵌入流程里插件应在 init 后先 `daemon stop`，再以 `--ingress=proxied` 拉起，避免起到 standalone 实例。
+> 注意：`config init` 默认会注册用户级自启服务并启动一个 **standalone** daemon。嵌入流程应使用 `--no-autostart` 初始化，或在 init 后执行 `daemon autostart disable`，再以 `--ingress=proxied` 拉起，避免 standalone 服务与宿主实例竞争。
 
 ## 7. 兼容与迁移
 

--- a/docs/design/ingress-layering.md
+++ b/docs/design/ingress-layering.md
@@ -50,6 +50,7 @@
   ```go
   type Egress interface {
       PushEvent(event string, payload any) error
+      PushEventTo(label string, event string, payload any) error
   }
   ```
   实现：`RelayEgress`（走隧道，= 现状）、`ProxyEgress`（POST 到 host 回调 URL）、`NoopEgress`（落盘即止）。
@@ -87,9 +88,11 @@ POST http://127.0.0.1:<port>/images
 
 `clientLabel` 由 api-key 映射得到（server.go `labelForAPIKey`），用于多租户区分，无需新协议。
 
+读取侧按同一个 label 隔离：能确指客户端的鉴权方式（Relay 隧道、api-key）只看得到自己写入的数据，本机 loopback 与宿主 gateway token 看全量（`authResult.scope()`）。判定集中在 `internal/clientlabel`：label 为空 / `default` / `legacy` 的条目属于「来源不明的历史数据」，对所有客户端可见——0.9.0 之前入库的存量数据几乎全是这一类，严格隔离会让它们从手机端整片消失。
+
 ### 5.2 出站：cli → 插件（回事件）
 
-已采用 **回调 webhook**（与入站对称）：daemon 启动时由 `--egress-callback-url` + `--egress-callback-token`（或 `config.ingress.egressCallback`）拿到 host 回调地址；`ProxyEgress.PushEvent` 即 `POST callbackUrl {event, payload}`（带 `Authorization: Bearer <token>`）。插件收到后用自己的 app_transport relay 转发给手机。未配置回调时退化为 `NoopEgress`（出站丢弃，仅告警）。
+已采用 **回调 webhook**（与入站对称）：daemon 启动时由 `--egress-callback-url` + `--egress-callback-token`（或 `config.ingress.egressCallback`）拿到 host 回调地址；`ProxyEgress.PushEvent` 即 `POST callbackUrl {event, payload}`（带 `Authorization: Bearer <token>`）；定向事件多带一个 `clientLabel`，由宿主按 label 转发给对应手机，缺省字段即广播。插件收到后用自己的 app_transport relay 转发给手机。未配置回调时退化为 `NoopEgress`（出站丢弃，仅告警）。
 
 > 备选未采用：拉取队列 `GET /egress/events`（SSE / long-poll）。无需 host 开端口，但插件要常驻订阅循环；如宿主不便监听端口可再切换。
 
@@ -121,7 +124,7 @@ L1/L2 几乎不动，主要是把传输从 server 里抽出去：
 - `config.IngressSection`（`ingress.mode` + `ingress.egressCallback{url,token}`，默认 `standalone`）。
 - `daemon.Egress` 端口 + `RelayEgress` / `ProxyEgress` / `NoopEgress`（`internal/daemon/egress.go`）。
 - `RunForeground` 按模式装配：`proxied` 跳过 Supervisor 并强制要求 api-key（否则 `YOOOCLAW_UNAUTHORIZED`）、装配 `ProxyEgress`；`direct` 跳过 Supervisor + `NoopEgress`；`standalone` 维持原 Relay 行为。`/daemon/reload` 仅在 `standalone` 重建隧道。
-- `recording.status` 出站改走 `s.egress.PushEvent`（`server_ingest.go`）。
+- `recording.status` 出站改走 `s.egress.PushEventTo`（`server_ingest.go`）：只回给这条录音的来源客户端，来源不明的历史录音仍旧广播。
 - `daemon run-foreground|start|restart` 新增 `--ingress` / `--egress-callback-url` / `--egress-callback-token`，经 `Spawn` 透传给 detach 子进程。
 - `/daemon/status` 新增 `ingressMode` 字段。
 - 单测 `internal/daemon/egress_test.go`；三模式手工冒烟通过。

--- a/internal/autostart/autostart.go
+++ b/internal/autostart/autostart.go
@@ -1,0 +1,197 @@
+// Package autostart manages the per-user OS service that supervises the
+// standalone daemon. The desired state is account-scoped because only the
+// active profile may consume the account Relay at a time.
+package autostart
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/YoooClaw/cli/internal/fsutil"
+)
+
+const (
+	DesiredEnabled  = "enabled"
+	DesiredDisabled = "disabled"
+)
+
+// Spec describes the command installed into the native service manager.
+type Spec struct {
+	RootDir       string
+	Executable    string
+	Arguments     []string
+	SupervisorLog string
+}
+
+// Status is the normalized state returned by every platform manager.
+type Status struct {
+	Manager    string `json:"manager"`
+	Unit       string `json:"unit"`
+	Installed  bool   `json:"installed"`
+	Loaded     bool   `json:"loaded"`
+	Running    bool   `json:"running"`
+	PID        int    `json:"pid,omitempty"`
+	Executable string `json:"executable,omitempty"`
+}
+
+// State records user intent independently of transient OS service state.
+type State struct {
+	Version    int    `json:"version"`
+	Desired    string `json:"desired"`
+	Manager    string `json:"manager,omitempty"`
+	Unit       string `json:"unit,omitempty"`
+	Executable string `json:"executable,omitempty"`
+}
+
+// Manager abstracts launchd, systemd --user and Windows Task Scheduler.
+type Manager interface {
+	Available() error
+	Status() (Status, error)
+	Install(Spec) error
+	Start() error
+	Stop() error
+	Restart() error
+	Uninstall() error
+}
+
+// StatePath is intentionally outside profile directories.
+func StatePath(root string) string { return filepath.Join(root, "autostart.json") }
+
+func ReadState(root string) (State, bool, error) {
+	var state State
+	exists, err := fsutil.ReadJSON(StatePath(root), &state)
+	return state, exists, err
+}
+
+func writeState(root string, state State) error {
+	state.Version = 1
+	return fsutil.WriteJSON(StatePath(root), state, fsutil.ConfigFileMode)
+}
+
+// Enable installs the service, persists intent, and optionally starts it now.
+func Enable(m Manager, spec Spec, start bool) (Status, error) {
+	if err := m.Available(); err != nil {
+		return Status{}, err
+	}
+	if err := m.Install(spec); err != nil {
+		return Status{}, err
+	}
+	status, err := m.Status()
+	if err != nil {
+		return Status{}, err
+	}
+	if err := writeState(spec.RootDir, State{
+		Desired: DesiredEnabled, Manager: status.Manager, Unit: status.Unit, Executable: spec.Executable,
+	}); err != nil {
+		return Status{}, err
+	}
+	if start {
+		if err := m.Start(); err != nil {
+			return Status{}, err
+		}
+		status, err = m.Status()
+	}
+	return status, err
+}
+
+// Disable stops and removes the service, then persists the explicit opt-out.
+func Disable(m Manager, root string) (Status, error) {
+	if err := m.Available(); err != nil {
+		status, _ := m.Status()
+		if status.Installed || status.Loaded {
+			if stopErr := m.Stop(); stopErr != nil {
+				return status, stopErr
+			}
+			if uninstallErr := m.Uninstall(); uninstallErr != nil {
+				return status, uninstallErr
+			}
+		}
+		if stateErr := writeState(root, State{Desired: DesiredDisabled, Manager: status.Manager, Unit: status.Unit}); stateErr != nil {
+			return status, stateErr
+		}
+		return status, nil
+	}
+	before, _ := m.Status()
+	if err := m.Stop(); err != nil && before.Installed {
+		return before, err
+	}
+	if err := m.Uninstall(); err != nil {
+		return before, err
+	}
+	if err := writeState(root, State{Desired: DesiredDisabled, Manager: before.Manager, Unit: before.Unit}); err != nil {
+		return before, err
+	}
+	after, err := m.Status()
+	return after, err
+}
+
+// Desired returns explicit user intent. Missing state is "unknown", allowing
+// migration code to distinguish an old install from an explicit opt-out.
+func Desired(root string) (string, error) {
+	state, exists, err := ReadState(root)
+	if err != nil || !exists {
+		return "", err
+	}
+	return state.Desired, nil
+}
+
+// RecordDisabled persists an explicit opt-out even when the current platform
+// cannot provide a service manager (for example, a container without systemd).
+func RecordDisabled(root string) error {
+	return writeState(root, State{Desired: DesiredDisabled})
+}
+
+// ServiceID uses a stable conventional name for the default root and a short
+// hash for explicitly isolated YOOOCLAW_HOME instances.
+func ServiceID(root string) string {
+	root = filepath.Clean(root)
+	defaultRoot := defaultRootDir()
+	if samePath(root, defaultRoot) {
+		return "yoooclaw-daemon"
+	}
+	sum := sha256.Sum256([]byte(root))
+	return "yoooclaw-daemon-" + hex.EncodeToString(sum[:])[:10]
+}
+
+func samePath(a, b string) bool {
+	aAbs, _ := filepath.Abs(a)
+	bAbs, _ := filepath.Abs(b)
+	return filepath.Clean(aAbs) == filepath.Clean(bAbs)
+}
+
+func defaultRootDir() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".yoooclaw")
+}
+
+// ResolveSpec captures only the runtime root. Shell/session configuration and
+// credentials are deliberately not copied into the service definition.
+func ResolveSpec(root string) (Spec, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return Spec{}, err
+	}
+	exe, err = filepath.Abs(exe)
+	if err != nil {
+		return Spec{}, err
+	}
+	return Spec{
+		RootDir:       filepath.Clean(root),
+		Executable:    exe,
+		Arguments:     []string{"daemon", "run-service", "--root", filepath.Clean(root)},
+		SupervisorLog: filepath.Join(root, "logs", "daemon-supervisor.log"),
+	}, nil
+}
+
+func Current(root string) Manager {
+	if dir := strings.TrimSpace(os.Getenv("YOOOCLAW_AUTOSTART_TEST_DIR")); dir != "" {
+		return newFileManager(root, dir)
+	}
+	return newPlatformManager(root)
+}
+
+var ErrUnavailable = errors.New("当前环境没有可用的用户级服务管理器")

--- a/internal/autostart/autostart_test.go
+++ b/internal/autostart/autostart_test.go
@@ -1,0 +1,55 @@
+package autostart
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestEnableDisablePersistsIntent(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "root")
+	services := filepath.Join(t.TempDir(), "services")
+	m := newFileManager(root, services)
+	spec := Spec{RootDir: root, Executable: "/tmp/yoooclaw", Arguments: []string{"daemon", "run-service"}}
+
+	status, err := Enable(m, spec, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !status.Installed || status.Running {
+		t.Fatalf("unexpected enabled status: %+v", status)
+	}
+	if desired, err := Desired(root); err != nil || desired != DesiredEnabled {
+		t.Fatalf("desired = %q, err=%v", desired, err)
+	}
+
+	status, err = Disable(m, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Installed || status.Running {
+		t.Fatalf("unexpected disabled status: %+v", status)
+	}
+	if desired, err := Desired(root); err != nil || desired != DesiredDisabled {
+		t.Fatalf("desired = %q, err=%v", desired, err)
+	}
+}
+
+func TestResolveSpecCarriesExplicitRoot(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "isolated root")
+	spec, err := ResolveSpec(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"daemon", "run-service", "--root", filepath.Clean(root)}
+	if len(spec.Arguments) != len(want) {
+		t.Fatalf("arguments = %#v", spec.Arguments)
+	}
+	for i := range want {
+		if spec.Arguments[i] != want[i] {
+			t.Fatalf("arguments = %#v", spec.Arguments)
+		}
+	}
+	if spec.SupervisorLog != filepath.Join(root, "logs", "daemon-supervisor.log") {
+		t.Fatalf("supervisor log = %q", spec.SupervisorLog)
+	}
+}

--- a/internal/autostart/file_manager.go
+++ b/internal/autostart/file_manager.go
@@ -1,0 +1,71 @@
+package autostart
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/YoooClaw/cli/internal/fsutil"
+)
+
+// fileManager is a deterministic service-manager substitute used by CLI tests.
+// It is selected only through YOOOCLAW_AUTOSTART_TEST_DIR.
+type fileManager struct {
+	root string
+	dir  string
+	id   string
+}
+
+type fileManagerState struct {
+	Installed  bool   `json:"installed"`
+	Running    bool   `json:"running"`
+	Executable string `json:"executable,omitempty"`
+}
+
+func newFileManager(root, dir string) Manager {
+	return &fileManager{root: root, dir: dir, id: ServiceID(root)}
+}
+
+func (m *fileManager) path() string     { return filepath.Join(m.dir, m.id+".json") }
+func (m *fileManager) Available() error { return nil }
+func (m *fileManager) read() fileManagerState {
+	var state fileManagerState
+	raw, err := os.ReadFile(m.path())
+	if err == nil {
+		_ = json.Unmarshal(raw, &state)
+	}
+	return state
+}
+func (m *fileManager) write(state fileManagerState) error {
+	return fsutil.WriteJSON(m.path(), state, fsutil.ConfigFileMode)
+}
+func (m *fileManager) Status() (Status, error) {
+	state := m.read()
+	return Status{Manager: "test", Unit: m.id, Installed: state.Installed, Loaded: state.Running, Running: state.Running, Executable: state.Executable}, nil
+}
+func (m *fileManager) Install(spec Spec) error {
+	state := m.read()
+	state.Installed = true
+	state.Executable = spec.Executable
+	return m.write(state)
+}
+func (m *fileManager) Start() error {
+	state := m.read()
+	state.Installed, state.Running = true, true
+	return m.write(state)
+}
+func (m *fileManager) Stop() error {
+	state := m.read()
+	state.Running = false
+	if !state.Installed {
+		return nil
+	}
+	return m.write(state)
+}
+func (m *fileManager) Restart() error { return m.Start() }
+func (m *fileManager) Uninstall() error {
+	if err := os.Remove(m.path()); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/internal/autostart/manager_darwin.go
+++ b/internal/autostart/manager_darwin.go
@@ -1,0 +1,131 @@
+//go:build darwin
+
+package autostart
+
+import (
+	"fmt"
+	"html"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/YoooClaw/cli/internal/fsutil"
+)
+
+type platformManager struct {
+	root  string
+	id    string
+	label string
+	plist string
+}
+
+func newPlatformManager(root string) Manager {
+	id := ServiceID(root)
+	label := "com.yoooclaw." + strings.TrimPrefix(id, "yoooclaw-")
+	home, _ := os.UserHomeDir()
+	return &platformManager{root: root, id: id, label: label, plist: filepath.Join(home, "Library", "LaunchAgents", label+".plist")}
+}
+
+func (m *platformManager) domain() string { return "gui/" + strconv.Itoa(os.Getuid()) }
+func (m *platformManager) target() string { return m.domain() + "/" + m.label }
+func (m *platformManager) Available() error {
+	if _, err := exec.LookPath("launchctl"); err != nil {
+		return fmt.Errorf("%w: launchctl 不可用", ErrUnavailable)
+	}
+	return nil
+}
+func (m *platformManager) Status() (Status, error) {
+	status := Status{Manager: "launchd", Unit: m.label}
+	if _, err := os.Stat(m.plist); err == nil {
+		status.Installed = true
+	}
+	out, err := exec.Command("launchctl", "print", m.target()).CombinedOutput()
+	if err != nil {
+		return status, nil
+	}
+	status.Loaded = true
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "state = ") {
+			status.Running = strings.TrimSpace(strings.TrimPrefix(line, "state = ")) == "running"
+		}
+		if strings.HasPrefix(line, "pid = ") {
+			status.PID, _ = strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(line, "pid = ")))
+		}
+	}
+	return status, nil
+}
+func plistXML(label string, spec Spec) string {
+	args := append([]string{spec.Executable}, spec.Arguments...)
+	var argXML strings.Builder
+	for _, arg := range args {
+		argXML.WriteString("    <string>" + html.EscapeString(arg) + "</string>\n")
+	}
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>` + html.EscapeString(label) + `</string>
+  <key>ProgramArguments</key>
+  <array>
+` + argXML.String() + `  </array>
+  <key>EnvironmentVariables</key>
+  <dict><key>YOOOCLAW_HOME</key><string>` + html.EscapeString(spec.RootDir) + `</string></dict>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><dict><key>SuccessfulExit</key><false/></dict>
+  <key>ProcessType</key><string>Background</string>
+  <key>ThrottleInterval</key><integer>5</integer>
+  <key>StandardOutPath</key><string>` + html.EscapeString(spec.SupervisorLog) + `</string>
+  <key>StandardErrorPath</key><string>` + html.EscapeString(spec.SupervisorLog) + `</string>
+</dict>
+</plist>
+`
+}
+func (m *platformManager) Install(spec Spec) error {
+	if err := fsutil.EnsureDir(filepath.Dir(spec.SupervisorLog), fsutil.DirMode); err != nil {
+		return err
+	}
+	return fsutil.WriteAtomic(m.plist, []byte(plistXML(m.label, spec)), fsutil.ConfigFileMode)
+}
+func (m *platformManager) Start() error {
+	status, _ := m.Status()
+	if !status.Loaded {
+		if out, err := exec.Command("launchctl", "bootstrap", m.domain(), m.plist).CombinedOutput(); err != nil {
+			return fmt.Errorf("launchctl bootstrap 失败: %s", strings.TrimSpace(string(out)))
+		}
+		return nil
+	}
+	out, err := exec.Command("launchctl", "kickstart", "-k", m.target()).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("launchctl kickstart 失败: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+func (m *platformManager) Stop() error {
+	status, _ := m.Status()
+	if !status.Loaded {
+		return nil
+	}
+	out, err := exec.Command("launchctl", "bootout", m.target()).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("launchctl bootout 失败: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+func (m *platformManager) Restart() error {
+	if err := m.Stop(); err != nil {
+		return err
+	}
+	return m.Start()
+}
+func (m *platformManager) Uninstall() error {
+	if err := m.Stop(); err != nil {
+		return err
+	}
+	if err := os.Remove(m.plist); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/internal/autostart/manager_darwin_test.go
+++ b/internal/autostart/manager_darwin_test.go
@@ -1,0 +1,31 @@
+//go:build darwin
+
+package autostart
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPlistUsesArgumentArrayAndEscapesValues(t *testing.T) {
+	spec := Spec{
+		RootDir:       "/tmp/root & profile",
+		Executable:    "/tmp/Yooo Claw/yoooclaw",
+		Arguments:     []string{"daemon", "run-service", "--root", "/tmp/root & profile"},
+		SupervisorLog: "/tmp/root & profile/logs/supervisor.log",
+	}
+	xml := plistXML("com.yoooclaw.test", spec)
+	for _, want := range []string{
+		"<key>ProgramArguments</key>",
+		"<string>/tmp/Yooo Claw/yoooclaw</string>",
+		"<string>/tmp/root &amp; profile</string>",
+		"<key>SuccessfulExit</key><false/>",
+	} {
+		if !strings.Contains(xml, want) {
+			t.Fatalf("plist missing %q:\n%s", want, xml)
+		}
+	}
+	if strings.Contains(xml, "sh -c") {
+		t.Fatal("plist must not execute through a shell")
+	}
+}

--- a/internal/autostart/manager_linux.go
+++ b/internal/autostart/manager_linux.go
@@ -1,0 +1,136 @@
+//go:build linux
+
+package autostart
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/YoooClaw/cli/internal/fsutil"
+)
+
+type platformManager struct{ root, id, unit, path string }
+
+func newPlatformManager(root string) Manager {
+	id := ServiceID(root)
+	configHome := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME"))
+	if configHome == "" {
+		home, _ := os.UserHomeDir()
+		configHome = filepath.Join(home, ".config")
+	}
+	unit := id + ".service"
+	return &platformManager{root: root, id: id, unit: unit, path: filepath.Join(configHome, "systemd", "user", unit)}
+}
+func systemctl(args ...string) ([]byte, error) {
+	return exec.Command("systemctl", append([]string{"--user"}, args...)...).CombinedOutput()
+}
+func (m *platformManager) Available() error {
+	if _, err := exec.LookPath("systemctl"); err != nil {
+		return fmt.Errorf("%w: systemctl 不可用", ErrUnavailable)
+	}
+	if out, err := systemctl("show-environment"); err != nil {
+		return fmt.Errorf("%w: systemd user manager 不可用: %s", ErrUnavailable, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+func (m *platformManager) Status() (Status, error) {
+	status := Status{Manager: "systemd", Unit: m.unit}
+	if _, err := os.Stat(m.path); err == nil {
+		status.Installed = true
+	}
+	out, err := systemctl("show", m.unit, "--property=LoadState,ActiveState,MainPID", "--value")
+	if err != nil {
+		return status, nil
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	for _, value := range lines {
+		value = strings.TrimSpace(value)
+		switch value {
+		case "loaded":
+			status.Loaded = true
+		case "active", "activating", "reloading":
+			status.Running = true
+		default:
+			if pid, e := strconv.Atoi(value); e == nil && pid > 0 {
+				status.PID = pid
+			}
+		}
+	}
+	return status, nil
+}
+func systemdQuote(value string) string {
+	// systemd expands % specifiers even inside quotes; doubling prevents paths
+	// supplied through YOOOCLAW_HOME from being interpreted as unit specifiers.
+	return strconv.Quote(strings.ReplaceAll(value, "%", "%%"))
+}
+func unitText(spec Spec) string {
+	args := []string{systemdQuote(spec.Executable)}
+	for _, arg := range spec.Arguments {
+		args = append(args, systemdQuote(arg))
+	}
+	return `[Unit]
+Description=YoooClaw daemon
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+[Service]
+Type=simple
+Environment=` + systemdQuote("YOOOCLAW_HOME="+spec.RootDir) + `
+ExecStart=` + strings.Join(args, " ") + `
+Restart=on-failure
+RestartSec=5
+StandardOutput=` + systemdQuote("append:"+spec.SupervisorLog) + `
+StandardError=` + systemdQuote("append:"+spec.SupervisorLog) + `
+
+[Install]
+WantedBy=default.target
+`
+}
+func (m *platformManager) Install(spec Spec) error {
+	if err := fsutil.EnsureDir(filepath.Dir(spec.SupervisorLog), fsutil.DirMode); err != nil {
+		return err
+	}
+	if err := fsutil.WriteAtomic(m.path, []byte(unitText(spec)), fsutil.ConfigFileMode); err != nil {
+		return err
+	}
+	if out, err := systemctl("daemon-reload"); err != nil {
+		return fmt.Errorf("systemctl daemon-reload 失败: %s", strings.TrimSpace(string(out)))
+	}
+	if out, err := systemctl("enable", m.unit); err != nil {
+		return fmt.Errorf("systemctl enable 失败: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+func (m *platformManager) Start() error {
+	out, err := systemctl("start", m.unit)
+	if err != nil {
+		return fmt.Errorf("systemctl start 失败: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+func (m *platformManager) Stop() error {
+	out, err := systemctl("stop", m.unit)
+	if err != nil && !strings.Contains(string(out), "not loaded") {
+		return fmt.Errorf("systemctl stop 失败: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+func (m *platformManager) Restart() error {
+	out, err := systemctl("restart", m.unit)
+	if err != nil {
+		return fmt.Errorf("systemctl restart 失败: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+func (m *platformManager) Uninstall() error {
+	_, _ = systemctl("disable", m.unit)
+	if err := os.Remove(m.path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	_, _ = systemctl("daemon-reload")
+	return nil
+}

--- a/internal/autostart/manager_other.go
+++ b/internal/autostart/manager_other.go
@@ -1,0 +1,16 @@
+//go:build !darwin && !linux && !windows
+
+package autostart
+
+type unsupportedManager struct{ root string }
+
+func newPlatformManager(root string) Manager   { return &unsupportedManager{root: root} }
+func (m *unsupportedManager) Available() error { return ErrUnavailable }
+func (m *unsupportedManager) Status() (Status, error) {
+	return Status{Manager: "unsupported", Unit: ServiceID(m.root)}, nil
+}
+func (m *unsupportedManager) Install(Spec) error { return ErrUnavailable }
+func (m *unsupportedManager) Start() error       { return ErrUnavailable }
+func (m *unsupportedManager) Stop() error        { return nil }
+func (m *unsupportedManager) Restart() error     { return ErrUnavailable }
+func (m *unsupportedManager) Uninstall() error   { return nil }

--- a/internal/autostart/manager_windows.go
+++ b/internal/autostart/manager_windows.go
@@ -1,0 +1,152 @@
+//go:build windows
+
+package autostart
+
+import (
+	"bytes"
+	"encoding/csv"
+	"fmt"
+	"html"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+)
+
+type platformManager struct{ root, id, task string }
+
+func newPlatformManager(root string) Manager {
+	id := ServiceID(root)
+	return &platformManager{root: root, id: id, task: `\YoooClaw\` + id}
+}
+func (m *platformManager) Available() error {
+	if _, err := exec.LookPath("schtasks.exe"); err != nil {
+		return fmt.Errorf("%w: schtasks 不可用", ErrUnavailable)
+	}
+	return nil
+}
+func schtasks(args ...string) ([]byte, error) {
+	return exec.Command("schtasks.exe", args...).CombinedOutput()
+}
+func (m *platformManager) Status() (Status, error) {
+	status := Status{Manager: "task-scheduler", Unit: m.task}
+	out, err := schtasks("/Query", "/TN", m.task, "/FO", "LIST", "/V")
+	if err != nil {
+		return status, nil
+	}
+	status.Installed, status.Loaded = true, true
+	text := strings.ToLower(string(out))
+	status.Running = strings.Contains(text, "status:") && strings.Contains(text, "running")
+	return status, nil
+}
+func taskXML(spec Spec, userSID string) string {
+	args := make([]string, 0, len(spec.Arguments)+2)
+	for _, arg := range append(spec.Arguments, "--format", "json") {
+		args = append(args, syscall.EscapeArg(arg))
+	}
+	return `<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <Triggers><LogonTrigger><Enabled>true</Enabled></LogonTrigger></Triggers>
+  <Principals><Principal id="Author"><UserId>` + html.EscapeString(userSID) + `</UserId><LogonType>InteractiveToken</LogonType><RunLevel>LeastPrivilege</RunLevel></Principal></Principals>
+  <Settings><MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy><RestartOnFailure><Interval>PT1M</Interval><Count>5</Count></RestartOnFailure><ExecutionTimeLimit>PT0S</ExecutionTimeLimit><Enabled>true</Enabled></Settings>
+  <Actions Context="Author"><Exec><Command>` + html.EscapeString(spec.Executable) + `</Command><Arguments>` + html.EscapeString(strings.Join(args, " ")) + `</Arguments><WorkingDirectory>` + html.EscapeString(spec.RootDir) + `</WorkingDirectory></Exec></Actions>
+</Task>`
+}
+
+func currentUserSID() (string, error) {
+	out, err := exec.Command("whoami.exe", "/user", "/fo", "csv", "/nh").Output()
+	if err != nil {
+		return "", fmt.Errorf("查询当前用户 SID 失败: %w", err)
+	}
+	records, err := csv.NewReader(bytes.NewReader(out)).ReadAll()
+	if err != nil {
+		return "", fmt.Errorf("解析当前用户 SID 失败: %w", err)
+	}
+	for _, record := range records {
+		for _, field := range record {
+			field = strings.TrimSpace(field)
+			if strings.HasPrefix(field, "S-1-") {
+				return field, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("whoami 未返回当前用户 SID")
+}
+
+func (m *platformManager) Install(spec Spec) error {
+	userSID, err := currentUserSID()
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp("", "yoooclaw-task-*.xml")
+	if err != nil {
+		return err
+	}
+	name := tmp.Name()
+	defer os.Remove(name)
+	content := []byte("\xff\xfe" + utf16LE(taskXML(spec, userSID)))
+	if _, err = tmp.Write(content); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err = tmp.Close(); err != nil {
+		return err
+	}
+	out, err := schtasks("/Create", "/TN", m.task, "/XML", name, "/F")
+	if err != nil {
+		return fmt.Errorf("创建计划任务失败: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+func utf16LE(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if r <= 0xffff {
+			b.WriteByte(byte(r))
+			b.WriteByte(byte(r >> 8))
+		} else {
+			r -= 0x10000
+			hi, lo := 0xd800+(r>>10), 0xdc00+(r&0x3ff)
+			b.WriteByte(byte(hi))
+			b.WriteByte(byte(hi >> 8))
+			b.WriteByte(byte(lo))
+			b.WriteByte(byte(lo >> 8))
+		}
+	}
+	return b.String()
+}
+func (m *platformManager) Start() error {
+	out, err := schtasks("/Run", "/TN", m.task)
+	if err != nil {
+		return fmt.Errorf("启动计划任务失败: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+func (m *platformManager) Stop() error {
+	status, _ := m.Status()
+	if !status.Installed {
+		return nil
+	}
+	// /End is idempotent for our purposes. Its "not currently running" error
+	// text is localized, so do not parse it; the daemon lock/HTTP stop path
+	// still verifies and retires any process that remains alive.
+	_, _ = schtasks("/End", "/TN", m.task)
+	return nil
+}
+func (m *platformManager) Restart() error {
+	if err := m.Stop(); err != nil {
+		return err
+	}
+	return m.Start()
+}
+func (m *platformManager) Uninstall() error {
+	status, _ := m.Status()
+	if !status.Installed {
+		return nil
+	}
+	out, err := schtasks("/Delete", "/TN", m.task, "/F")
+	if err != nil {
+		return fmt.Errorf("删除计划任务失败: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/internal/cli/cli_local_test.go
+++ b/internal/cli/cli_local_test.go
@@ -82,6 +82,37 @@ func TestProfileCreateUseDelete(t *testing.T) {
 	}
 }
 
+func TestProfileUseTransfersRunningManagedService(t *testing.T) {
+	home := sandbox(t)
+	imp := filepath.Join(home, "import.json")
+	if err := os.WriteFile(imp, []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if out, code := execCLI(t, "config", "init", "--non-interactive", "--from-file", imp, "--no-start"); code != 0 {
+		t.Fatalf("default init: %s", out)
+	}
+	if out, code := execCLI(t, "profile", "create", "work", "--non-interactive", "--from-file", imp, "--no-start"); code != 0 {
+		t.Fatalf("profile create: %s", out)
+	}
+	if out, code := execCLI(t, "daemon", "autostart", "enable"); code != 0 {
+		t.Fatalf("autostart enable: %s", out)
+	}
+	out, code := execCLI(t, "profile", "use", "work")
+	if code != 0 {
+		t.Fatalf("profile use: %s", out)
+	}
+	result := decode(t, out)
+	daemonInfo := result["daemon"].(map[string]any)
+	if daemonInfo["started"] != true || daemonInfo["supervised"] != true {
+		t.Fatalf("managed service was not transferred: %+v", result)
+	}
+	out, code = execCLI(t, "daemon", "autostart", "status")
+	status := decode(t, out)
+	if code != 0 || status["profile"] != "work" || status["running"] != true {
+		t.Fatalf("unexpected service status after profile use: %s", out)
+	}
+}
+
 func TestProfileUseRepairsStaleActiveProfile(t *testing.T) {
 	home := sandbox(t)
 	if err := os.MkdirAll(filepath.Join(home, "profiles", "default"), 0o700); err != nil {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -46,6 +46,7 @@ func sandbox(t *testing.T) string {
 	home := t.TempDir()
 	t.Setenv("YOOOCLAW_HOME", home)
 	t.Setenv("YOOOCLAW_PROFILE", "")
+	t.Setenv("YOOOCLAW_AUTOSTART_TEST_DIR", filepath.Join(home, "test-services"))
 	return home
 }
 
@@ -96,6 +97,10 @@ func TestConfigInitShowSetUnset(t *testing.T) {
 	if m["ok"] != true {
 		t.Errorf("init not ok: %+v", m)
 	}
+	daemonInfo := m["daemon"].(map[string]any)
+	if daemonInfo["autostart"] != true || daemonInfo["started"] != false {
+		t.Errorf("--no-start should enable autostart without starting: %+v", daemonInfo)
+	}
 
 	// 再次 init 无 force -> ALREADY_EXISTS
 	out, code = execCLI(t, "config", "init", "--non-interactive", "--from-file", cfgFile, "--no-start")
@@ -134,6 +139,76 @@ func TestConfigInitShowSetUnset(t *testing.T) {
 	out, code = execCLI(t, "config", "unset", "daemon.port")
 	if code != 0 || decode(t, out)["removed"] != true {
 		t.Errorf("unset failed: %s", out)
+	}
+}
+
+func TestDaemonAutostartEnableStatusDisable(t *testing.T) {
+	home := sandbox(t)
+	cfgFile := filepath.Join(home, "import.json")
+	if err := os.WriteFile(cfgFile, []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if out, code := execCLI(t, "config", "init", "--non-interactive", "--from-file", cfgFile, "--no-start"); code != 0 {
+		t.Fatalf("config init failed: %s", out)
+	}
+
+	out, code := execCLI(t, "daemon", "autostart", "status")
+	if code != 0 {
+		t.Fatalf("autostart status failed: %s", out)
+	}
+	status := decode(t, out)
+	if status["desired"] != "enabled" || status["installed"] != true || status["running"] != false {
+		t.Fatalf("unexpected status: %+v", status)
+	}
+
+	out, code = execCLI(t, "daemon", "autostart", "disable")
+	if code != 0 {
+		t.Fatalf("autostart disable failed: %s", out)
+	}
+	status = decode(t, out)
+	if status["desired"] != "disabled" || status["installed"] != false {
+		t.Fatalf("unexpected disabled status: %+v", status)
+	}
+}
+
+func TestConfigInitEnablesAndStartsAutostartByDefault(t *testing.T) {
+	home := sandbox(t)
+	cfgFile := filepath.Join(home, "import.json")
+	if err := os.WriteFile(cfgFile, []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, code := execCLI(t, "config", "init", "--non-interactive", "--from-file", cfgFile)
+	if code != 0 {
+		t.Fatalf("config init failed: %s", out)
+	}
+	info := decode(t, out)["daemon"].(map[string]any)
+	if info["autostart"] != true || info["started"] != true {
+		t.Fatalf("default init did not enable/start autostart: %+v", info)
+	}
+	out, code = execCLI(t, "daemon", "autostart", "status")
+	status := decode(t, out)
+	if code != 0 || status["desired"] != "enabled" || status["running"] != true {
+		t.Fatalf("unexpected autostart status: %s", out)
+	}
+}
+
+func TestConfigInitNoAutostartPersistsOptOut(t *testing.T) {
+	home := sandbox(t)
+	cfgFile := filepath.Join(home, "import.json")
+	if err := os.WriteFile(cfgFile, []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, code := execCLI(t, "config", "init", "--non-interactive", "--from-file", cfgFile, "--no-start", "--no-autostart")
+	if code != 0 {
+		t.Fatalf("config init failed: %s", out)
+	}
+	info := decode(t, out)["daemon"].(map[string]any)
+	if info["autostart"] != false {
+		t.Fatalf("unexpected daemon info: %+v", info)
+	}
+	out, code = execCLI(t, "daemon", "autostart", "status")
+	if code != 0 || decode(t, out)["desired"] != "disabled" {
+		t.Fatalf("opt-out was not persisted: %s", out)
 	}
 }
 
@@ -217,8 +292,8 @@ func TestLightruleCloudValidation(t *testing.T) {
 		args     []string
 		wantCode string
 	}{
-		{[]string{"lightrule", "create"}, "YOOOCLAW_INVALID_ARGUMENT"},                                        // 缺 --intent
-		{[]string{"lightrule", "update", "r1"}, "YOOOCLAW_INVALID_ARGUMENT"},                                  // 无更新字段
+		{[]string{"lightrule", "create"}, "YOOOCLAW_INVALID_ARGUMENT"},                                          // 缺 --intent
+		{[]string{"lightrule", "update", "r1"}, "YOOOCLAW_INVALID_ARGUMENT"},                                    // 无更新字段
 		{[]string{"lightrule", "update", "r1", "--intent", "改绿灯", "--title", "t"}, "YOOOCLAW_INVALID_ARGUMENT"}, // ruleText 与普通字段混用
 		{[]string{"lightrule", "update", "r1", "--repeat-times", "abc"}, "YOOOCLAW_INVALID_ARGUMENT"},
 		{[]string{"lightrule", "update", "r1", "--segments", `[{"mode":"nope"}]`}, "VALIDATION_FAILED"},

--- a/internal/cli/cmd_config.go
+++ b/internal/cli/cmd_config.go
@@ -4,12 +4,14 @@ import (
 	"encoding/json"
 	"os"
 
+	"github.com/YoooClaw/cli/internal/autostart"
 	"github.com/YoooClaw/cli/internal/clictx"
 	"github.com/YoooClaw/cli/internal/config"
 	"github.com/YoooClaw/cli/internal/creds"
 	"github.com/YoooClaw/cli/internal/daemon"
 	"github.com/YoooClaw/cli/internal/errs"
 	"github.com/YoooClaw/cli/internal/fsutil"
+	"github.com/YoooClaw/cli/internal/paths"
 	"github.com/YoooClaw/cli/internal/prompt"
 	"github.com/spf13/cobra"
 )
@@ -47,14 +49,15 @@ func newConfigCmd() *cobra.Command {
 
 	initCmd := &cobra.Command{
 		Use:   "init",
-		Short: "交互式首次向导，生成 config + gateway token 并启动 daemon",
+		Short: "交互式首次向导，生成配置并默认启用 daemon 自启",
 		Args:  cobra.NoArgs,
 		RunE:  run(configInit),
 	}
 	initCmd.Flags().Bool("non-interactive", false, "跳过向导（配合 --from-file）")
 	initCmd.Flags().String("from-file", "", "从 JSON 文件导入配置（- 为 stdin）")
 	initCmd.Flags().Bool("force", false, "已存在 config 时覆盖")
-	initCmd.Flags().Bool("no-start", false, "只生成配置，不自动启动 daemon")
+	initCmd.Flags().Bool("no-start", false, "当前不启动 daemon（仍配置登录自启）")
+	initCmd.Flags().Bool("no-autostart", false, "不配置用户登录自启")
 
 	showCmd := &cobra.Command{Use: "show", Short: "显示当前 profile 配置（敏感字段遮罩）", Args: cobra.NoArgs, RunE: run(configShow)}
 	showCmd.Flags().Bool("show-secrets", false, "输出敏感字段明文（需 TTY）")
@@ -71,6 +74,7 @@ type initOpts struct {
 	nonInteractive bool
 	fromFile       string
 	noStart        bool
+	noAutostart    bool
 }
 
 func configInit(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error) {
@@ -79,6 +83,7 @@ func configInit(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error
 		nonInteractive: flagBool(cmd, "non-interactive"),
 		fromFile:       flagStr(cmd, "from-file"),
 		noStart:        flagBool(cmd, "no-start"),
+		noAutostart:    flagBool(cmd, "no-autostart"),
 	})
 }
 
@@ -146,12 +151,10 @@ func initCore(ctx *clictx.Context, o initOpts) (any, error) {
 		return nil, err
 	}
 
-	// init 即用：默认把 daemon 拉起来；--no-start 跳过。失败不阻断 init（配置已落盘）。
+	// active profile 默认注册用户级自启并立即启动。自启配置失败不回滚已经
+	// 落盘的 config/凭据；当前启动会降级到原有 detach 模式并明确返回 warning。
 	apiKey := creds.ResolveAPIKey()
-	daemonInfo := map[string]any{"started": false}
-	if !o.noStart {
-		daemonInfo = startDaemonForInit(ctx)
-	}
+	daemonInfo := setupDaemonForInit(ctx, o)
 	started, _ := daemonInfo["started"].(bool)
 	hint := initHint(started, apiKey.Value != "")
 	return map[string]any{
@@ -167,6 +170,70 @@ func initCore(ctx *clictx.Context, o initOpts) (any, error) {
 		"configPath":   ctx.Paths.Config,
 		"hint":         hint,
 	}, nil
+}
+
+func setupDaemonForInit(ctx *clictx.Context, o initOpts) map[string]any {
+	if ctx.Profile != persistentActiveProfile() {
+		return map[string]any{
+			"started": false, "autostart": false,
+			"reason": "非 active profile 不改变账号级 daemon 自启状态",
+			"hint":   "运行 `yoooclaw profile use " + ctx.Profile + "` 激活该 profile",
+		}
+	}
+	if o.noAutostart {
+		manager := autostartManager()
+		if status, _ := manager.Status(); status.Installed {
+			if _, err := autostart.Disable(manager, paths.RootDir()); err != nil {
+				return map[string]any{"started": false, "autostart": true, "autostartError": err.Error()}
+			}
+		} else {
+			_ = autostart.RecordDisabled(paths.RootDir())
+		}
+		if o.noStart {
+			return map[string]any{"started": false, "autostart": false}
+		}
+		info := startDaemonForInit(ctx)
+		info["autostart"] = false
+		return info
+	}
+
+	manager := autostartManager()
+	if status, _ := manager.Status(); status.Running {
+		_ = manager.Stop()
+	}
+	if state := daemon.State(ctx.Paths); state.Running {
+		_, _ = daemon.Stop(ctx.Paths)
+	}
+	err := daemon.PrecheckStart(ctx, daemon.StartOpts{})
+	var spec autostart.Spec
+	if err == nil {
+		spec, err = autostartSpec()
+	}
+	if err == nil {
+		var status autostart.Status
+		status, err = autostart.Enable(manager, spec, !o.noStart)
+		if err == nil && !o.noStart && status.Manager != "test" {
+			if readyErr := waitForManagedDaemon(ctx); readyErr != nil {
+				_ = manager.Stop()
+				err = readyErr
+			}
+		}
+		if err == nil {
+			return map[string]any{
+				"started": !o.noStart, "autostart": true,
+				"manager": status.Manager, "unit": status.Unit,
+			}
+		}
+	}
+	result := map[string]any{"started": false, "autostart": false, "autostartError": err.Error()}
+	if !o.noStart {
+		fallback := startDaemonForInit(ctx)
+		for key, value := range fallback {
+			result[key] = value
+		}
+		result["fallback"] = "detached"
+	}
+	return result
 }
 
 func readConfigImport(fromFile string) ([]byte, error) {

--- a/internal/cli/cmd_daemon.go
+++ b/internal/cli/cmd_daemon.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -9,13 +10,14 @@ import (
 	"github.com/YoooClaw/cli/internal/config"
 	"github.com/YoooClaw/cli/internal/daemon"
 	"github.com/YoooClaw/cli/internal/errs"
+	"github.com/YoooClaw/cli/internal/paths"
 	"github.com/spf13/cobra"
 )
 
 func newDaemonCmd() *cobra.Command {
 	c := &cobra.Command{Use: "daemon", Short: "守护进程管理 🔵"}
 
-	start := &cobra.Command{Use: "start", Short: "启动 daemon（默认后台 detach）", Args: cobra.NoArgs, RunE: run(daemonStart)}
+	start := &cobra.Command{Use: "start", Short: "启动 daemon（自启已启用时由系统用户服务托管）", Args: cobra.NoArgs, RunE: run(daemonStart)}
 	start.Flags().String("bind", "", "监听地址（默认 config.daemon.bind）")
 	start.Flags().String("port", "", "监听端口（默认 config.daemon.port）")
 	start.Flags().Bool("no-detach", false, "前台运行（systemd/launchd 用）")
@@ -41,6 +43,7 @@ func newDaemonCmd() *cobra.Command {
 	logs.Flags().BoolP("follow", "f", false, "持续 tail")
 	logs.Flags().String("lines", "100", "初始展示行数")
 	logs.Flags().String("level", "", "过滤日志级别")
+	logs.Flags().Bool("supervisor", false, "查看系统用户服务启动日志")
 
 	runFg := &cobra.Command{Use: "run-foreground", Short: "（内部）前台运行 daemon 主循环", Args: cobra.NoArgs, RunE: run(daemonRunForeground)}
 	runFg.Flags().String("bind", "", "监听地址")
@@ -48,8 +51,10 @@ func newDaemonCmd() *cobra.Command {
 	runFg.Flags().String("log-level", "", "日志级别")
 	addDaemonLifecycleFlags(runFg)
 	addIngressFlags(runFg)
+	runService := &cobra.Command{Use: "run-service", Short: "由系统用户服务运行 daemon", Hidden: true, Args: cobra.NoArgs, RunE: run(daemonRunService)}
+	runService.Flags().String("root", "", "（内部）服务数据根目录")
 
-	c.AddCommand(start, stop, restart, reload, status, logs, runFg)
+	c.AddCommand(start, stop, restart, reload, status, logs, runFg, runService, newDaemonAutostartCmd())
 	return c
 }
 
@@ -101,6 +106,9 @@ func daemonStart(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, erro
 	if state.Stale {
 		daemon.RemoveLock(ctx.Paths)
 	}
+	if err := rejectManagedOverrides(cmd); err != nil {
+		return nil, err
+	}
 	opts := startOptsFromCmd(cmd)
 	// detach 模式下子进程失败只会表现为"等 lock 超时"；先在父进程做
 	// 写者锁预检，把 YOOOCLAW_DAEMON_DISABLED_BY_PLUGIN 直接抛给调用方。
@@ -113,6 +121,17 @@ func daemonStart(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, erro
 		}
 		return map[string]any{"ok": true}, nil
 	}
+	if managed, _ := serviceManaged(); managed {
+		lock, err := startStandalone(ctx)
+		if err != nil {
+			return nil, err
+		}
+		result := map[string]any{"ok": true, "supervised": true, "autostart": true}
+		if lock != nil && lock.PID > 0 {
+			result["pid"], result["bind"], result["port"] = lock.PID, lock.Bind, lock.Port
+		}
+		return result, nil
+	}
 	lock, err := daemon.Spawn(ctx, opts)
 	if err != nil {
 		return nil, err
@@ -121,10 +140,24 @@ func daemonStart(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, erro
 }
 
 func daemonStop(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error) {
-	return daemon.StopWithOptions(ctx.Paths, stopOptsFromCmd(cmd))
+	return stopManagedDaemon(ctx, stopOptsFromCmd(cmd))
 }
 
 func daemonRestart(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error) {
+	if err := rejectManagedOverrides(cmd); err != nil {
+		return nil, err
+	}
+	if _, err := config.Require(ctx.Paths); err != nil {
+		return nil, err
+	}
+	if managed, serviceStatus := serviceManaged(); managed {
+		if !serviceStatus.Running {
+			if err := daemon.PrecheckStart(ctx, daemon.StartOpts{}); err != nil {
+				return nil, err
+			}
+		}
+		return restartManagedDaemon(ctx)
+	}
 	state := daemon.State(ctx.Paths)
 	lock := state.Lock
 	opts := startOptsFromCmd(cmd)
@@ -143,9 +176,6 @@ func daemonRestart(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, er
 				return nil, err
 			}
 		}
-	}
-	if _, err := config.Require(ctx.Paths); err != nil {
-		return nil, err
 	}
 	if flagBool(cmd, "no-detach") {
 		if err := daemon.RunForeground(ctx, opts); err != nil {
@@ -182,12 +212,21 @@ func daemonStatus(ctx *clictx.Context, _ *cobra.Command, _ []string) (any, error
 	if err != nil {
 		return nil, err
 	}
+	if m, ok := body.(map[string]any); ok {
+		if supervision, snapshotErr := autostartSnapshot(); snapshotErr == nil {
+			m["supervision"] = supervision
+		}
+	}
 	return body, nil
 }
 
 func daemonLogs(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error) {
 	n := atoiDefault(flagStr(cmd, "lines"), 100)
-	lines := tailLines(ctx.Paths.DaemonLog, n)
+	file := ctx.Paths.DaemonLog
+	if flagBool(cmd, "supervisor") {
+		file = filepath.Join(paths.RootDir(), "logs", "daemon-supervisor.log")
+	}
+	lines := tailLines(file, n)
 	if level := flagStr(cmd, "level"); level != "" {
 		want := "[" + strings.ToUpper(level) + "]"
 		filtered := lines[:0]
@@ -199,7 +238,7 @@ func daemonLogs(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error
 		lines = filtered
 	}
 	// --follow 的实时 tail 暂不实现（Phase 2 标准输出即可）；返回当前快照。
-	return map[string]any{"ok": true, "file": ctx.Paths.DaemonLog, "total": len(lines), "lines": lines}, nil
+	return map[string]any{"ok": true, "file": file, "total": len(lines), "lines": lines}, nil
 }
 
 func tailLines(file string, n int) []string {

--- a/internal/cli/cmd_daemon_autostart.go
+++ b/internal/cli/cmd_daemon_autostart.go
@@ -1,0 +1,353 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/YoooClaw/cli/internal/autostart"
+	"github.com/YoooClaw/cli/internal/clictx"
+	"github.com/YoooClaw/cli/internal/config"
+	"github.com/YoooClaw/cli/internal/daemon"
+	"github.com/YoooClaw/cli/internal/errs"
+	"github.com/YoooClaw/cli/internal/fsutil"
+	"github.com/YoooClaw/cli/internal/paths"
+	"github.com/spf13/cobra"
+)
+
+const managedDaemonReadyTimeout = 15 * time.Second
+
+func newDaemonAutostartCmd() *cobra.Command {
+	c := &cobra.Command{Use: "autostart", Short: "管理用户登录时自动启动"}
+	enable := &cobra.Command{Use: "enable", Short: "启用自启并立即启动 daemon", Args: cobra.NoArgs, RunE: run(daemonAutostartEnable)}
+	enable.Flags().Bool("no-start", false, "只启用自启，当前不启动")
+	disable := &cobra.Command{Use: "disable", Short: "停止 daemon 并关闭自启", Args: cobra.NoArgs, RunE: run(daemonAutostartDisable)}
+	status := &cobra.Command{Use: "status", Short: "显示自启期望与系统服务状态", Args: cobra.NoArgs, RunE: run(daemonAutostartStatus)}
+	c.AddCommand(enable, disable, status)
+	return c
+}
+
+func autostartError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return errs.New(errs.CodeAutostartUnavailable, "无法配置 daemon 自启："+err.Error()).
+		WithHint("检查用户级服务管理器后重试；也可用 `yoooclaw daemon start` 手动运行")
+}
+
+func autostartManager() autostart.Manager { return autostart.Current(paths.RootDir()) }
+
+func autostartSpec() (autostart.Spec, error) { return autostart.ResolveSpec(paths.RootDir()) }
+
+func autostartSnapshot() (map[string]any, error) {
+	root := paths.RootDir()
+	desired, stateErr := autostart.Desired(root)
+	manager := autostartManager()
+	status, statusErr := manager.Status()
+	if statusErr != nil {
+		return nil, statusErr
+	}
+	state, exists, _ := autostart.ReadState(root)
+	drift := desired == autostart.DesiredEnabled && !status.Installed
+	if desired == autostart.DesiredDisabled && status.Installed {
+		drift = true
+	}
+	if exists && state.Executable != "" && status.Executable != "" && state.Executable != status.Executable {
+		drift = true
+	}
+	if currentSpec, specErr := autostartSpec(); specErr == nil && exists && state.Executable != "" && state.Executable != currentSpec.Executable {
+		drift = true
+	}
+	result := map[string]any{
+		"ok": true, "desired": desired, "configured": exists,
+		"manager": status.Manager, "unit": status.Unit,
+		"installed": status.Installed, "loaded": status.Loaded,
+		"running": status.Running, "drift": drift,
+		"profile": persistentActiveProfile(),
+	}
+	if desired == "" {
+		result["desired"] = "unknown"
+	}
+	if status.PID > 0 {
+		result["pid"] = status.PID
+	}
+	if stateErr != nil {
+		result["stateError"] = stateErr.Error()
+	}
+	return result, nil
+}
+
+func persistentActiveProfile() string {
+	if active := paths.ReadActiveProfile(); active != "" {
+		return active
+	}
+	return paths.DefaultProfile
+}
+
+func daemonAutostartStatus(_ *clictx.Context, _ *cobra.Command, _ []string) (any, error) {
+	result, err := autostartSnapshot()
+	if err != nil {
+		return nil, autostartError(err)
+	}
+	return result, nil
+}
+
+func daemonAutostartEnable(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error) {
+	if ctx.Profile != persistentActiveProfile() {
+		return nil, errs.New(errs.CodeInvalidArgument, "自启服务只运行 active profile `"+persistentActiveProfile()+"`").
+			WithHint("先运行 `yoooclaw profile use " + ctx.Profile + "`")
+	}
+	if _, err := config.Require(ctx.Paths); err != nil {
+		return nil, err
+	}
+	manager := autostartManager()
+	status, _ := manager.Status()
+	if status.Running {
+		if err := manager.Stop(); err != nil {
+			return nil, autostartError(err)
+		}
+	}
+	if state := daemon.State(ctx.Paths); state.Running {
+		if _, err := daemon.Stop(ctx.Paths); err != nil {
+			return nil, err
+		}
+	}
+	if err := daemon.PrecheckStart(ctx, daemon.StartOpts{}); err != nil {
+		return nil, err
+	}
+	spec, err := autostartSpec()
+	if err != nil {
+		return nil, autostartError(err)
+	}
+	start := !flagBool(cmd, "no-start")
+	status, err = autostart.Enable(manager, spec, start)
+	if err != nil {
+		return nil, autostartError(err)
+	}
+	if start && status.Manager != "test" {
+		if err := waitForManagedDaemon(ctx); err != nil {
+			return nil, err
+		}
+	}
+	result, _ := autostartSnapshot()
+	return result, nil
+}
+
+func daemonAutostartDisable(_ *clictx.Context, _ *cobra.Command, _ []string) (any, error) {
+	manager := autostartManager()
+	if _, err := autostart.Disable(manager, paths.RootDir()); err != nil {
+		return nil, autostartError(err)
+	}
+	// Also retire a legacy detached daemon that is not owned by the manager.
+	for _, name := range paths.ListProfileNames() {
+		p := paths.For(name)
+		if state := daemon.State(p); state.Running {
+			if _, err := daemon.Stop(p); err != nil {
+				return nil, err
+			}
+		}
+	}
+	result, _ := autostartSnapshot()
+	return result, nil
+}
+
+func serviceManaged() (bool, autostart.Status) {
+	desired, _ := autostart.Desired(paths.RootDir())
+	status, _ := autostartManager().Status()
+	return desired == autostart.DesiredEnabled || status.Installed, status
+}
+
+func startStandalone(ctx *clictx.Context) (*daemon.Lock, error) {
+	managed, status := serviceManaged()
+	if !managed {
+		return daemon.Spawn(ctx, daemon.StartOpts{})
+	}
+	if status.Running {
+		state := daemon.State(ctx.Paths)
+		if state.Running {
+			return state.Lock, nil
+		}
+	}
+	manager := autostartManager()
+	spec, err := autostartSpec()
+	if err != nil {
+		return nil, autostartError(err)
+	}
+	// Reinstall is idempotent and refreshes an executable path that may have
+	// changed during an npm/native update.
+	if _, err := autostart.Enable(manager, spec, false); err != nil {
+		return nil, autostartError(err)
+	}
+	if err := manager.Start(); err != nil {
+		return nil, autostartError(err)
+	}
+	if status.Manager == "test" {
+		return &daemon.Lock{}, nil
+	}
+	if err := waitForManagedDaemon(ctx); err != nil {
+		return nil, err
+	}
+	return daemon.State(ctx.Paths).Lock, nil
+}
+
+func waitForManagedDaemon(ctx *clictx.Context) error {
+	deadline := time.Now().Add(managedDaemonReadyTimeout)
+	for time.Now().Before(deadline) {
+		state := daemon.State(ctx.Paths)
+		if state.Running {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return errs.New(errs.CodeDaemonNotRunning, "系统服务已启动，但 daemon 未在 "+managedDaemonReadyTimeout.String()+" 内就绪").
+		WithHint("查看 `yoooclaw daemon logs` 和 `yoooclaw daemon logs --supervisor`")
+}
+
+func stopManagedDaemon(ctx *clictx.Context, opts daemon.StopOpts) (any, error) {
+	// Lifecycle-filtered stops target a specific hosted process and must retain
+	// the daemon package's owner/generation checks.
+	if opts.Owner != "" || opts.Generation != "" {
+		return daemon.StopWithOptions(ctx.Paths, opts)
+	}
+	managed, status := serviceManaged()
+	if managed && status.Loaded {
+		pid := 0
+		if state := daemon.State(ctx.Paths); state.Running {
+			pid = state.Lock.PID
+		}
+		if err := autostartManager().Stop(); err != nil {
+			return nil, autostartError(err)
+		}
+		waitForProfileDaemonExit(pid)
+		if state := daemon.State(ctx.Paths); state.Running {
+			if _, err := daemon.StopWithOptions(ctx.Paths, opts); err != nil {
+				return nil, err
+			}
+		}
+		return map[string]any{"ok": true, "stopped": true, "supervised": true, "autostart": true}, nil
+	}
+	return daemon.StopWithOptions(ctx.Paths, opts)
+}
+
+func restartManagedDaemon(ctx *clictx.Context) (any, error) {
+	managed, status := serviceManaged()
+	if !managed {
+		lock, err := daemon.Spawn(ctx, daemon.StartOpts{})
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{"ok": true, "pid": lock.PID, "bind": lock.Bind, "port": lock.Port, "detached": true}, nil
+	}
+	manager := autostartManager()
+	spec, err := autostartSpec()
+	if err != nil {
+		return nil, autostartError(err)
+	}
+	if _, err := autostart.Enable(manager, spec, false); err != nil {
+		return nil, autostartError(err)
+	}
+	if err := manager.Restart(); err != nil {
+		return nil, autostartError(err)
+	}
+	if status.Manager != "test" {
+		if err := waitForManagedDaemon(ctx); err != nil {
+			return nil, err
+		}
+	}
+	state := daemon.State(ctx.Paths)
+	result := map[string]any{"ok": true, "supervised": true, "autostart": true}
+	if state.Lock != nil {
+		result["pid"] = state.Lock.PID
+		result["port"] = state.Lock.Port
+	}
+	return result, nil
+}
+
+func daemonRunServiceWithRoot(ctx *clictx.Context, cmd *cobra.Command) (*clictx.Context, error) {
+	root := flagStr(cmd, "root")
+	if root == "" {
+		return ctx, nil
+	}
+	if err := os.Setenv("YOOOCLAW_HOME", root); err != nil {
+		return nil, err
+	}
+	profile := persistentActiveProfile()
+	return &clictx.Context{
+		Profile: profile, Paths: paths.For(profile), Format: ctx.Format,
+		Quiet: ctx.Quiet, Color: ctx.Color,
+	}, nil
+}
+
+func daemonRunService(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error) {
+	ctx, err := daemonRunServiceWithRoot(ctx, cmd)
+	if err != nil {
+		return nil, err
+	}
+	if !config.Exists(ctx.Paths) {
+		return map[string]any{"ok": true, "running": false, "skipped": "active profile 尚未初始化", "profile": ctx.Profile}, nil
+	}
+	err = daemon.RunForeground(ctx, daemon.StartOpts{})
+	if err == nil {
+		return map[string]any{"ok": true, "stopped": true}, nil
+	}
+	var structured *errs.Error
+	if errors.As(err, &structured) && (structured.Code == errs.CodeDaemonDisabledByPlugin || structured.Code == errs.CodeDaemonAlreadyRunning) {
+		appendSupervisorLog("INFO", structured.Message)
+		return map[string]any{"ok": true, "running": false, "skipped": structured.Message, "profile": ctx.Profile}, nil
+	}
+	appendSupervisorLog("ERROR", err.Error())
+	return nil, err
+}
+
+func appendSupervisorLog(level, message string) {
+	file := filepath.Join(paths.RootDir(), "logs", "daemon-supervisor.log")
+	if err := fsutil.EnsureDir(filepath.Dir(file), fsutil.DirMode); err != nil {
+		return
+	}
+	f, err := os.OpenFile(file, os.O_CREATE|os.O_APPEND|os.O_WRONLY, fsutil.SecretFileMode)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	_, _ = fmt.Fprintf(f, "%s [%s] %s\n", time.Now().UTC().Format(time.RFC3339), level, message)
+}
+
+func managedOverrides(cmd *cobra.Command) bool {
+	return flagStr(cmd, "bind") != "" || flagStr(cmd, "port") != "" || flagStr(cmd, "log-level") != "" ||
+		flagStr(cmd, "owner") != "" || flagStr(cmd, "generation") != "" || flagStr(cmd, "ingress") != "" ||
+		flagStr(cmd, "egress-callback-url") != "" || flagStr(cmd, "egress-callback-token") != "" || flagBool(cmd, "no-detach")
+}
+
+func rejectManagedOverrides(cmd *cobra.Command) error {
+	managed, _ := serviceManaged()
+	if managed && managedOverrides(cmd) {
+		return errs.New(errs.CodeInvalidArgument, "自启托管模式不接受临时 daemon 启动参数").
+			WithHint("用 `yoooclaw config set daemon.<key> <value>` 持久化配置，或先关闭 autostart")
+	}
+	return nil
+}
+
+func removeAutostartForUninstall() ([]string, error) {
+	manager := autostartManager()
+	status, statusErr := manager.Status()
+	if statusErr != nil {
+		return nil, autostartError(statusErr)
+	}
+	if status.Installed || status.Loaded {
+		if err := manager.Stop(); err != nil {
+			return nil, autostartError(err)
+		}
+		if err := manager.Uninstall(); err != nil {
+			return nil, autostartError(err)
+		}
+	}
+	statePath := autostart.StatePath(paths.RootDir())
+	if err := os.Remove(statePath); err == nil {
+		return []string{statePath}, nil
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
+	return nil, nil
+}

--- a/internal/cli/cmd_doctor.go
+++ b/internal/cli/cmd_doctor.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"strconv"
 
+	"github.com/YoooClaw/cli/internal/autostart"
 	"github.com/YoooClaw/cli/internal/clictx"
 	"github.com/YoooClaw/cli/internal/config"
 	"github.com/YoooClaw/cli/internal/creds"
@@ -106,6 +107,49 @@ func doctor(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error) {
 		checks = append(checks, check{"daemon", "warn", "锁文件存在但进程已死（陈旧锁）"})
 	default:
 		checks = append(checks, check{"daemon", "skip", "未运行"})
+	}
+
+	manager := autostartManager()
+	desired, desiredErr := autostart.Desired(paths.RootDir())
+	serviceStatus, serviceErr := manager.Status()
+	storedState, storedExists, _ := autostart.ReadState(paths.RootDir())
+	currentSpec, specErr := autostartSpec()
+	executableDrift := storedExists && specErr == nil && storedState.Executable != "" && storedState.Executable != currentSpec.Executable
+	needsEnableRepair := desired == autostart.DesiredEnabled && (!serviceStatus.Installed || executableDrift)
+	switch {
+	case desiredErr != nil:
+		checks = append(checks, check{"daemon-autostart", "fail", desiredErr.Error()})
+	case serviceErr != nil:
+		checks = append(checks, check{"daemon-autostart", "warn", serviceErr.Error()})
+	case needsEnableRepair && fix:
+		if specErr == nil {
+			_, specErr = autostart.Enable(manager, currentSpec, false)
+		}
+		if specErr != nil {
+			checks = append(checks, check{"daemon-autostart", "fail", "修复失败：" + specErr.Error()})
+		} else {
+			checks = append(checks, check{"daemon-autostart", "ok", "已重新注册用户级自启服务"})
+		}
+	case needsEnableRepair:
+		detail := "期望启用但系统服务缺失（doctor --fix 可修复）"
+		if executableDrift {
+			detail = "系统服务仍指向旧版本二进制（doctor --fix 可修复）"
+		}
+		checks = append(checks, check{"daemon-autostart", "warn", detail})
+	case desired == autostart.DesiredEnabled && serviceStatus.Installed:
+		checks = append(checks, check{"daemon-autostart", "ok", serviceStatus.Manager + " 已启用"})
+	case desired == autostart.DesiredDisabled && serviceStatus.Installed && fix:
+		if _, disableErr := autostart.Disable(manager, paths.RootDir()); disableErr != nil {
+			checks = append(checks, check{"daemon-autostart", "fail", "修复失败：" + disableErr.Error()})
+		} else {
+			checks = append(checks, check{"daemon-autostart", "ok", "已移除用户级自启服务"})
+		}
+	case desired == autostart.DesiredDisabled && serviceStatus.Installed:
+		checks = append(checks, check{"daemon-autostart", "warn", "已关闭自启但系统服务仍存在"})
+	case desired == autostart.DesiredDisabled:
+		checks = append(checks, check{"daemon-autostart", "skip", "用户已关闭"})
+	default:
+		checks = append(checks, check{"daemon-autostart", "skip", "尚未配置（下一次 config init 默认启用）"})
 	}
 
 	failed, warned := 0, 0

--- a/internal/cli/cmd_owner.go
+++ b/internal/cli/cmd_owner.go
@@ -125,14 +125,16 @@ func activateCLIOwner(ctx *clictx.Context, hermesProfile string, start bool) (ma
 		result["hint"] = "运行 `yoooclaw config init`；配置完成后 daemon 会自动启动"
 		return result, nil
 	}
-	lock, err := daemon.Spawn(ctx, daemon.StartOpts{})
+	lock, err := startStandalone(ctx)
 	if err != nil {
 		return nil, errs.New(errs.CodeUnknown, "CLI owner 已释放，但 standalone daemon 启动失败："+err.Error()).
 			WithHint("检查 `yoooclaw daemon logs`，修复后运行 `yoooclaw daemon start`")
 	}
 	result["activation"] = "active"
 	result["daemonStarted"] = true
-	result["pid"] = lock.PID
+	if lock != nil && lock.PID > 0 {
+		result["pid"] = lock.PID
+	}
 	return result, nil
 }
 

--- a/internal/cli/cmd_profile.go
+++ b/internal/cli/cmd_profile.go
@@ -24,7 +24,8 @@ func newProfileCmd() *cobra.Command {
 	createCmd.Flags().Bool("non-interactive", false, "跳过向导（配合 --from-file）")
 	createCmd.Flags().String("from-file", "", "从 JSON 文件导入配置（- 为 stdin）")
 	createCmd.Flags().Bool("force", false, "已存在 config 时覆盖")
-	createCmd.Flags().Bool("no-start", false, "只生成配置，不自动启动 daemon")
+	createCmd.Flags().Bool("no-start", false, "当前不启动 daemon")
+	createCmd.Flags().Bool("no-autostart", false, "不配置用户登录自启")
 	deleteCmd := &cobra.Command{Use: "delete <name>", Short: "删除 profile（非 active，需 --yes）", Args: cobra.ExactArgs(1), RunE: run(profileDelete)}
 	deleteCmd.Flags().Bool("yes", false, "跳过确认")
 
@@ -78,6 +79,18 @@ func profileUse(ctx *clictx.Context, _ *cobra.Command, args []string) (any, erro
 
 	// active profile 与 daemon 的存储根目录必须一起切换。旧行为只改文本文件，
 	// 旧 daemon 会继续用 test profile 消费生产 Relay，造成“消息仍落测试区”。
+	managed, serviceStatus := serviceManaged()
+	serviceWasRunning := managed && serviceStatus.Running
+	oldPID := 0
+	if oldState := daemon.State(paths.For(previous)); oldState.Running {
+		oldPID = oldState.Lock.PID
+	}
+	if serviceWasRunning {
+		if err := autostartManager().Stop(); err != nil {
+			return nil, autostartError(err)
+		}
+		waitForProfileDaemonExit(oldPID)
+	}
 	stoppedPID, err := stopProfileDaemon(paths.For(previous))
 	if err != nil {
 		return nil, err
@@ -89,17 +102,22 @@ func profileUse(ctx *clictx.Context, _ *cobra.Command, args []string) (any, erro
 	result := map[string]any{
 		"ok": true, "active": name, "previous": previous, "changed": true,
 	}
-	if stoppedPID == 0 {
+	if stoppedPID == 0 && !serviceWasRunning {
 		return result, nil
 	}
 	// daemon 会在退出末尾先删 profile lock、随后由进程退出释放 account Relay
 	// flock；两者之间存在极短窗口。等旧 PID 真正消失，避免目标启动误报全局锁冲突。
-	waitForProfileDaemonExit(stoppedPID)
+	if stoppedPID != 0 {
+		waitForProfileDaemonExit(stoppedPID)
+	}
 
 	// 旧 profile 原本有 daemon 在提供服务时，切换后尽力恢复同等运行态。目标
 	// profile 未初始化或启动失败不回滚到旧 profile：宁可明确停住，也不能让旧
 	// profile 再次静默消费新环境消息。
-	daemonInfo := map[string]any{"stopped": stoppedPID, "started": false}
+	if stoppedPID == 0 {
+		stoppedPID = oldPID
+	}
+	daemonInfo := map[string]any{"stopped": stoppedPID, "started": false, "supervised": serviceWasRunning}
 	result["daemon"] = daemonInfo
 	if targetState := daemon.State(p); targetState.Running {
 		daemonInfo["started"] = true
@@ -121,15 +139,17 @@ func profileUse(ctx *clictx.Context, _ *cobra.Command, args []string) (any, erro
 		daemonInfo["hint"] = "修复启动条件后运行 `yoooclaw daemon start`"
 		return result, nil
 	}
-	lock, err := daemon.Spawn(targetCtx, daemon.StartOpts{})
+	lock, err := startStandalone(targetCtx)
 	if err != nil {
 		daemonInfo["error"] = err.Error()
 		daemonInfo["hint"] = "查看 `yoooclaw daemon logs` 后重新启动"
 		return result, nil
 	}
 	daemonInfo["started"] = true
-	daemonInfo["pid"] = lock.PID
-	daemonInfo["port"] = lock.Port
+	if lock != nil && lock.PID > 0 {
+		daemonInfo["pid"] = lock.PID
+		daemonInfo["port"] = lock.Port
+	}
 	return result, nil
 }
 
@@ -145,6 +165,7 @@ func profileCreate(ctx *clictx.Context, cmd *cobra.Command, args []string) (any,
 		nonInteractive: flagBool(cmd, "non-interactive"),
 		fromFile:       flagStr(cmd, "from-file"),
 		noStart:        flagBool(cmd, "no-start"),
+		noAutostart:    flagBool(cmd, "no-autostart"),
 	})
 }
 
@@ -207,6 +228,9 @@ func stopProfileDaemon(p paths.Paths) (int, error) {
 }
 
 func waitForProfileDaemonExit(pid int) {
+	if pid <= 0 {
+		return
+	}
 	deadline := time.Now().Add(time.Second)
 	for daemon.IsProcessAlive(pid) && time.Now().Before(deadline) {
 		time.Sleep(20 * time.Millisecond)

--- a/internal/cli/cmd_uninstall.go
+++ b/internal/cli/cmd_uninstall.go
@@ -43,7 +43,12 @@ func uninstall(_ *clictx.Context, cmd *cobra.Command, _ []string) (any, error) {
 		}
 	}
 
-	// 1. 停掉所有 profile 的 daemon。
+	// 1. 先卸载系统用户服务，避免删除二进制后留下失效的自启项；再清理
+	// 可能由旧版本或 --no-autostart 启动的 detached daemon。
+	autostartRemoved, err := removeAutostartForUninstall()
+	if err != nil {
+		return nil, err
+	}
 	stopped := stopAllDaemons()
 
 	// 2. 删配置（默认保留数据）或整目录（--data）。
@@ -58,6 +63,7 @@ func uninstall(_ *clictx.Context, cmd *cobra.Command, _ []string) (any, error) {
 	} else {
 		removed = removeConfigKeepData()
 	}
+	removed = append(autostartRemoved, removed...)
 
 	// 3. 删二进制（npm 安装无法自删，给提示）。
 	binRemoved, hint := removeSelfBinary()

--- a/internal/cli/cmd_web.go
+++ b/internal/cli/cmd_web.go
@@ -35,6 +35,7 @@ func newSyncedWebPageCmd() *cobra.Command {
 	}
 	list.Flags().String("from", "", "包含在该 ISO 8601 时间及之后抓取的网页")
 	list.Flags().String("to", "", "包含在该 ISO 8601 时间之前抓取的网页")
+	list.Flags().String("client", "", "按 clientLabel 过滤；all 为全部")
 	pathCmd := &cobra.Command{
 		Use:   "path <urlHash>",
 		Short: "根据 URL 哈希打印网页 Markdown 文件绝对路径 🟢",
@@ -48,6 +49,7 @@ func newSyncedWebPageCmd() *cobra.Command {
 		RunE:  run(webSearch),
 	}
 	search.Flags().String("limit", strconv.Itoa(defaultWebSearchLimit), "最多返回的网页数量（默认 20）")
+	search.Flags().String("client", "", "按 clientLabel 过滤；all 为全部")
 	storagePath := &cobra.Command{
 		Use:   "storage-path",
 		Short: "查询网页存储路径 🟢",
@@ -90,8 +92,12 @@ func webList(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error) {
 		return nil, errs.New(errs.CodeInvalidArgument, "--from 不能晚于 --to")
 	}
 
+	client := flagStr(cmd, "client")
 	pages := make([]any, 0, len(entries))
 	for _, entry := range entries {
+		if client != "" && client != "all" && labelOrLegacy2(entry.ClientLabel) != client {
+			continue
+		}
 		if from != nil || to != nil {
 			capturedAt, ok := notif.ParseTime(entry.CapturedAt)
 			if !ok {
@@ -329,13 +335,28 @@ func webSearch(ctx *clictx.Context, cmd *cobra.Command, args []string) (any, err
 	}
 	pages := searchWebPages(
 		ctx.Paths.WebPages,
-		webpage.ReadIndex(ctx.Paths.WebPages),
+		filterWebPagesByClient(webpage.ReadIndex(ctx.Paths.WebPages), flagStr(cmd, "client")),
 		keyword,
 		limit,
 	)
 	return map[string]any{
 		"ok": true, "keyword": keyword, "total": len(pages), "pages": pages,
 	}, nil
+}
+
+// filterWebPagesByClient 按 clientLabel 过滤，语义与 recording/image 的 --client 一致：
+// 空或 all 表示不过滤，老数据在 CLI 侧显示为 legacy。
+func filterWebPagesByClient(entries []webpage.Entry, client string) []webpage.Entry {
+	if client == "" || client == "all" {
+		return entries
+	}
+	kept := make([]webpage.Entry, 0, len(entries))
+	for _, entry := range entries {
+		if labelOrLegacy2(entry.ClientLabel) == client {
+			kept = append(kept, entry)
+		}
+	}
+	return kept
 }
 
 func webStoragePath(ctx *clictx.Context, _ *cobra.Command, _ []string) (any, error) {

--- a/internal/cli/cmd_web_client_test.go
+++ b/internal/cli/cmd_web_client_test.go
@@ -1,0 +1,45 @@
+package cli
+
+import "testing"
+
+// fixture 里 mdn 的 clientLabel 是 webext，internal 没有 label（显示为 legacy）。
+func TestWebListFiltersByClient(t *testing.T) {
+	_, mdn, internal := writeWebFixture(t)
+
+	out, code := execCLI(t, "synced-web-page", "list", "--client", "webext")
+	if code != 0 {
+		t.Fatalf("client-filtered list failed: %s", out)
+	}
+	result := decode(t, out)
+	pages := result["pages"].([]any)
+	if result["total"] != float64(1) || pages[0].(map[string]any)["urlHash"] != mdn.URLHash {
+		t.Fatalf("--client webext = %+v, want only mdn", result)
+	}
+
+	out, _ = execCLI(t, "synced-web-page", "list", "--client", "legacy")
+	result = decode(t, out)
+	pages = result["pages"].([]any)
+	if result["total"] != float64(1) || pages[0].(map[string]any)["urlHash"] != internal.URLHash {
+		t.Fatalf("--client legacy = %+v, want only the unlabeled page", result)
+	}
+
+	out, _ = execCLI(t, "synced-web-page", "list", "--client", "all")
+	if decode(t, out)["total"] != float64(2) {
+		t.Fatalf("--client all should not filter: %s", out)
+	}
+}
+
+func TestWebSearchFiltersByClient(t *testing.T) {
+	writeWebFixture(t)
+	out, code := execCLI(t, "synced-web-page", "search", "guide", "--client", "webext")
+	if code != 0 {
+		t.Fatalf("client-filtered search failed: %s", out)
+	}
+	if total := decode(t, out)["total"]; total != float64(0) {
+		t.Fatalf("search --client webext total = %v, want 0 (命中的是 legacy 那篇)", total)
+	}
+	out, _ = execCLI(t, "synced-web-page", "search", "guide", "--client", "legacy")
+	if total := decode(t, out)["total"]; total != float64(1) {
+		t.Fatalf("search --client legacy total = %v, want 1", total)
+	}
+}

--- a/internal/clientlabel/clientlabel.go
+++ b/internal/clientlabel/clientlabel.go
@@ -1,0 +1,36 @@
+// Package clientlabel 统一「一条数据属于哪个客户端」的判定。
+//
+// 各 store 用 clientLabel 记录数据来源（api-key 的 label，也就是一条 Relay
+// 隧道）。读取侧要按来源隔离时，判定规则必须三处一致——录音、网页、图片各写
+// 一遍迟早会走偏，所以集中在这里。
+package clientlabel
+
+import "strings"
+
+// Shared 判断 label 是否属于「没有明确来源」的数据：
+//   - ""        —— 0.9.0 之前入库的老条目，那时写入路径还没带上 label；
+//   - "default" —— 各 store 对空 label 的归一值；
+//   - "legacy"  —— 查询侧对空 label 的显示名。
+//
+// 这三类一律对所有客户端可见：升级前的存量数据几乎全是 default，按来源严格
+// 隔离会让它们从手机端整片消失。
+func Shared(label string) bool {
+	switch strings.ToLower(strings.TrimSpace(label)) {
+	case "", "default", "legacy":
+		return true
+	}
+	return false
+}
+
+// Visible 判断 entryLabel 的条目在 scope 视角下是否可见。
+// scope 为空表示本机/宿主视角（CLI、loopback、gateway token），不做隔离。
+func Visible(entryLabel, scope string) bool {
+	scope = strings.TrimSpace(scope)
+	if scope == "" || Shared(scope) {
+		return true
+	}
+	if Shared(entryLabel) {
+		return true
+	}
+	return strings.TrimSpace(entryLabel) == scope
+}

--- a/internal/clientlabel/clientlabel_test.go
+++ b/internal/clientlabel/clientlabel_test.go
@@ -1,0 +1,36 @@
+package clientlabel
+
+import "testing"
+
+func TestShared(t *testing.T) {
+	for _, label := range []string{"", "  ", "default", "Default", "legacy"} {
+		if !Shared(label) {
+			t.Errorf("Shared(%q) = false, want true", label)
+		}
+	}
+	for _, label := range []string{"phone-a", "8bf56c19debc4fd587378c88a4f419d8"} {
+		if Shared(label) {
+			t.Errorf("Shared(%q) = true, want false", label)
+		}
+	}
+}
+
+func TestVisible(t *testing.T) {
+	cases := []struct {
+		entry, scope string
+		want         bool
+	}{
+		{"phone-a", "", true},         // 本机视角不隔离
+		{"phone-a", "phone-a", true},  // 自己的数据
+		{"phone-a", "phone-b", false}, // 别人的数据
+		{"default", "phone-b", true},  // 老数据对所有人可见
+		{"", "phone-b", true},
+		{"legacy", "phone-b", true},
+		{"phone-a", "default", true}, // scope 本身没来源信息时不隔离
+	}
+	for _, c := range cases {
+		if got := Visible(c.entry, c.scope); got != c.want {
+			t.Errorf("Visible(%q, %q) = %v, want %v", c.entry, c.scope, got, c.want)
+		}
+	}
+}

--- a/internal/daemon/egress.go
+++ b/internal/daemon/egress.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/YoooClaw/cli/internal/relay"
@@ -15,6 +16,10 @@ import (
 // 见 docs/design/ingress-layering.md。
 type Egress interface {
 	PushEvent(event string, payload any) error
+	// PushEventTo 只投给指定 client label 的客户端。label 为空退化成广播；
+	// 传了 label 但对应通道不在时事件直接丢弃，不回退广播——那条数据属于
+	// 那个客户端，广播就是把它漏给别人。
+	PushEventTo(label string, event string, payload any) error
 }
 
 // RelayEgress 把事件经 Relay 隧道广播给手机端（standalone 模式）。
@@ -33,6 +38,21 @@ func (e *RelayEgress) PushEvent(event string, payload any) error {
 		return nil
 	}
 	e.sup.PushEvent(event, payload)
+	return nil
+}
+
+// PushEventTo 只经 label 对应的那条隧道投递。
+func (e *RelayEgress) PushEventTo(label string, event string, payload any) error {
+	if e.sup == nil {
+		return nil
+	}
+	if strings.TrimSpace(label) == "" {
+		e.sup.PushEvent(event, payload)
+		return nil
+	}
+	if !e.sup.PushEventTo(label, event, payload) {
+		return fmt.Errorf("client %q 没有在线隧道，事件已丢弃", label)
+	}
 	return nil
 }
 
@@ -61,7 +81,17 @@ var proxyEgressRetryDelays = []time.Duration{time.Second, 3 * time.Second, 9 * t
 // PushEvent 异步把 {event, payload} POST 给宿主回调。请求会保留自身的 10s
 // 超时，但调用方只负责排队，不会被宿主回调的延迟阻塞 ingest 响应。
 func (e *ProxyEgress) PushEvent(event string, payload any) error {
-	body, err := json.Marshal(map[string]any{"event": event, "payload": payload})
+	return e.PushEventTo("", event, payload)
+}
+
+// PushEventTo 带上 clientLabel 回投，定向投递由宿主按 label 转发；
+// label 为空时字段省略，回调体与旧版一致。
+func (e *ProxyEgress) PushEventTo(label string, event string, payload any) error {
+	frame := map[string]any{"event": event, "payload": payload}
+	if strings.TrimSpace(label) != "" {
+		frame["clientLabel"] = label
+	}
+	body, err := json.Marshal(frame)
 	if err != nil {
 		return err
 	}
@@ -116,3 +146,6 @@ type NoopEgress struct{}
 
 // PushEvent 丢弃事件。
 func (NoopEgress) PushEvent(string, any) error { return nil }
+
+// PushEventTo 丢弃事件。
+func (NoopEgress) PushEventTo(string, string, any) error { return nil }

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -365,9 +365,9 @@ func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case path == "/web-pages" && r.Method == http.MethodPost:
 		s.handleWebPageIngest(w, r, authCtx)
 	case path == "/web-pages/status" && r.Method == http.MethodGet:
-		s.handleWebPageStatus(w, r)
+		s.handleWebPageStatus(w, r, authCtx)
 	case path == "/web-pages/index" && r.Method == http.MethodGet:
-		s.handleWebPageIndex(w, r)
+		s.handleWebPageIndex(w, r, authCtx)
 	case path == "/monitors" || strings.HasPrefix(path, "/monitors/"):
 		s.handleMonitors(w, r, path)
 	case path == "/light/send" && r.Method == http.MethodPost:
@@ -417,6 +417,17 @@ func (s *server) reloadCredentials() (creds.CredentialSet, relay.ApplyResult) {
 type authResult struct {
 	clientLabel string
 	authKind    string
+}
+
+// scope 返回本次请求在读取侧应被限制到的 client label；空串表示不隔离。
+// 只有能确指某个客户端的鉴权方式（Relay 隧道、api-key）才收窄可见范围；
+// 本机 loopback 与宿主 gateway token 代表机器主人，看全量。
+func (a authResult) scope() string {
+	switch a.authKind {
+	case "relay-api-key", "http-api-key":
+		return a.clientLabel
+	}
+	return ""
 }
 
 func (s *server) authContext(r *http.Request, path string) (authResult, bool) {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -357,7 +357,7 @@ func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case path == "/gateway/notifications.push" && r.Method == http.MethodPost:
 		s.handleIngest(w, r, authCtx, "items")
 	case strings.HasPrefix(path, "/gateway/recordings.") && r.Method == http.MethodPost:
-		s.handleRecordingGateway(w, r, path)
+		s.handleRecordingGateway(w, r, authCtx, path)
 	case path == "/images" && r.Method == http.MethodPost:
 		s.handleImageHTTP(w, r, authCtx)
 	case path == "/gateway/images.sync" && r.Method == http.MethodPost:

--- a/internal/daemon/server_ingest.go
+++ b/internal/daemon/server_ingest.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/YoooClaw/cli/internal/clientlabel"
 	"github.com/YoooClaw/cli/internal/config"
 	"github.com/YoooClaw/cli/internal/fsutil"
 	imgstore "github.com/YoooClaw/cli/internal/image"
@@ -82,7 +83,7 @@ func (s *server) handleRecordingGateway(w http.ResponseWriter, r *http.Request, 
 			return
 		}
 		entry, ok := s.recordingStorage.FindByID(recordingID)
-		if !ok {
+		if !ok || !clientlabel.Visible(entry.ClientLabel, auth.scope()) {
 			gatewayErr(w, "NOT_FOUND", "Recording not found: "+recordingID)
 			return
 		}
@@ -133,8 +134,12 @@ func (s *server) handleRecordingGateway(w http.ResponseWriter, r *http.Request, 
 		if status != "" {
 			entries = s.recordingStorage.ListByStatus(status)
 		}
+		scope := auth.scope()
 		items := make([]map[string]any, 0, len(entries))
 		for _, entry := range entries {
+			if !clientlabel.Visible(entry.ClientLabel, scope) {
+				continue
+			}
 			items = append(items, recordingListItem(entry))
 		}
 		gatewayOK(w, map[string]any{"total": len(items), "recordings": items})
@@ -150,7 +155,7 @@ func (s *server) handleRecordingGateway(w http.ResponseWriter, r *http.Request, 
 			return
 		}
 		entry, ok := s.recordingStorage.FindByID(recordingID)
-		if !ok {
+		if !ok || !clientlabel.Visible(entry.ClientLabel, auth.scope()) {
 			gatewayErr(w, "NOT_FOUND", "Recording not found: "+recordingID)
 			return
 		}
@@ -168,6 +173,11 @@ func (s *server) handleRecordingGateway(w http.ResponseWriter, r *http.Request, 
 		name := strings.TrimSpace(body.Name)
 		if recordingID == "" || name == "" {
 			gatewayErr(w, "INVALID_PARAMS", "recordingId and name are required")
+			return
+		}
+		if existing, found := s.recordingStorage.FindByID(recordingID); !found ||
+			!clientlabel.Visible(existing.ClientLabel, auth.scope()) {
+			gatewayErr(w, "NOT_FOUND", "Recording not found: "+recordingID)
 			return
 		}
 		entry, ok, err := s.recordingStorage.Rename(recordingID, name)
@@ -192,6 +202,11 @@ func (s *server) handleRecordingGateway(w http.ResponseWriter, r *http.Request, 
 		recordingID := strings.TrimSpace(body.RecordingID)
 		if recordingID == "" {
 			gatewayErr(w, "INVALID_PARAMS", "recordingId is required")
+			return
+		}
+		if existing, found := s.recordingStorage.FindByID(recordingID); !found ||
+			!clientlabel.Visible(existing.ClientLabel, auth.scope()) {
+			gatewayErr(w, "NOT_FOUND", "Recording not found: "+recordingID)
 			return
 		}
 		deleted, err := s.recordingStorage.Delete(recordingID, !body.DeleteRemote)
@@ -252,8 +267,16 @@ func (s *server) notifyRecordingStatus(event recording.StatusEvent) {
 			s.logger.Warn("[recording-status] 事件落盘失败: " + err.Error())
 		}
 	}
+	// 事件只回给这条录音的来源客户端；来源不明的历史数据（label 空/default）
+	// 仍旧广播，否则老录音的转写进度谁都收不到。
+	label := ""
+	if s.recordingStorage != nil {
+		if entry, ok := s.recordingStorage.FindByID(event.RecordingID); ok && !clientlabel.Shared(entry.ClientLabel) {
+			label = entry.ClientLabel
+		}
+	}
 	if egress := s.currentEgress(); egress != nil {
-		if err := egress.PushEvent("recording.status", event); err != nil {
+		if err := egress.PushEventTo(label, "recording.status", event); err != nil {
 			s.logger.Warn("[recording-status] 出站事件投递失败: " + err.Error())
 		}
 	}

--- a/internal/daemon/server_ingest.go
+++ b/internal/daemon/server_ingest.go
@@ -15,7 +15,7 @@ type recordingIDBody struct {
 	ASR         *recording.AsrConfig `json:"asr,omitempty"`
 }
 
-func (s *server) handleRecordingGateway(w http.ResponseWriter, r *http.Request, path string) {
+func (s *server) handleRecordingGateway(w http.ResponseWriter, r *http.Request, auth authResult, path string) {
 	method := strings.TrimPrefix(path, "/gateway/")
 	switch method {
 	case "recordings.result.write":
@@ -41,6 +41,7 @@ func (s *server) handleRecordingGateway(w http.ResponseWriter, r *http.Request, 
 		body.RecordingID = recordingID
 		result, err := recording.HandleRecordingResultWrite(body, s.recordingStorage, s.logger, recording.SyncOptions{
 			NotifyStatus: s.notifyRecordingStatus,
+			ClientLabel:  auth.clientLabel,
 		})
 		if err != nil {
 			code := "RESULT_WRITE_FAILED"

--- a/internal/daemon/server_recording_label_test.go
+++ b/internal/daemon/server_recording_label_test.go
@@ -1,0 +1,50 @@
+package daemon
+
+import (
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/YoooClaw/cli/internal/recording"
+	"github.com/YoooClaw/cli/internal/relay"
+)
+
+// TestRecordingResultWriteKeepsRelayClientLabel 回归：录音经 Relay 隧道回环写入时，
+// 曾丢掉隧道自带的 client label，全部落到 default（通知走的是同一套鉴权，没这个问题）。
+func TestRecordingResultWriteKeepsRelayClientLabel(t *testing.T) {
+	srv, ts := newTestServer(t, "")
+	dir := filepath.Join(t.TempDir(), "recordings")
+	storage := recording.NewStorage(dir, srv.logger)
+	if err := storage.Init(); err != nil {
+		t.Fatal(err)
+	}
+	srv.recordingStorage = storage
+	srv.recordingEventLog = recording.NewEventLog(dir)
+	srv.egress = NoopEgress{}
+
+	const label = "8bf56c19debc4fd587378c88a4f419d8"
+	body := `{"recordingId":"rec_1","transcript":{"text":"你好"}}`
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/gateway/recordings.result.write", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set(relay.InternalHTTPHeader, "1")
+	req.Header.Set(relay.InternalClientLabelHeader, label)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("result.write status = %d", resp.StatusCode)
+	}
+
+	entry, ok := storage.FindByID("rec_1")
+	if !ok {
+		t.Fatal("recording not stored")
+	}
+	if entry.ClientLabel != label {
+		t.Fatalf("clientLabel = %q, want %q", entry.ClientLabel, label)
+	}
+}

--- a/internal/daemon/server_scope_test.go
+++ b/internal/daemon/server_scope_test.go
@@ -1,0 +1,209 @@
+package daemon
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/YoooClaw/cli/internal/recording"
+	"github.com/YoooClaw/cli/internal/relay"
+)
+
+// asClient 发一个带 Relay 隧道身份的请求；label 为空表示本机 loopback（不隔离）。
+func asClient(t *testing.T, method, url, label, body string) map[string]any {
+	t.Helper()
+	var reader io.Reader
+	if body != "" {
+		reader = strings.NewReader(body)
+	}
+	req, err := http.NewRequest(method, url, reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if label != "" {
+		req.Header.Set(relay.InternalHTTPHeader, "1")
+		req.Header.Set(relay.InternalClientLabelHeader, label)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var out map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode %s %s: %v", method, url, err)
+	}
+	return out
+}
+
+func gatewayData(t *testing.T, resp map[string]any) map[string]any {
+	t.Helper()
+	if ok, _ := resp["ok"].(bool); !ok {
+		t.Fatalf("gateway call failed: %+v", resp)
+	}
+	data, _ := resp["data"].(map[string]any)
+	return data
+}
+
+func recordingIDs(t *testing.T, resp map[string]any) []string {
+	t.Helper()
+	raw, _ := gatewayData(t, resp)["recordings"].([]any)
+	ids := make([]string, 0, len(raw))
+	for _, item := range raw {
+		id, _ := item.(map[string]any)["recordingId"].(string)
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func withRecordings(t *testing.T, srv *server) *recording.Storage {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "recordings")
+	storage := recording.NewStorage(dir, srv.logger)
+	if err := storage.Init(); err != nil {
+		t.Fatal(err)
+	}
+	srv.recordingStorage = storage
+	srv.recordingEventLog = recording.NewEventLog(dir)
+	srv.egress = NoopEgress{}
+	return storage
+}
+
+// TestRecordingReadScopedByClientLabel：手机 A 只看得到自己的录音 + 来源不明的
+// 历史数据，看不到手机 B 的；本机 loopback 看全量。
+func TestRecordingReadScopedByClientLabel(t *testing.T) {
+	srv, ts := newTestServer(t, "")
+	storage := withRecordings(t, srv)
+	for id, label := range map[string]string{"rec_a": "phone-a", "rec_b": "phone-b", "rec_old": ""} {
+		if _, err := storage.Ingest(id, recording.Metadata{Name: id}, label); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	listURL := ts.URL + "/gateway/recordings.list"
+	got := recordingIDs(t, asClient(t, http.MethodPost, listURL, "phone-a", `{}`))
+	want := map[string]bool{"rec_a": true, "rec_old": true}
+	if len(got) != 2 {
+		t.Fatalf("phone-a sees %v, want rec_a + rec_old", got)
+	}
+	for _, id := range got {
+		if !want[id] {
+			t.Fatalf("phone-a sees %v, want rec_a + rec_old", got)
+		}
+	}
+	if local := recordingIDs(t, asClient(t, http.MethodPost, listURL, "", `{}`)); len(local) != 3 {
+		t.Fatalf("loopback sees %v, want all 3", local)
+	}
+}
+
+// TestRecordingMutationScopedByClientLabel：别的客户端的录音一律当不存在，
+// 读、改名、删除、重转写都不能越界。
+func TestRecordingMutationScopedByClientLabel(t *testing.T) {
+	srv, ts := newTestServer(t, "")
+	storage := withRecordings(t, srv)
+	if _, err := storage.Ingest("rec_b", recording.Metadata{Name: "B 的录音"}, "phone-b"); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, c := range []struct{ method, body string }{
+		{"recordings.status", `{"recordingId":"rec_b"}`},
+		{"recordings.rename", `{"recordingId":"rec_b","name":"改个名"}`},
+		{"recordings.delete", `{"recordingId":"rec_b"}`},
+		{"recordings.retranscribe", `{"recordingId":"rec_b","asr":{"mode":"api"}}`},
+	} {
+		resp := asClient(t, http.MethodPost, ts.URL+"/gateway/"+c.method, "phone-a", c.body)
+		errBody, _ := resp["error"].(map[string]any)
+		if ok, _ := resp["ok"].(bool); ok || errBody["code"] != "NOT_FOUND" {
+			t.Errorf("%s as phone-a = %+v, want NOT_FOUND", c.method, resp)
+		}
+	}
+	if entry, _ := storage.FindByID("rec_b"); entry.Metadata.Name != "B 的录音" {
+		t.Errorf("phone-a renamed another client's recording: %+v", entry)
+	}
+}
+
+// TestWebPageReadScopedByClientLabel：扩展只回填自己收藏的网页。
+func TestWebPageReadScopedByClientLabel(t *testing.T) {
+	_, ts := newTestServer(t, "")
+	pages := map[string]string{"webext-a": "https://a.example.com/x", "webext-b": "https://b.example.com/y"}
+	for label, url := range pages {
+		body := `{"canonicalUrl":"` + url + `","url":"` + url + `","title":"t","markdown":"# t"}`
+		resp := asClient(t, http.MethodPost, ts.URL+"/web-pages", label, body)
+		if ok, _ := resp["ok"].(bool); !ok {
+			t.Fatalf("ingest as %s failed: %+v", label, resp)
+		}
+	}
+
+	indexed := func(label string) []any {
+		resp := asClient(t, http.MethodGet, ts.URL+"/web-pages/index", label, "")
+		out, _ := resp["pages"].([]any)
+		return out
+	}
+	if got := indexed("webext-a"); len(got) != 1 {
+		t.Fatalf("webext-a index = %+v, want only its own page", got)
+	}
+	if got := indexed(""); len(got) != 2 {
+		t.Fatalf("loopback index = %+v, want both pages", got)
+	}
+
+	// status 走同一份可见性判定：别人的 hash 不能回「已收藏」。
+	hash := indexed("webext-b")[0].(map[string]any)["urlHash"].(string)
+	resp := asClient(t, http.MethodGet, ts.URL+"/web-pages/status?h="+hash, "webext-a", "")
+	saved, _ := resp["saved"].(map[string]any)
+	if len(saved) != 0 {
+		t.Errorf("webext-a sees webext-b's page as saved: %+v", saved)
+	}
+	resp = asClient(t, http.MethodGet, ts.URL+"/web-pages/status?h="+hash, "webext-b", "")
+	if saved, _ = resp["saved"].(map[string]any); len(saved) != 1 {
+		t.Errorf("webext-b lost its own page: %+v", resp)
+	}
+}
+
+type recordingEgress struct {
+	broadcast []string
+	targeted  map[string]int
+}
+
+func (e *recordingEgress) PushEvent(event string, _ any) error {
+	e.broadcast = append(e.broadcast, event)
+	return nil
+}
+
+func (e *recordingEgress) PushEventTo(label string, event string, payload any) error {
+	if label == "" {
+		return e.PushEvent(event, payload)
+	}
+	if e.targeted == nil {
+		e.targeted = map[string]int{}
+	}
+	e.targeted[label]++
+	return nil
+}
+
+// TestRecordingStatusEventTargetsOwner：录音状态事件只回给来源客户端，
+// 来源不明的历史录音仍旧广播。
+func TestRecordingStatusEventTargetsOwner(t *testing.T) {
+	srv, _ := newTestServer(t, "")
+	storage := withRecordings(t, srv)
+	egress := &recordingEgress{}
+	srv.egress = egress
+	if _, err := storage.Ingest("rec_a", recording.Metadata{Name: "A"}, "phone-a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := storage.Ingest("rec_old", recording.Metadata{Name: "老录音"}, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	srv.notifyRecordingStatus(recording.StatusEvent{RecordingID: "rec_a", TransferStatus: recording.StatusTranscribed})
+	if egress.targeted["phone-a"] != 1 || len(egress.broadcast) != 0 {
+		t.Fatalf("owned recording not targeted: targeted=%+v broadcast=%+v", egress.targeted, egress.broadcast)
+	}
+
+	srv.notifyRecordingStatus(recording.StatusEvent{RecordingID: "rec_old", TransferStatus: recording.StatusTranscribed})
+	if len(egress.broadcast) != 1 {
+		t.Fatalf("legacy recording not broadcast: %+v", egress.broadcast)
+	}
+}

--- a/internal/daemon/server_webpage.go
+++ b/internal/daemon/server_webpage.go
@@ -30,15 +30,15 @@ func (s *server) handleWebPageIngest(w http.ResponseWriter, r *http.Request, aut
 
 // handleWebPageStatus 回答「这些网页收过没有」（GET /web-pages/status?h=…&h=…），
 // 供扩展 popup 打开时就地核对本地索引（§3.4）。
-func (s *server) handleWebPageStatus(w http.ResponseWriter, r *http.Request) {
+func (s *server) handleWebPageStatus(w http.ResponseWriter, r *http.Request, auth authResult) {
 	hashes := r.URL.Query()["h"]
-	writeJSON(w, 200, map[string]any{"saved": webpage.Status(s.ctx.Paths.WebPages, hashes)})
+	writeJSON(w, 200, map[string]any{"saved": webpage.Status(s.ctx.Paths.WebPages, hashes, auth.scope())})
 }
 
 // handleWebPageIndex 返回索引（GET /web-pages/index?fields=hash,capturedAt），
 // 供扩展登录后一次性回填本地收藏状态。
-func (s *server) handleWebPageIndex(w http.ResponseWriter, r *http.Request) {
-	entries := webpage.ReadIndex(s.ctx.Paths.WebPages)
+func (s *server) handleWebPageIndex(w http.ResponseWriter, r *http.Request, auth authResult) {
+	entries := webpage.FilterByScope(webpage.ReadIndex(s.ctx.Paths.WebPages), auth.scope())
 	webpage.SortByCapturedDesc(entries)
 	var fields []string
 	if raw := strings.TrimSpace(r.URL.Query().Get("fields")); raw != "" {

--- a/internal/errs/errors.go
+++ b/internal/errs/errors.go
@@ -32,6 +32,7 @@ const (
 	CodeConfirmationRequired    = "YOOOCLAW_CONFIRMATION_REQUIRED"
 	CodeNotInteractive          = "YOOOCLAW_NOT_INTERACTIVE"
 	CodeDaemonUnresponsive      = "YOOOCLAW_DAEMON_UNRESPONSIVE"
+	CodeAutostartUnavailable    = "YOOOCLAW_AUTOSTART_UNAVAILABLE"
 	CodeVoiceStorageNotFound    = "YOOOCLAW_VOICE_STORAGE_NOT_FOUND"
 	CodeVoiceSchemaUnsupported  = "YOOOCLAW_VOICE_SCHEMA_UNSUPPORTED"
 )

--- a/internal/recording/handler.go
+++ b/internal/recording/handler.go
@@ -6,6 +6,9 @@ import "fmt"
 type SyncOptions struct {
 	NotifyStatus    func(StatusEvent)
 	DownloadOptions DownloadOptions
+	// ClientLabel 是本次调用的来源客户端 label（daemon 侧鉴权解析，非请求体字段）；
+	// 留空按 "default" 入库。
+	ClientLabel string
 }
 
 // TriggerTranscription 触发 ASR 转写。

--- a/internal/recording/result_writer.go
+++ b/internal/recording/result_writer.go
@@ -94,9 +94,10 @@ func HandleRecordingResultWrite(params ResultWriteParams, storage *Storage, logg
 	}
 
 	entry, found := storage.FindByID(recordingID)
+	clientLabel := strings.TrimSpace(opts.ClientLabel)
 	if !found {
 		metadata, timeSource := buildPlaceholderMetadata(recordingID, params)
-		if _, err := storage.Ingest(recordingID, metadata, ""); err != nil {
+		if _, err := storage.Ingest(recordingID, metadata, clientLabel); err != nil {
 			return ResultWriteResult{}, err
 		}
 		var ok bool
@@ -104,19 +105,32 @@ func HandleRecordingResultWrite(params ResultWriteParams, storage *Storage, logg
 		if !ok {
 			return ResultWriteResult{}, fmt.Errorf("Recording not found: %s", recordingID)
 		}
-		logger.Info("[recording-result] 录音不存在，已按结果写入新建: " + recordingID)
+		logger.Info("[recording-result] 录音不存在，已按结果写入新建: " + recordingID +
+			", client=" + entry.ClientLabel)
 		logger.Info("[recording-result] 录音时间已入库: " + recordingID +
 			", created_at=" + entry.Metadata.CreatedAt + ", source=" + timeSource)
-	} else if merged, timeSource, changed := mergeResultMetadata(entry.Metadata, params); changed {
-		if err := storage.updateEntry(recordingID, func(current *Entry) {
-			current.Metadata = merged
-		}); err != nil {
-			return ResultWriteResult{}, err
+	} else {
+		// 已有录音：来源 label 以本次推送为准，顺带把早期写成 default 的老数据纠回来。
+		if clientLabel != "" && entry.ClientLabel != clientLabel {
+			if err := storage.updateEntry(recordingID, func(current *Entry) {
+				current.ClientLabel = clientLabel
+			}); err != nil {
+				return ResultWriteResult{}, err
+			}
+			entry, _ = storage.FindByID(recordingID)
+			logger.Info("[recording-result] 录音来源已更新: " + recordingID + ", client=" + clientLabel)
 		}
-		entry, _ = storage.FindByID(recordingID)
-		if timeSource != "" {
-			logger.Info("[recording-result] 录音时间已更新: " + recordingID +
-				", created_at=" + entry.Metadata.CreatedAt + ", source=" + timeSource)
+		if merged, timeSource, changed := mergeResultMetadata(entry.Metadata, params); changed {
+			if err := storage.updateEntry(recordingID, func(current *Entry) {
+				current.Metadata = merged
+			}); err != nil {
+				return ResultWriteResult{}, err
+			}
+			entry, _ = storage.FindByID(recordingID)
+			if timeSource != "" {
+				logger.Info("[recording-result] 录音时间已更新: " + recordingID +
+					", created_at=" + entry.Metadata.CreatedAt + ", source=" + timeSource)
+			}
 		}
 	}
 

--- a/internal/recording/result_writer_label_test.go
+++ b/internal/recording/result_writer_label_test.go
@@ -1,0 +1,61 @@
+package recording
+
+import "testing"
+
+func TestResultWriteUsesClientLabel(t *testing.T) {
+	t.Parallel()
+	storage := newResultStorage(t)
+
+	if _, err := HandleRecordingResultWrite(ResultWriteParams{
+		RecordingID: "rec_new",
+		Transcript:  &ResultTranscript{Text: "你好"},
+	}, storage, testLogger{t}, SyncOptions{ClientLabel: "phone-a"}); err != nil {
+		t.Fatal(err)
+	}
+	entry, ok := storage.FindByID("rec_new")
+	if !ok || entry.ClientLabel != "phone-a" {
+		t.Fatalf("new recording clientLabel = %q, want phone-a", entry.ClientLabel)
+	}
+}
+
+// 老数据（或早期版本写入的）label 是 default，再次收到结果时按来源纠正。
+func TestResultWriteBackfillsClientLabel(t *testing.T) {
+	t.Parallel()
+	storage := newResultStorage(t)
+	if _, err := storage.Ingest("rec_old", Metadata{Name: "会议"}, ""); err != nil {
+		t.Fatal(err)
+	}
+	if entry, _ := storage.FindByID("rec_old"); entry.ClientLabel != "default" {
+		t.Fatalf("precondition: clientLabel = %q", entry.ClientLabel)
+	}
+
+	if _, err := HandleRecordingResultWrite(ResultWriteParams{
+		RecordingID: "rec_old",
+		Summary:     &ResultSummary{Markdown: "# 总结"},
+	}, storage, testLogger{t}, SyncOptions{ClientLabel: "phone-b"}); err != nil {
+		t.Fatal(err)
+	}
+	entry, _ := storage.FindByID("rec_old")
+	if entry.ClientLabel != "phone-b" {
+		t.Fatalf("clientLabel = %q, want phone-b", entry.ClientLabel)
+	}
+}
+
+// 没有来源信息时不应把已有 label 抹成 default。
+func TestResultWriteKeepsLabelWhenUnknown(t *testing.T) {
+	t.Parallel()
+	storage := newResultStorage(t)
+	if _, err := storage.Ingest("rec_keep", Metadata{Name: "会议"}, "phone-c"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := HandleRecordingResultWrite(ResultWriteParams{
+		RecordingID: "rec_keep",
+		Summary:     &ResultSummary{Markdown: "# 总结"},
+	}, storage, testLogger{t}, SyncOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	entry, _ := storage.FindByID("rec_keep")
+	if entry.ClientLabel != "phone-c" {
+		t.Fatalf("clientLabel = %q, want phone-c", entry.ClientLabel)
+	}
+}

--- a/internal/relay/supervisor.go
+++ b/internal/relay/supervisor.go
@@ -153,6 +153,19 @@ func (s *Supervisor) PushEvent(event string, payload any) {
 	}
 }
 
+// PushEventTo 只把事件投给 label 对应的那条隧道，返回是否投出去了。
+// 隧道不存在或没连上时返回 false——事件属于那个客户端，广播出去等于泄露。
+func (s *Supervisor) PushEventTo(label string, event string, payload any) bool {
+	s.mu.Lock()
+	managed := s.tunnels[label]
+	s.mu.Unlock()
+	if managed == nil {
+		return false
+	}
+	managed.dispatcher.PushEvent(event, payload)
+	return true
+}
+
 // Status 返回所有隧道状态。
 func (s *Supervisor) Status() SupervisorStatus {
 	s.mu.Lock()

--- a/internal/webpage/store.go
+++ b/internal/webpage/store.go
@@ -30,6 +30,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/YoooClaw/cli/internal/clientlabel"
 	"github.com/YoooClaw/cli/internal/fsutil"
 )
 
@@ -284,9 +285,9 @@ func DecodeArchive(archive Archive) ([]byte, error) {
 
 // Status 回答「这些 URL 收过没有」。入参可以是完整 hash，也可以是扩展本地
 // 索引里那种 16 位前缀（§3.4：本地索引存 hash 不存明文 URL）。
-func Status(dir string, hashes []string) map[string]map[string]string {
+func Status(dir string, hashes []string, scope string) map[string]map[string]string {
 	saved := map[string]map[string]string{}
-	entries := ReadIndex(dir)
+	entries := FilterByScope(ReadIndex(dir), scope)
 	for _, raw := range hashes {
 		query := strings.ToLower(strings.TrimSpace(raw))
 		// 太短的前缀会命中一大片，不如不答。
@@ -301,6 +302,21 @@ func Status(dir string, hashes []string) map[string]map[string]string {
 		}
 	}
 	return saved
+}
+
+// FilterByScope 只保留 scope 视角可见的网页：scope 为空（本机/宿主）时返回全部，
+// 否则只留本客户端收藏的与来源不明的历史条目。
+func FilterByScope(entries []Entry, scope string) []Entry {
+	if strings.TrimSpace(scope) == "" {
+		return entries
+	}
+	visible := make([]Entry, 0, len(entries))
+	for _, entry := range entries {
+		if clientlabel.Visible(entry.ClientLabel, scope) {
+			visible = append(visible, entry)
+		}
+	}
+	return visible
 }
 
 // ReadIndex 读取 web-pages/index.json 的 pages[]；不存在返回空。

--- a/internal/webpage/store_test.go
+++ b/internal/webpage/store_test.go
@@ -297,7 +297,7 @@ func TestStatusMatchesFullHashAndPrefix(t *testing.T) {
 	}
 	full := result.URLHash
 
-	saved := Status(dir, []string{full, full[:16], strings.ToUpper(full[:16]), "deadbeef", "abc"})
+	saved := Status(dir, []string{full, full[:16], strings.ToUpper(full[:16]), "deadbeef", "abc"}, "")
 	if saved[full]["capturedAt"] != "2026-07-27T15:04:22+08:00" {
 		t.Errorf("完整 hash 未命中: %+v", saved)
 	}

--- a/npm/cli/bin/activate-owner.js
+++ b/npm/cli/bin/activate-owner.js
@@ -58,6 +58,15 @@ function run(args) {
   }
 }
 
+function tryRun(args) {
+  const result = spawnSync(bin, args, {
+    stdio: "inherit",
+    env: process.env,
+    windowsHide: true,
+  });
+  return !result.error && result.status === 0;
+}
+
 if (activationRequested) {
   const args = ["owner", "activate", "cli", "--format", "json"];
   if (process.env.HERMES_PROFILE) {
@@ -66,7 +75,14 @@ if (activationRequested) {
   run(args);
 } else {
   for (const profile of runningProfiles) {
-    run(["--profile", profile, "daemon", "start", "--format", "json"]);
+    if (
+      !tryRun(["--profile", profile, "daemon", "autostart", "enable", "--format", "json"])
+    ) {
+      process.stderr.write(
+        `@yoooclaw/cli: autostart unavailable; restoring detached daemon for ${profile}\n`,
+      );
+      run(["--profile", profile, "daemon", "start", "--format", "json"]);
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.8.2",
+  "version": "0.9.0-beta.0",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -377,9 +377,13 @@ if [ "$ACTIVATE_OWNER" -eq 1 ]; then
   fi
 else
   for profile_name in $STOPPED_PROFILES; do
-    yoooclaw --profile "$profile_name" daemon start >/dev/null \
-      || err "CLI 已更新，但无法恢复 profile $profile_name 的 daemon；请运行: yoooclaw --profile $profile_name daemon start"
-    info "已恢复 CLI daemon: $profile_name"
+    if yoooclaw --profile "$profile_name" daemon autostart enable >/dev/null; then
+      info "已恢复 CLI daemon 并启用登录自启: $profile_name"
+    else
+      warn "当前环境无法配置用户级自启，降级恢复 detached daemon: $profile_name"
+      yoooclaw --profile "$profile_name" daemon start >/dev/null \
+        || err "CLI 已更新，但无法恢复 profile $profile_name 的 daemon；请运行: yoooclaw --profile $profile_name daemon start"
+    fi
   done
   info "已保留当前 Relay owner（如需切换到 CLI，请重新运行并加 --activate）"
 fi

--- a/scripts/install_test.go
+++ b/scripts/install_test.go
@@ -208,7 +208,7 @@ esac
 	for _, want := range []string{
 		"old:--profile default daemon status",
 		"old:--profile default daemon stop",
-		"new:--profile default daemon start",
+		"new:--profile default daemon autostart enable",
 	} {
 		if !strings.Contains(logText, want) {
 			t.Fatalf("update did not preserve CLI owner (%q missing):\n%s", want, logText)
@@ -309,7 +309,7 @@ exit 0
 	for _, want := range []string{
 		"old:--profile default daemon status",
 		"old:--profile default daemon stop",
-		"new:--profile default daemon start",
+		"new:--profile default daemon autostart enable",
 	} {
 		if !strings.Contains(logText, want) {
 			t.Fatalf("npm lifecycle did not restore CLI owner (%q missing):\n%s", want, logText)

--- a/skills/yoooclaw-context-query/references/web-pages.md
+++ b/skills/yoooclaw-context-query/references/web-pages.md
@@ -12,12 +12,12 @@ The captured copy is local historical context, not proof of the current live Int
 
 ```bash
 yoooclaw synced-web-page storage-path --format json
-yoooclaw synced-web-page list [--from <ISO_TIME>] [--to <ISO_TIME>] --format json
-yoooclaw synced-web-page search "<keyword>" --limit <requested-count-or-total-pages> --format json
+yoooclaw synced-web-page list [--from <ISO_TIME>] [--to <ISO_TIME>] [--client <label>] --format json
+yoooclaw synced-web-page search "<keyword>" --limit <requested-count-or-total-pages> [--client <label>] --format json
 yoooclaw synced-web-page path <urlHash> --format json
 ```
 
-`yoooclaw synced-web-page list` returns newest capture first with fields including `urlHash`, `title`, `siteName`, `canonicalUrl`, `capturedAt`, `firstCapturedAt`, `captureCount`, `relativePath`, and `hasArchive`. Its optional ISO 8601 `--from` boundary is inclusive and `--to` boundary is exclusive.
+`yoooclaw synced-web-page list` returns newest capture first with fields including `urlHash`, `title`, `siteName`, `canonicalUrl`, `capturedAt`, `firstCapturedAt`, `captureCount`, `relativePath`, and `hasArchive`. Its optional ISO 8601 `--from` boundary is inclusive and `--to` boundary is exclusive. Pass `--client <label>` only for an explicit source filter (`all` disables it); pages captured before client labels existed report `legacy`.
 
 `yoooclaw synced-web-page search` searches title, site name, URL, canonical URL, and Markdown body. It intentionally does not search raw HTML archives or access the Internet.
 


### PR DESCRIPTION
合回主干：0.9.0-beta.0 已随 tag `cli-v0.9.0-beta.0` 发布（npm dist-tag `beta`）。

## 本次改动
- feat: daemon 默认开启开机自启（新增 `internal/autostart`，覆盖 darwin/linux/windows，配套 `yoooclaw daemon autostart` 子命令与 doctor 检查）
- fix(recording): 录音入库带上来源 client label
- feat(daemon): 读取侧按 client label 隔离（新增 `internal/clientlabel`，webpage/recording 读写按 label 分域）
- chore: package.json 版本 bump 到 0.9.0-beta.0

## 验证
- Release CLI workflow 全绿：https://github.com/YoooClaw/cli/actions/runs/32476366551
- npm dist-tags：`beta: 0.9.0-beta.0`（latest 仍为 0.8.2）

🤖 Generated with [Claude Code](https://claude.com/claude-code)