### PR TITLE
cli-0.9.0

### DIFF
--- a/internal/autostart/autostart.go
+++ b/internal/autostart/autostart.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/YoooClaw/cli/internal/fsutil"
 )
@@ -48,6 +49,9 @@ type State struct {
 }
 
 // Manager abstracts launchd, systemd --user and Windows Task Scheduler.
+// Stop and Uninstall are idempotent. Uninstall must stop the service before
+// removing its registration, so callers do not need to coordinate two
+// separate lifecycle operations.
 type Manager interface {
 	Available() error
 	Status() (Status, error)
@@ -98,14 +102,11 @@ func Enable(m Manager, spec Spec, start bool) (Status, error) {
 	return status, err
 }
 
-// Disable stops and removes the service, then persists the explicit opt-out.
+// Disable removes the service, then persists the explicit opt-out.
 func Disable(m Manager, root string) (Status, error) {
 	if err := m.Available(); err != nil {
 		status, _ := m.Status()
 		if status.Installed || status.Loaded {
-			if stopErr := m.Stop(); stopErr != nil {
-				return status, stopErr
-			}
 			if uninstallErr := m.Uninstall(); uninstallErr != nil {
 				return status, uninstallErr
 			}
@@ -116,9 +117,6 @@ func Disable(m Manager, root string) (Status, error) {
 		return status, nil
 	}
 	before, _ := m.Status()
-	if err := m.Stop(); err != nil && before.Installed {
-		return before, err
-	}
 	if err := m.Uninstall(); err != nil {
 		return before, err
 	}
@@ -195,3 +193,27 @@ func Current(root string) Manager {
 }
 
 var ErrUnavailable = errors.New("当前环境没有可用的用户级服务管理器")
+
+const (
+	serviceStatePollInterval = 50 * time.Millisecond
+	serviceStatePollTimeout  = 3 * time.Second
+)
+
+// waitForServiceState allows native service managers to converge after a
+// synchronous lifecycle command returns. launchd in particular can report a
+// service as loaded briefly after bootout has already accepted the request.
+func waitForServiceState(status func() (Status, error), done func(Status) bool) (Status, error) {
+	deadline := time.Now().Add(serviceStatePollTimeout)
+	var current Status
+	var err error
+	for {
+		current, err = status()
+		if err == nil && done(current) {
+			return current, nil
+		}
+		if !time.Now().Before(deadline) {
+			return current, err
+		}
+		time.Sleep(serviceStatePollInterval)
+	}
+}

--- a/internal/autostart/autostart_test.go
+++ b/internal/autostart/autostart_test.go
@@ -1,9 +1,35 @@
 package autostart
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
 )
+
+type lifecycleManager struct {
+	status         Status
+	availableErr   error
+	stopCalls      int
+	uninstallCalls int
+}
+
+func (m *lifecycleManager) Available() error        { return m.availableErr }
+func (m *lifecycleManager) Status() (Status, error) { return m.status, nil }
+func (m *lifecycleManager) Install(Spec) error      { return nil }
+func (m *lifecycleManager) Start() error            { return nil }
+func (m *lifecycleManager) Stop() error {
+	m.stopCalls++
+	m.status.Running = false
+	return nil
+}
+func (m *lifecycleManager) Restart() error { return nil }
+func (m *lifecycleManager) Uninstall() error {
+	m.uninstallCalls++
+	m.status.Installed = false
+	m.status.Loaded = false
+	m.status.Running = false
+	return nil
+}
 
 func TestEnableDisablePersistsIntent(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "root")
@@ -51,5 +77,71 @@ func TestResolveSpecCarriesExplicitRoot(t *testing.T) {
 	}
 	if spec.SupervisorLog != filepath.Join(root, "logs", "daemon-supervisor.log") {
 		t.Fatalf("supervisor log = %q", spec.SupervisorLog)
+	}
+}
+
+func TestDisableDelegatesLifecycleToUninstall(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "root")
+	m := &lifecycleManager{status: Status{Manager: "fake", Unit: "fake.service", Installed: true, Loaded: true, Running: true}}
+
+	status, err := Disable(m, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.stopCalls != 0 || m.uninstallCalls != 1 {
+		t.Fatalf("stop calls = %d, uninstall calls = %d", m.stopCalls, m.uninstallCalls)
+	}
+	if status.Installed || status.Loaded || status.Running {
+		t.Fatalf("unexpected status after disable: %+v", status)
+	}
+}
+
+func TestDisableUnavailableManagerStillDelegatesToUninstall(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "root")
+	m := &lifecycleManager{
+		availableErr: errors.New("manager unavailable"),
+		status:       Status{Manager: "fake", Unit: "fake.service", Installed: true, Loaded: true, Running: true},
+	}
+
+	if _, err := Disable(m, root); err != nil {
+		t.Fatal(err)
+	}
+	if m.stopCalls != 0 || m.uninstallCalls != 1 {
+		t.Fatalf("stop calls = %d, uninstall calls = %d", m.stopCalls, m.uninstallCalls)
+	}
+}
+
+func TestFileManagerStopAndUninstallAreIdempotent(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "root")
+	m := newFileManager(root, filepath.Join(t.TempDir(), "services"))
+	spec := Spec{RootDir: root, Executable: "/tmp/yoooclaw", Arguments: []string{"daemon", "run-service"}}
+
+	if err := m.Install(spec); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Stop(); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Stop(); err != nil {
+		t.Fatalf("second stop failed: %v", err)
+	}
+	if err := m.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Uninstall(); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Uninstall(); err != nil {
+		t.Fatalf("second uninstall failed: %v", err)
+	}
+	status, err := m.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Installed || status.Loaded || status.Running {
+		t.Fatalf("unexpected status after uninstall: %+v", status)
 	}
 }

--- a/internal/autostart/file_manager.go
+++ b/internal/autostart/file_manager.go
@@ -64,6 +64,9 @@ func (m *fileManager) Stop() error {
 }
 func (m *fileManager) Restart() error { return m.Start() }
 func (m *fileManager) Uninstall() error {
+	if err := m.Stop(); err != nil {
+		return err
+	}
 	if err := os.Remove(m.path()); err != nil && !os.IsNotExist(err) {
 		return err
 	}

--- a/internal/autostart/manager_darwin.go
+++ b/internal/autostart/manager_darwin.go
@@ -21,6 +21,10 @@ type platformManager struct {
 	plist string
 }
 
+var launchctl = func(args ...string) ([]byte, error) {
+	return exec.Command("launchctl", args...).CombinedOutput()
+}
+
 func newPlatformManager(root string) Manager {
 	id := ServiceID(root)
 	label := "com.yoooclaw." + strings.TrimPrefix(id, "yoooclaw-")
@@ -41,9 +45,15 @@ func (m *platformManager) Status() (Status, error) {
 	if _, err := os.Stat(m.plist); err == nil {
 		status.Installed = true
 	}
-	out, err := exec.Command("launchctl", "print", m.target()).CombinedOutput()
+	out, err := launchctl("print", m.target())
 	if err != nil {
-		return status, nil
+		// Inspect the user domain instead of matching launchctl's localized
+		// "service not found" text or relying on an OS-version-specific code.
+		domainOut, domainErr := launchctl("print", m.domain())
+		if domainErr == nil && !strings.Contains(string(domainOut), m.label) {
+			return status, nil
+		}
+		return status, fmt.Errorf("launchctl print 失败: %s (%v)", strings.TrimSpace(string(out)), err)
 	}
 	status.Loaded = true
 	for _, line := range strings.Split(string(out), "\n") {
@@ -92,27 +102,37 @@ func (m *platformManager) Install(spec Spec) error {
 func (m *platformManager) Start() error {
 	status, _ := m.Status()
 	if !status.Loaded {
-		if out, err := exec.Command("launchctl", "bootstrap", m.domain(), m.plist).CombinedOutput(); err != nil {
+		if out, err := launchctl("bootstrap", m.domain(), m.plist); err != nil {
 			return fmt.Errorf("launchctl bootstrap 失败: %s", strings.TrimSpace(string(out)))
 		}
 		return nil
 	}
-	out, err := exec.Command("launchctl", "kickstart", "-k", m.target()).CombinedOutput()
+	out, err := launchctl("kickstart", "-k", m.target())
 	if err != nil {
 		return fmt.Errorf("launchctl kickstart 失败: %s", strings.TrimSpace(string(out)))
 	}
 	return nil
 }
 func (m *platformManager) Stop() error {
-	status, _ := m.Status()
+	status, err := m.Status()
+	if err != nil {
+		return err
+	}
 	if !status.Loaded {
 		return nil
 	}
-	out, err := exec.Command("launchctl", "bootout", m.target()).CombinedOutput()
-	if err != nil {
+	out, stopErr := launchctl("bootout", m.target())
+	after, statusErr := waitForServiceState(m.Status, func(status Status) bool { return !status.Loaded })
+	if statusErr == nil && !after.Loaded {
+		return nil
+	}
+	if stopErr != nil {
 		return fmt.Errorf("launchctl bootout 失败: %s", strings.TrimSpace(string(out)))
 	}
-	return nil
+	if statusErr != nil {
+		return fmt.Errorf("launchctl bootout 后无法确认服务状态: %w", statusErr)
+	}
+	return fmt.Errorf("launchctl bootout 后服务仍处于加载状态: %s", m.target())
 }
 func (m *platformManager) Restart() error {
 	if err := m.Stop(); err != nil {

--- a/internal/autostart/manager_darwin_test.go
+++ b/internal/autostart/manager_darwin_test.go
@@ -3,9 +3,53 @@
 package autostart
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+type fakeLaunchctlExitError struct{ code int }
+
+func (e fakeLaunchctlExitError) Error() string { return "launchctl failed" }
+func (e fakeLaunchctlExitError) ExitCode() int { return e.code }
+
+func stubLaunchctl(t *testing.T, loaded *bool, bootoutErr error, unloadOnBootout bool) *int {
+	t.Helper()
+	original := launchctl
+	bootoutCalls := 0
+	pendingUnload := false
+	launchctl = func(args ...string) ([]byte, error) {
+		switch args[0] {
+		case "print":
+			if pendingUnload {
+				// launchd may still expose the service for one observation after
+				// bootout returns, then converge to the unloaded state.
+				pendingUnload = false
+				*loaded = false
+				return []byte("state = running\npid = 123\n"), nil
+			}
+			if !*loaded {
+				if strings.Count(args[1], "/") == 1 {
+					return []byte("services = {\n}\n"), nil
+				}
+				return []byte("service missing"), fakeLaunchctlExitError{code: 113}
+			}
+			return []byte("state = running\npid = 123\n"), nil
+		case "bootout":
+			bootoutCalls++
+			if unloadOnBootout {
+				pendingUnload = true
+			}
+			return []byte("bootout result"), bootoutErr
+		default:
+			return nil, errors.New("unexpected launchctl command")
+		}
+	}
+	t.Cleanup(func() { launchctl = original })
+	return &bootoutCalls
+}
 
 func TestPlistUsesArgumentArrayAndEscapesValues(t *testing.T) {
 	spec := Spec{
@@ -27,5 +71,54 @@ func TestPlistUsesArgumentArrayAndEscapesValues(t *testing.T) {
 	}
 	if strings.Contains(xml, "sh -c") {
 		t.Fatal("plist must not execute through a shell")
+	}
+}
+
+func TestDarwinStopAcceptsBootoutErrorWhenServiceIsGone(t *testing.T) {
+	loaded := true
+	bootoutCalls := stubLaunchctl(t, &loaded, fakeLaunchctlExitError{code: 3}, true)
+	m := &platformManager{label: "com.yoooclaw.test", plist: filepath.Join(t.TempDir(), "test.plist")}
+
+	if err := m.Stop(); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Stop(); err != nil {
+		t.Fatalf("second stop failed: %v", err)
+	}
+	if *bootoutCalls != 1 {
+		t.Fatalf("bootout calls = %d", *bootoutCalls)
+	}
+}
+
+func TestDarwinStopReturnsErrorWhenServiceRemainsLoaded(t *testing.T) {
+	loaded := true
+	stubLaunchctl(t, &loaded, fakeLaunchctlExitError{code: 3}, false)
+	m := &platformManager{label: "com.yoooclaw.test", plist: filepath.Join(t.TempDir(), "test.plist")}
+
+	if err := m.Stop(); err == nil {
+		t.Fatal("expected stop error while service remains loaded")
+	}
+}
+
+func TestDarwinUninstallStopsOnceAndIsIdempotent(t *testing.T) {
+	loaded := true
+	bootoutCalls := stubLaunchctl(t, &loaded, nil, true)
+	plist := filepath.Join(t.TempDir(), "test.plist")
+	if err := os.WriteFile(plist, []byte("plist"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	m := &platformManager{label: "com.yoooclaw.test", plist: plist}
+
+	if err := m.Uninstall(); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Uninstall(); err != nil {
+		t.Fatalf("second uninstall failed: %v", err)
+	}
+	if *bootoutCalls != 1 {
+		t.Fatalf("bootout calls = %d", *bootoutCalls)
+	}
+	if _, err := os.Stat(plist); !os.IsNotExist(err) {
+		t.Fatalf("plist still exists or stat failed unexpectedly: %v", err)
 	}
 }

--- a/internal/autostart/manager_linux.go
+++ b/internal/autostart/manager_linux.go
@@ -25,9 +25,11 @@ func newPlatformManager(root string) Manager {
 	unit := id + ".service"
 	return &platformManager{root: root, id: id, unit: unit, path: filepath.Join(configHome, "systemd", "user", unit)}
 }
-func systemctl(args ...string) ([]byte, error) {
+
+var systemctl = func(args ...string) ([]byte, error) {
 	return exec.Command("systemctl", append([]string{"--user"}, args...)...).CombinedOutput()
 }
+
 func (m *platformManager) Available() error {
 	if _, err := exec.LookPath("systemctl"); err != nil {
 		return fmt.Errorf("%w: systemctl 不可用", ErrUnavailable)
@@ -42,23 +44,39 @@ func (m *platformManager) Status() (Status, error) {
 	if _, err := os.Stat(m.path); err == nil {
 		status.Installed = true
 	}
-	out, err := systemctl("show", m.unit, "--property=LoadState,ActiveState,MainPID", "--value")
-	if err != nil {
-		return status, nil
-	}
+	out, commandErr := systemctl("show", m.unit, "--property=LoadState,ActiveState,MainPID")
+	loadState := ""
 	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
-	for _, value := range lines {
-		value = strings.TrimSpace(value)
-		switch value {
-		case "loaded":
-			status.Loaded = true
-		case "active", "activating", "reloading":
-			status.Running = true
-		default:
-			if pid, e := strconv.Atoi(value); e == nil && pid > 0 {
+	for _, line := range lines {
+		key, value, found := strings.Cut(strings.TrimSpace(line), "=")
+		if !found {
+			continue
+		}
+		switch key {
+		case "LoadState":
+			loadState = value
+			if value == "loaded" {
+				status.Loaded = true
+			}
+		case "ActiveState":
+			switch value {
+			case "active", "activating", "reloading":
+				status.Running = true
+			}
+		case "MainPID":
+			if pid, err := strconv.Atoi(value); err == nil && pid > 0 {
 				status.PID = pid
 			}
 		}
+	}
+	if commandErr != nil && loadState != "not-found" {
+		// A missing unit is not an error for lifecycle operations. Ask systemd
+		// for an exact unit listing instead of matching localized error text.
+		listed, listErr := systemctl("list-units", "--all", "--full", "--plain", "--no-legend", m.unit)
+		if listErr == nil && strings.TrimSpace(string(listed)) == "" {
+			return status, nil
+		}
+		return status, fmt.Errorf("systemctl show 失败: %s (%v)", strings.TrimSpace(string(out)), commandErr)
 	}
 	return status, nil
 }
@@ -113,11 +131,25 @@ func (m *platformManager) Start() error {
 	return nil
 }
 func (m *platformManager) Stop() error {
-	out, err := systemctl("stop", m.unit)
-	if err != nil && !strings.Contains(string(out), "not loaded") {
+	status, err := m.Status()
+	if err != nil {
+		return err
+	}
+	if !status.Running {
+		return nil
+	}
+	out, stopErr := systemctl("stop", m.unit)
+	after, statusErr := waitForServiceState(m.Status, func(status Status) bool { return !status.Running })
+	if statusErr == nil && !after.Running {
+		return nil
+	}
+	if stopErr != nil {
 		return fmt.Errorf("systemctl stop 失败: %s", strings.TrimSpace(string(out)))
 	}
-	return nil
+	if statusErr != nil {
+		return fmt.Errorf("systemctl stop 后无法确认服务状态: %w", statusErr)
+	}
+	return fmt.Errorf("systemctl stop 后服务仍在运行: %s", m.unit)
 }
 func (m *platformManager) Restart() error {
 	out, err := systemctl("restart", m.unit)
@@ -127,10 +159,31 @@ func (m *platformManager) Restart() error {
 	return nil
 }
 func (m *platformManager) Uninstall() error {
-	_, _ = systemctl("disable", m.unit)
+	if err := m.Stop(); err != nil {
+		return err
+	}
+	status, err := m.Status()
+	if err != nil {
+		return err
+	}
+	if !status.Installed && !status.Loaded {
+		return nil
+	}
+	if out, err := systemctl("disable", m.unit); err != nil {
+		return fmt.Errorf("systemctl disable 失败: %s", strings.TrimSpace(string(out)))
+	}
 	if err := os.Remove(m.path); err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	_, _ = systemctl("daemon-reload")
+	if out, err := systemctl("daemon-reload"); err != nil {
+		return fmt.Errorf("systemctl daemon-reload 失败: %s", strings.TrimSpace(string(out)))
+	}
+	after, err := m.Status()
+	if err != nil {
+		return err
+	}
+	if after.Installed || after.Loaded {
+		return fmt.Errorf("systemd 服务卸载后仍有注册: %s", m.unit)
+	}
 	return nil
 }

--- a/internal/autostart/manager_linux_test.go
+++ b/internal/autostart/manager_linux_test.go
@@ -1,0 +1,110 @@
+//go:build linux
+
+package autostart
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type fakeSystemd struct {
+	loaded       bool
+	running      bool
+	stopChanges  bool
+	stopErr      error
+	stopCalls    int
+	disableCalls int
+}
+
+func stubSystemctl(t *testing.T, m *platformManager, fake *fakeSystemd) {
+	t.Helper()
+	original := systemctl
+	systemctl = func(args ...string) ([]byte, error) {
+		switch args[0] {
+		case "show":
+			if !fake.loaded {
+				return []byte("unit missing"), errors.New("show failed")
+			}
+			active := "inactive"
+			pid := "0"
+			if fake.running {
+				active = "active"
+				pid = "123"
+			}
+			return []byte("LoadState=loaded\nActiveState=" + active + "\nMainPID=" + pid + "\n"), nil
+		case "list-units":
+			if !fake.loaded {
+				return nil, nil
+			}
+			return []byte(m.unit + " loaded active running\n"), nil
+		case "stop":
+			fake.stopCalls++
+			if fake.stopChanges {
+				fake.running = false
+			}
+			return []byte("stop result"), fake.stopErr
+		case "disable":
+			fake.disableCalls++
+			return nil, nil
+		case "daemon-reload":
+			if _, err := os.Stat(m.path); os.IsNotExist(err) {
+				fake.loaded = false
+			}
+			return nil, nil
+		default:
+			return nil, errors.New("unexpected systemctl command")
+		}
+	}
+	t.Cleanup(func() { systemctl = original })
+}
+
+func TestLinuxStopAcceptsCommandErrorWhenServiceStopped(t *testing.T) {
+	m := &platformManager{unit: "yoooclaw-test.service", path: filepath.Join(t.TempDir(), "yoooclaw-test.service")}
+	fake := &fakeSystemd{loaded: true, running: true, stopChanges: true, stopErr: errors.New("stop failed")}
+	stubSystemctl(t, m, fake)
+
+	if err := m.Stop(); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Stop(); err != nil {
+		t.Fatalf("second stop failed: %v", err)
+	}
+	if fake.stopCalls != 1 {
+		t.Fatalf("stop calls = %d", fake.stopCalls)
+	}
+}
+
+func TestLinuxStopReturnsErrorWhenServiceStillRunning(t *testing.T) {
+	m := &platformManager{unit: "yoooclaw-test.service", path: filepath.Join(t.TempDir(), "yoooclaw-test.service")}
+	fake := &fakeSystemd{loaded: true, running: true, stopErr: errors.New("stop failed")}
+	stubSystemctl(t, m, fake)
+
+	if err := m.Stop(); err == nil {
+		t.Fatal("expected stop error while service remains running")
+	}
+}
+
+func TestLinuxUninstallStopsAndRemovesService(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "yoooclaw-test.service")
+	if err := os.WriteFile(path, []byte("unit"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	m := &platformManager{unit: "yoooclaw-test.service", path: path}
+	fake := &fakeSystemd{loaded: true, running: true, stopChanges: true}
+	stubSystemctl(t, m, fake)
+
+	if err := m.Uninstall(); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Uninstall(); err != nil {
+		t.Fatalf("second uninstall failed: %v", err)
+	}
+	if fake.stopCalls != 1 || fake.disableCalls != 1 {
+		t.Fatalf("stop calls = %d, disable calls = %d", fake.stopCalls, fake.disableCalls)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("unit still exists or stat failed unexpectedly: %v", err)
+	}
+}

--- a/internal/autostart/manager_windows.go
+++ b/internal/autostart/manager_windows.go
@@ -9,6 +9,7 @@ import (
 	"html"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"syscall"
 )
@@ -25,14 +26,27 @@ func (m *platformManager) Available() error {
 	}
 	return nil
 }
-func schtasks(args ...string) ([]byte, error) {
+
+var schtasks = func(args ...string) ([]byte, error) {
 	return exec.Command("schtasks.exe", args...).CombinedOutput()
+}
+
+func (m *platformManager) taskFile() string {
+	systemRoot := strings.TrimSpace(os.Getenv("SystemRoot"))
+	if systemRoot == "" {
+		systemRoot = `C:\Windows`
+	}
+	relative := strings.ReplaceAll(strings.TrimPrefix(m.task, `\`), `\`, "/")
+	return filepath.Join(systemRoot, "System32", "Tasks", filepath.FromSlash(relative))
 }
 func (m *platformManager) Status() (Status, error) {
 	status := Status{Manager: "task-scheduler", Unit: m.task}
 	out, err := schtasks("/Query", "/TN", m.task, "/FO", "LIST", "/V")
 	if err != nil {
-		return status, nil
+		if _, statErr := os.Stat(m.taskFile()); os.IsNotExist(statErr) {
+			return status, nil
+		}
+		return status, fmt.Errorf("查询计划任务失败: %s", strings.TrimSpace(string(out)))
 	}
 	status.Installed, status.Loaded = true, true
 	text := strings.ToLower(string(out))
@@ -123,15 +137,27 @@ func (m *platformManager) Start() error {
 	return nil
 }
 func (m *platformManager) Stop() error {
-	status, _ := m.Status()
-	if !status.Installed {
+	status, err := m.Status()
+	if err != nil {
+		return err
+	}
+	if !status.Installed || !status.Running {
 		return nil
 	}
-	// /End is idempotent for our purposes. Its "not currently running" error
-	// text is localized, so do not parse it; the daemon lock/HTTP stop path
-	// still verifies and retires any process that remains alive.
-	_, _ = schtasks("/End", "/TN", m.task)
-	return nil
+	out, stopErr := schtasks("/End", "/TN", m.task)
+	after, statusErr := waitForServiceState(m.Status, func(status Status) bool {
+		return !status.Installed || !status.Running
+	})
+	if statusErr == nil && (!after.Installed || !after.Running) {
+		return nil
+	}
+	if stopErr != nil {
+		return fmt.Errorf("停止计划任务失败: %s", strings.TrimSpace(string(out)))
+	}
+	if statusErr != nil {
+		return fmt.Errorf("停止计划任务后无法确认状态: %w", statusErr)
+	}
+	return fmt.Errorf("停止计划任务后任务仍在运行: %s", m.task)
 }
 func (m *platformManager) Restart() error {
 	if err := m.Stop(); err != nil {
@@ -140,13 +166,26 @@ func (m *platformManager) Restart() error {
 	return m.Start()
 }
 func (m *platformManager) Uninstall() error {
-	status, _ := m.Status()
+	if err := m.Stop(); err != nil {
+		return err
+	}
+	status, err := m.Status()
+	if err != nil {
+		return err
+	}
 	if !status.Installed {
 		return nil
 	}
-	out, err := schtasks("/Delete", "/TN", m.task, "/F")
-	if err != nil {
+	out, deleteErr := schtasks("/Delete", "/TN", m.task, "/F")
+	after, statusErr := m.Status()
+	if statusErr == nil && !after.Installed {
+		return nil
+	}
+	if deleteErr != nil {
 		return fmt.Errorf("删除计划任务失败: %s", strings.TrimSpace(string(out)))
 	}
-	return nil
+	if statusErr != nil {
+		return fmt.Errorf("删除计划任务后无法确认状态: %w", statusErr)
+	}
+	return fmt.Errorf("删除计划任务后任务仍存在: %s", m.task)
 }

--- a/internal/autostart/manager_windows_test.go
+++ b/internal/autostart/manager_windows_test.go
@@ -1,0 +1,112 @@
+//go:build windows
+
+package autostart
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type fakeTaskScheduler struct {
+	installed    bool
+	running      bool
+	endChanges   bool
+	endErr       error
+	endCalls     int
+	deleteCalls  int
+	taskFilePath string
+}
+
+func stubSchtasks(t *testing.T, fake *fakeTaskScheduler) {
+	t.Helper()
+	original := schtasks
+	schtasks = func(args ...string) ([]byte, error) {
+		switch args[0] {
+		case "/Query":
+			if !fake.installed {
+				return []byte("task missing"), errors.New("query failed")
+			}
+			status := "Ready"
+			if fake.running {
+				status = "Running"
+			}
+			return []byte("Status: " + status), nil
+		case "/End":
+			fake.endCalls++
+			if fake.endChanges {
+				fake.running = false
+			}
+			return []byte("end result"), fake.endErr
+		case "/Delete":
+			fake.deleteCalls++
+			fake.installed = false
+			_ = os.Remove(fake.taskFilePath)
+			return nil, nil
+		default:
+			return nil, errors.New("unexpected schtasks command")
+		}
+	}
+	t.Cleanup(func() { schtasks = original })
+}
+
+func newWindowsTestManager(t *testing.T) (*platformManager, string) {
+	t.Helper()
+	systemRoot := t.TempDir()
+	t.Setenv("SystemRoot", systemRoot)
+	m := &platformManager{task: `\YoooClaw\yoooclaw-test`}
+	taskFile := filepath.Join(systemRoot, "System32", "Tasks", "YoooClaw", "yoooclaw-test")
+	if err := os.MkdirAll(filepath.Dir(taskFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(taskFile, []byte("task"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return m, taskFile
+}
+
+func TestWindowsStopAcceptsCommandErrorWhenTaskStopped(t *testing.T) {
+	m, taskFile := newWindowsTestManager(t)
+	fake := &fakeTaskScheduler{installed: true, running: true, endChanges: true, endErr: errors.New("end failed"), taskFilePath: taskFile}
+	stubSchtasks(t, fake)
+
+	if err := m.Stop(); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Stop(); err != nil {
+		t.Fatalf("second stop failed: %v", err)
+	}
+	if fake.endCalls != 1 {
+		t.Fatalf("end calls = %d", fake.endCalls)
+	}
+}
+
+func TestWindowsStopReturnsErrorWhenTaskStillRunning(t *testing.T) {
+	m, taskFile := newWindowsTestManager(t)
+	fake := &fakeTaskScheduler{installed: true, running: true, endErr: errors.New("end failed"), taskFilePath: taskFile}
+	stubSchtasks(t, fake)
+
+	if err := m.Stop(); err == nil {
+		t.Fatal("expected stop error while task remains running")
+	}
+}
+
+func TestWindowsUninstallStopsAndDeletesTask(t *testing.T) {
+	m, taskFile := newWindowsTestManager(t)
+	fake := &fakeTaskScheduler{installed: true, running: true, endChanges: true, taskFilePath: taskFile}
+	stubSchtasks(t, fake)
+
+	if err := m.Uninstall(); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Uninstall(); err != nil {
+		t.Fatalf("second uninstall failed: %v", err)
+	}
+	if fake.endCalls != 1 || fake.deleteCalls != 1 {
+		t.Fatalf("end calls = %d, delete calls = %d", fake.endCalls, fake.deleteCalls)
+	}
+	if _, err := os.Stat(taskFile); !os.IsNotExist(err) {
+		t.Fatalf("task file still exists or stat failed unexpectedly: %v", err)
+	}
+}

--- a/internal/cli/cmd_daemon_autostart.go
+++ b/internal/cli/cmd_daemon_autostart.go
@@ -336,9 +336,6 @@ func removeAutostartForUninstall() ([]string, error) {
 		return nil, autostartError(statusErr)
 	}
 	if status.Installed || status.Loaded {
-		if err := manager.Stop(); err != nil {
-			return nil, autostartError(err)
-		}
 		if err := manager.Uninstall(); err != nil {
 			return nil, autostartError(err)
 		}

--- a/internal/daemon/egress.go
+++ b/internal/daemon/egress.go
@@ -62,20 +62,26 @@ type ProxyEgress struct {
 	token  string
 	client *http.Client
 	logger *Logger
+	// retryDelays 是本实例的重试间隔，构造时从 proxyEgressRetryDelays 取默认值。
+	// 做成实例字段而不是直接读全局：deliver 在后台 goroutine 里读它，若测试去改
+	// 全局，就会和上一个用例遗留的 deliver goroutine 撞成 data race。
+	retryDelays []time.Duration
 }
 
 // NewProxyEgress 构造回投宿主回调的出站端口。
 func NewProxyEgress(url, token string, logger *Logger) *ProxyEgress {
 	return &ProxyEgress{
-		url:    url,
-		token:  token,
-		client: &http.Client{Timeout: 10 * time.Second},
-		logger: logger,
+		url:         url,
+		token:       token,
+		client:      &http.Client{Timeout: 10 * time.Second},
+		logger:      logger,
+		retryDelays: proxyEgressRetryDelays,
 	}
 }
 
-// proxyEgressRetryDelays 是回投失败后的重试间隔。宿主插件可能正在整组重启
+// proxyEgressRetryDelays 是回投失败后的重试间隔默认值。宿主插件可能正在整组重启
 // （回调服务短暂不可达），带退避多试几次能把重启窗口内的事件送达而不是丢掉。
+// 这里只作默认值使用，构造后不再改动——要换间隔请改 ProxyEgress.retryDelays。
 var proxyEgressRetryDelays = []time.Duration{time.Second, 3 * time.Second, 9 * time.Second}
 
 // PushEvent 异步把 {event, payload} POST 给宿主回调。请求会保留自身的 10s
@@ -99,7 +105,7 @@ func (e *ProxyEgress) PushEventTo(label string, event string, payload any) error
 	return nil
 }
 
-// deliver 投递事件，网络错误与 5xx 按 proxyEgressRetryDelays 重试；4xx 属
+// deliver 投递事件，网络错误与 5xx 按 e.retryDelays 重试；4xx 属
 // 配置性失败（token 不符、路径不对），重试无意义，立即放弃。
 func (e *ProxyEgress) deliver(event string, body []byte) {
 	for attempt := 0; ; attempt++ {
@@ -107,13 +113,13 @@ func (e *ProxyEgress) deliver(event string, body []byte) {
 		if err == nil {
 			return
 		}
-		if !retryable || attempt >= len(proxyEgressRetryDelays) {
+		if !retryable || attempt >= len(e.retryDelays) {
 			if e.logger != nil {
 				e.logger.Warn(fmt.Sprintf("egress 回投失败（放弃）event=%s attempts=%d: %v", event, attempt+1, err))
 			}
 			return
 		}
-		delay := proxyEgressRetryDelays[attempt]
+		delay := e.retryDelays[attempt]
 		if e.logger != nil {
 			e.logger.Warn(fmt.Sprintf("egress 回投失败 event=%s attempt=%d，%s 后重试: %v", event, attempt+1, delay, err))
 		}

--- a/internal/daemon/egress_test.go
+++ b/internal/daemon/egress_test.go
@@ -135,10 +135,6 @@ func TestProxyEgressDoesNotWaitForSlowCallback(t *testing.T) {
 }
 
 func TestProxyEgressRetriesOnServerError(t *testing.T) {
-	oldDelays := proxyEgressRetryDelays
-	proxyEgressRetryDelays = []time.Duration{5 * time.Millisecond, 5 * time.Millisecond, 5 * time.Millisecond}
-	defer func() { proxyEgressRetryDelays = oldDelays }()
-
 	var mu sync.Mutex
 	calls := 0
 	success := make(chan struct{}, 1)
@@ -157,6 +153,9 @@ func TestProxyEgressRetriesOnServerError(t *testing.T) {
 	defer srv.Close()
 
 	eg := NewProxyEgress(srv.URL, "", nil)
+	// 按实例调间隔，不碰包级默认值——deliver 在后台 goroutine 里读它，
+	// 改全局会和别的用例遗留的 deliver goroutine 撞成 data race。
+	eg.retryDelays = []time.Duration{5 * time.Millisecond, 5 * time.Millisecond, 5 * time.Millisecond}
 	if err := eg.PushEvent("recording.status", map[string]any{"id": "r1"}); err != nil {
 		t.Fatalf("PushEvent error: %v", err)
 	}
@@ -173,10 +172,6 @@ func TestProxyEgressRetriesOnServerError(t *testing.T) {
 }
 
 func TestProxyEgressDoesNotRetryClientError(t *testing.T) {
-	oldDelays := proxyEgressRetryDelays
-	proxyEgressRetryDelays = []time.Duration{time.Millisecond}
-	defer func() { proxyEgressRetryDelays = oldDelays }()
-
 	var mu sync.Mutex
 	calls := 0
 	first := make(chan struct{}, 1)
@@ -193,6 +188,7 @@ func TestProxyEgressDoesNotRetryClientError(t *testing.T) {
 	defer srv.Close()
 
 	eg := NewProxyEgress(srv.URL, "", nil)
+	eg.retryDelays = []time.Duration{time.Millisecond}
 	if err := eg.PushEvent("recording.status", nil); err != nil {
 		t.Fatalf("PushEvent error: %v", err)
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.9.0-beta.1",
+  "version": "0.9.0",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {


### PR DESCRIPTION
0.9.0 正式版发布，合回主干同步。

包含（相对 master）：
- fix(daemon): 消除 egress 重试间隔的 data race
- fix(daemon): 统一自启动卸载与停止状态收敛
- chore: version 0.9.0-beta.1 → 0.9.0

发布由 tag `cli-v0.9.0` 触发（Release CLI workflow），本 PR 仅为同步主干。

🤖 Generated with [Claude Code](https://claude.com/claude-code)