### PR TITLE
chore(windows): 补充录音索引写盘失败诊断日志

### DIFF
--- a/internal/daemon/server_ingest.go
+++ b/internal/daemon/server_ingest.go
@@ -9,6 +9,7 @@ import (
 	"github.com/YoooClaw/cli/internal/fsutil"
 	imgstore "github.com/YoooClaw/cli/internal/image"
 	"github.com/YoooClaw/cli/internal/recording"
+	"github.com/YoooClaw/cli/internal/relay"
 )
 
 type recordingIDBody struct {
@@ -52,6 +53,7 @@ func (s *server) handleRecordingGateway(w http.ResponseWriter, r *http.Request, 
 			case err.Error() == "recordingId is required" || err.Error() == "transcript or summary is required":
 				code = "INVALID_PARAMS"
 			}
+			s.logRecordingWriteFailure(recordingID, r.Header.Get(relay.InternalRequestIDHeader), err)
 			gatewayErr(w, code, err.Error())
 			return
 		}

--- a/internal/daemon/server_recording_diag.go
+++ b/internal/daemon/server_recording_diag.go
@@ -1,0 +1,74 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/YoooClaw/cli/internal/filelockdiag"
+)
+
+// logRecordingWriteFailure 先同步记录请求上下文，再异步查询 Windows 文件占用者。
+// Restart Manager 诊断不能拖慢 Relay 的失败响应；每次写盘失败都独立采集现场。
+func (s *server) logRecordingWriteFailure(recordingID, relayID string, err error) {
+	fields := "recordingId=" + recordingID
+	if relayID = strings.TrimSpace(relayID); relayID != "" {
+		fields += ", relay=" + relayID
+	}
+	s.logger.Error("[recording-result] 写入失败: " + fields + ", error=" + err.Error())
+
+	target, ok := recordingIndexRenameTarget(err)
+	if !ok {
+		return
+	}
+	go s.logFileLockHolders(target, recordingID, relayID)
+}
+
+func recordingIndexRenameTarget(err error) (string, bool) {
+	var linkErr *os.LinkError
+	if !errors.As(err, &linkErr) || !strings.EqualFold(linkErr.Op, "rename") {
+		return "", false
+	}
+	target := strings.TrimSpace(linkErr.New)
+	if target == "" || !strings.EqualFold(filepath.Base(target), "index.json") {
+		return "", false
+	}
+	return filepath.Clean(target), true
+}
+
+func (s *server) logFileLockHolders(path, recordingID, relayID string) {
+	holders, supported, err := filelockdiag.Lookup(path)
+	if !supported {
+		return
+	}
+	context := "recordingId=" + recordingID
+	if relayID != "" {
+		context += ", relay=" + relayID
+	}
+	if err != nil {
+		s.logger.Warn("[recording-store] 查询 index.json 占用进程失败: " + context +
+			", path=" + path + ", error=" + err.Error())
+		return
+	}
+	if len(holders) == 0 {
+		s.logger.Warn("[recording-store] index.json 替换被拒绝，但 Restart Manager 未识别到占用进程: " +
+			context + ", path=" + path + "（可能是瞬时占用、ACL、只读属性或安全软件）")
+		return
+	}
+	parts := make([]string, 0, len(holders))
+	for _, holder := range holders {
+		parts = append(parts, fmt.Sprintf("{pid=%d, app=%q, service=%q, type=%d, restartable=%t}",
+			holder.PID, cleanLogField(holder.Application), cleanLogField(holder.Service),
+			holder.ApplicationType, holder.Restartable))
+	}
+	// Restart Manager 能确认哪些进程正在使用该文件，但不暴露每个句柄的
+	// FILE_SHARE_DELETE 标志；因此只称“相关占用进程”，不武断归因其中某一个。
+	s.logger.Error("[recording-store] index.json 相关占用进程（Restart Manager）: " + context +
+		", path=" + path + ", holders=[" + strings.Join(parts, ", ") + "]")
+}
+
+func cleanLogField(value string) string {
+	return strings.Join(strings.Fields(value), " ")
+}

--- a/internal/daemon/server_recording_diag_test.go
+++ b/internal/daemon/server_recording_diag_test.go
@@ -1,0 +1,49 @@
+package daemon
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRecordingIndexRenameTarget(t *testing.T) {
+	target := filepath.Join("recordings", "index.json")
+	err := &os.LinkError{Op: "rename", Old: filepath.Join("recordings", ".abc.tmp"), New: target, Err: os.ErrPermission}
+	got, ok := recordingIndexRenameTarget(err)
+	if !ok || got != filepath.Clean(target) {
+		t.Fatalf("target=(%q,%v), want (%q,true)", got, ok, filepath.Clean(target))
+	}
+	if _, ok := recordingIndexRenameTarget(&os.PathError{Op: "open", Path: target, Err: os.ErrPermission}); ok {
+		t.Fatal("non-rename error unexpectedly selected for holder diagnosis")
+	}
+	if _, ok := recordingIndexRenameTarget(&os.LinkError{Op: "rename", Old: "a", New: "summary.json", Err: os.ErrPermission}); ok {
+		t.Fatal("non-index target unexpectedly selected for holder diagnosis")
+	}
+	if _, ok := recordingIndexRenameTarget(errors.New("plain error")); ok {
+		t.Fatal("plain error unexpectedly selected for holder diagnosis")
+	}
+}
+
+func TestLogRecordingWriteFailureIncludesRequestContext(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "daemon.log")
+	s := &server{logger: NewLogger(logPath, "info", false)}
+	s.logRecordingWriteFailure("rec-123", "relay-256", errors.New("write failed"))
+
+	raw, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := string(raw)
+	for _, want := range []string{
+		"[recording-result] 写入失败",
+		"recordingId=rec-123",
+		"relay=relay-256",
+		"error=write failed",
+	} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("log missing %q: %s", want, line)
+		}
+	}
+}

--- a/internal/filelockdiag/holders.go
+++ b/internal/filelockdiag/holders.go
@@ -1,0 +1,11 @@
+// Package filelockdiag 提供文件占用者诊断。它只做只读查询，绝不关闭句柄或终止进程。
+package filelockdiag
+
+// Holder 描述一个由操作系统识别出的文件占用进程。
+type Holder struct {
+	PID             uint32
+	Application     string
+	Service         string
+	ApplicationType uint32
+	Restartable     bool
+}

--- a/internal/filelockdiag/holders_other.go
+++ b/internal/filelockdiag/holders_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package filelockdiag
+
+// Lookup 在非 Windows 平台不受支持。supported=false 让调用方保持安静，
+// 避免为一个仅用于 Windows rename 失败的诊断输出无意义告警。
+func Lookup(_ string) (holders []Holder, supported bool, err error) {
+	return nil, false, nil
+}

--- a/internal/filelockdiag/holders_windows.go
+++ b/internal/filelockdiag/holders_windows.go
@@ -1,0 +1,127 @@
+//go:build windows
+
+package filelockdiag
+
+import (
+	"fmt"
+	"sort"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	rmSessionKeyLen = 32
+	rmMaxAppName    = 255
+	rmMaxSvcName    = 63
+	errorMoreData   = syscall.Errno(234)
+)
+
+var (
+	restartManagerDLL  = syscall.NewLazyDLL("rstrtmgr.dll")
+	rmStartSessionProc = restartManagerDLL.NewProc("RmStartSession")
+	rmRegisterProc     = restartManagerDLL.NewProc("RmRegisterResources")
+	rmGetListProc      = restartManagerDLL.NewProc("RmGetList")
+	rmEndSessionProc   = restartManagerDLL.NewProc("RmEndSession")
+)
+
+type rmUniqueProcess struct {
+	ProcessID        uint32
+	ProcessStartTime syscall.Filetime
+}
+
+type rmProcessInfo struct {
+	Process          rmUniqueProcess
+	Application      [rmMaxAppName + 1]uint16
+	Service          [rmMaxSvcName + 1]uint16
+	ApplicationType  uint32
+	ApplicationState uint32
+	TerminalSession  uint32
+	Restartable      int32
+}
+
+// Lookup 使用 Windows Restart Manager 查询当前占用 path 的进程。
+// Restart Manager 只枚举占用者，不会关闭句柄、停止服务或结束进程。
+func Lookup(path string) ([]Holder, bool, error) {
+	pathPtr, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, true, err
+	}
+
+	var session uint32
+	key := make([]uint16, rmSessionKeyLen+1)
+	code, _, _ := rmStartSessionProc.Call(
+		uintptr(unsafe.Pointer(&session)), 0, uintptr(unsafe.Pointer(&key[0])),
+	)
+	if code != 0 {
+		return nil, true, rmError("RmStartSession", code)
+	}
+	defer rmEndSessionProc.Call(uintptr(session))
+
+	files := []*uint16{pathPtr}
+	code, _, _ = rmRegisterProc.Call(
+		uintptr(session), 1, uintptr(unsafe.Pointer(&files[0])),
+		0, 0, 0, 0,
+	)
+	if code != 0 {
+		return nil, true, rmError("RmRegisterResources", code)
+	}
+
+	// 占用者可能在两次 RmGetList 之间变化；最多重试三次重新分配。
+	for attempt := 0; attempt < 3; attempt++ {
+		var needed, count, rebootReasons uint32
+		code, _, _ = rmGetListProc.Call(
+			uintptr(session),
+			uintptr(unsafe.Pointer(&needed)),
+			uintptr(unsafe.Pointer(&count)),
+			0,
+			uintptr(unsafe.Pointer(&rebootReasons)),
+		)
+		if code == 0 && needed == 0 {
+			return []Holder{}, true, nil
+		}
+		if syscall.Errno(code) != errorMoreData {
+			return nil, true, rmError("RmGetList(size)", code)
+		}
+		if needed == 0 {
+			return []Holder{}, true, nil
+		}
+
+		infos := make([]rmProcessInfo, needed)
+		count = needed
+		code, _, _ = rmGetListProc.Call(
+			uintptr(session),
+			uintptr(unsafe.Pointer(&needed)),
+			uintptr(unsafe.Pointer(&count)),
+			uintptr(unsafe.Pointer(&infos[0])),
+			uintptr(unsafe.Pointer(&rebootReasons)),
+		)
+		if syscall.Errno(code) == errorMoreData {
+			continue
+		}
+		if code != 0 {
+			return nil, true, rmError("RmGetList", code)
+		}
+
+		holders := make([]Holder, 0, count)
+		for i := uint32(0); i < count; i++ {
+			info := infos[i]
+			holders = append(holders, Holder{
+				PID:             info.Process.ProcessID,
+				Application:     syscall.UTF16ToString(info.Application[:]),
+				Service:         syscall.UTF16ToString(info.Service[:]),
+				ApplicationType: info.ApplicationType,
+				Restartable:     info.Restartable != 0,
+			})
+		}
+		sort.Slice(holders, func(i, j int) bool { return holders[i].PID < holders[j].PID })
+		return holders, true, nil
+	}
+	return nil, true, fmt.Errorf("RmGetList: 占用进程列表持续变化")
+}
+
+func rmError(op string, code uintptr) error {
+	if code == 0 {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", op, syscall.Errno(code))
+}

--- a/internal/filelockdiag/holders_windows_test.go
+++ b/internal/filelockdiag/holders_windows_test.go
@@ -1,0 +1,38 @@
+//go:build windows
+
+package filelockdiag
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLookupFindsCurrentProcessHoldingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "index.json")
+	if err := os.WriteFile(path, []byte(`{"recordings":[]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Go 在 Windows 上的普通只读打开不包含 FILE_SHARE_DELETE，正好模拟
+	// 会阻止 daemon 原子替换 index.json 的读取者。
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	holders, supported, err := Lookup(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !supported {
+		t.Fatal("Windows Lookup reported unsupported")
+	}
+	wantPID := uint32(os.Getpid())
+	for _, holder := range holders {
+		if holder.PID == wantPID {
+			return
+		}
+	}
+	t.Fatalf("current process %d not found in holders: %+v", wantPID, holders)
+}

--- a/internal/relay/dispatcher.go
+++ b/internal/relay/dispatcher.go
@@ -102,7 +102,9 @@ func (d *Dispatcher) handleReq(frame Frame) {
 		params = map[string]any{}
 	}
 	d.logger.Info("Relay dispatcher: req id=" + id + " method=" + method)
-	raw, status, err := d.loopbackJSON(http.MethodPost, "/gateway/"+url.PathEscape(method), params, nil)
+	raw, status, err := d.loopbackJSON(http.MethodPost, "/gateway/"+url.PathEscape(method), params, map[string]string{
+		InternalRequestIDHeader: id,
+	})
 	if err != nil {
 		d.client.Send(RPCResponseFrame{Type: "res", ID: id, OK: false, Error: map[string]any{"code": "INTERNAL_ERROR", "message": err.Error()}})
 		return
@@ -149,6 +151,7 @@ func (d *Dispatcher) handleRequest(frame Frame) {
 			delete(headers, k)
 		}
 	}
+	headers[InternalRequestIDHeader] = id
 	d.addInternalHeaders(headers)
 
 	target := d.httpBaseURL + path

--- a/internal/relay/dispatcher_test.go
+++ b/internal/relay/dispatcher_test.go
@@ -31,9 +31,15 @@ func TestClientDispatcherReqAndRequest(t *testing.T) {
 		}
 		switch r.URL.Path {
 		case "/gateway/notifications.push":
+			if r.Header.Get(InternalRequestIDHeader) != "req_1" {
+				t.Fatalf("missing relay request id on %s: %q", r.URL.Path, r.Header.Get(InternalRequestIDHeader))
+			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"ok":true,"data":{"ok":true,"echo":"notifications.push"}}`))
 		case "/notifications":
+			if r.Header.Get(InternalRequestIDHeader) != "http_1" {
+				t.Fatalf("missing relay request id on %s: %q", r.URL.Path, r.Header.Get(InternalRequestIDHeader))
+			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"ok":true,"ingested":1}`))
 		default:

--- a/internal/relay/types.go
+++ b/internal/relay/types.go
@@ -7,6 +7,8 @@ const (
 	InternalHTTPHeader = "x-openclaw-relay-internal"
 	// InternalClientLabelHeader 是当前隧道对应的 api-key label。
 	InternalClientLabelHeader = "x-yoooclaw-internal-client-label"
+	// InternalRequestIDHeader 把 Relay frame id 透传给 daemon，仅用于故障日志关联。
+	InternalRequestIDHeader = "x-yoooclaw-internal-request-id"
 )
 
 const (


### PR DESCRIPTION
## 背景

Windows 客户反馈录音在 App 侧显示同步成功，但本地 CLI/Agent 无法查询到对应录音。

App 侧捕获到本地 daemon 写入录音索引失败：

```text
rename C:\Users\lenovo\.yoooclaw\profiles\default\recordings\.xxx.tmp C:\Users\lenovo\.yoooclaw\profiles\default\recordings\index.json: Access is denied.
```

故障持续一段时间后，客户通过重新登录并重新连接恢复正常。目前只能确认 Windows 拒绝了 `index.json` 的原子替换操作，尚无法确认具体原因是外部进程占用、文件或目录 ACL/只读属性异常、安全软件临时拦截，还是其他瞬时文件系统问题。

由于客户电脑已经恢复，现有日志没有记录失败发生时的文件占用信息，无法继续还原现场。

## 本次改动

本次改动仅增强诊断能力，**未修复写盘失败问题，也未改变写盘、重试或文件锁处理逻辑**。

- 每次录音结果写盘失败时记录完整底层错误、`recordingId` 和 Relay 请求 ID
- Windows 下遇到 `rename index.json` 失败时，通过 Restart Manager 查询当时正在使用该文件的相关进程
- 记录相关进程的 PID、应用名称、服务名称及是否支持重启
- 查询异步执行，不阻塞 Relay 的失败响应
- 不关闭文件句柄、不结束进程，也不尝试强制解锁

Restart Manager 只能识别正在使用该文件的相关进程，不能确认具体哪个句柄缺少 `FILE_SHARE_DELETE`，因此日志仅作为后续定位依据，不能直接将某个进程判定为根因。

## 预期效果

问题再次出现时，可以通过 daemon 日志确认：

1. 是否确实失败在 `index.json` 的原子替换阶段
2. 失败时是否存在相关占用进程
3. 相关进程的 PID 和应用名称
4. 若未发现占用进程，再进一步排查 ACL、只读属性或安全软件

## 验证

- `go test ./...`
- `go vet ./...`
- Windows amd64 交叉编译通过
- 增加 Windows Restart Manager 占用进程识别测试