### PR TITLE
cli-0.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Service-oriented command tree, a three-tier command system, Agent-Native.
 | 🔌 Tunnel                   | Relay tunnel status, force reconnect, local ingest loopback self-check                                      | 🟡     |
 | 🛡️ Gateway                  | Simulate phone-side calls into the daemon, verify local connectivity & auth                                 | 🟢/🟡  |
 | 📋 Log                      | daemon log search & error-level filtering                                                                   | 🟢     |
-| ⚙️ Infrastructure           | config / profile / auth / daemon / migrate / update / doctor / uninstall                                    | 🟢/🔵  |
+| ⚙️ Infrastructure           | config / profile / auth / daemon / owner / migrate / update / doctor / uninstall                            | 🟢/🔵/🟡  |
 | 🧩 Skills                   | Install bundled SKILL.md into the agent's discovery directory                                               | 🟢     |
 
 > daemon legend: 🟢 no daemon needed · 🟡 daemon must be running · 🔵 manages the daemon itself.
@@ -207,6 +207,32 @@ Autostart always follows the active profile. `profile use` transfers a running
 daemon to the new profile while preserving a manually stopped state. On Linux,
 autostart begins with the user service manager; enabling pre-login boot via
 `loginctl enable-linger` remains an explicit system-administration choice.
+
+Switching or deleting a profile (`profile use` / `profile delete`) first waits
+for the old profile's daemon to actually release the **account-level Relay
+consumer lock** before proceeding (so a not-yet-exited old process can't keep
+writing production messages into a profile you've switched away from); an
+OS-managed autostart service is stopped/started along with it.
+
+## Storage ownership: CLI ↔ Hermes plugin
+
+`~/.yoooclaw/profiles/<profile>/writer.lock` guarantees exactly one storage
+writer per profile at a time. When the Hermes plugin runs in daemonless mode
+it holds this lock, and `daemon start` / `daemon run-foreground` are then
+refused with `YOOOCLAW_DAEMON_DISABLED_BY_PLUGIN`. On Windows, if probing the
+lock itself fails (e.g. a permission error), the behavior is **fail-closed**:
+startup is refused outright with `YOOOCLAW_STORAGE_UNAVAILABLE`, rather than
+treating a failed probe as "not held."
+
+```bash
+yoooclaw owner activate cli                          # hand ownership from the Hermes plugin to the standalone CLI
+yoooclaw owner activate cli --hermes-profile work --no-start
+```
+
+`install.sh` **preserves ownership as it was before the upgrade** by default —
+an upgrade never silently hands it off. Only passing `--activate` explicitly
+(or setting `YOOOCLAW_ACTIVATE_OWNER=cli`) makes it actively hand ownership to
+the standalone CLI after install.
 
 ## Daemon lifecycle protocol
 
@@ -393,7 +419,7 @@ yoooclaw recording events --since 1h --limit 50
 yoooclaw recording events --id <recording-id> --watch
 ```
 
-Recording config and events live under the current profile at `recordings/asr-config.json` and `recordings/state/events.jsonl` respectively.
+Recording config and events live under the current profile at `recordings/asr-config.json` and `recordings/state/events.jsonl` respectively. Files under `transcripts/` / `summaries/` follow the naming convention `<YYYYMMDDHH>_<title>_<id>.md`, so filename order is chronological (files written before an upgrade keep their old names — no bulk migration). Recordings ingested via `/gateway/recordings.*` are tagged with the `clientLabel` of the api-key that wrote them, and the read side (`recording list/status/events`) is scoped the same way — a client connected over a Relay tunnel or a specific api-key only sees its own recordings, while loopback / gateway-token requests are unrestricted; `synced-web-page` and its endpoints follow the same scoping.
 
 ### Data Directory
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,9 @@ Autostart always follows the active profile. `profile use` transfers a running
 daemon to the new profile while preserving a manually stopped state. On Linux,
 autostart begins with the user service manager; enabling pre-login boot via
 `loginctl enable-linger` remains an explicit system-administration choice.
+Upgrades from releases without an autostart preference register the initialized
+active profile even if its daemon was stopped during the upgrade. An explicit
+`autostart disable` preference and a live Hermes owner are always preserved.
 
 Switching or deleting a profile (`profile use` / `profile delete`) first waits
 for the old profile's daemon to actually release the **account-level Relay

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -205,6 +205,9 @@ yoooclaw config init --no-autostart  # 当前启动，但不开启自启
 自启服务始终跟随 active profile；`profile use` 会在 profile 间转移正在运行的
 daemon，但会保留用户手动 stop 后的停止状态。Linux 默认随用户服务管理器启动；是否
 通过 `loginctl enable-linger` 扩展为登录前启动，仍由系统管理员显式决定。
+从尚无自启偏好的旧版本升级时，即使 daemon 当时处于停止状态，也会为已初始化的
+active profile 注册自启；用户明确执行过 `autostart disable` 或 Hermes 正在持有
+owner 时不会被覆盖。
 
 `profile use` / `profile delete` 切换时会先等旧 profile 的 daemon 真正释放**账号级
 Relay 消费锁**再继续（防止旧进程还没退干净就把生产消息落错 profile），OS 托管自启

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -38,7 +38,7 @@ Service-oriented 命令树、三层命令体系、Agent-Native。
 | 🔌 隧道 Tunnel        | Relay 隧道状态、强制重连、本地 ingest 回环自检               | 🟡     |
 | 🛡️ 网关 Gateway       | 模拟手机端调 daemon，校验本地连通与鉴权                      | 🟢/🟡  |
 | 📋 日志 Log           | daemon 日志检索与 error 级筛选                               | 🟢     |
-| ⚙️ 基础设施           | config / profile / auth / daemon / migrate / update / doctor / uninstall | 🟢/🔵  |
+| ⚙️ 基础设施           | config / profile / auth / daemon / owner / migrate / update / doctor / uninstall | 🟢/🔵/🟡  |
 | 🧩 技能 Skills        | 把随包 SKILL.md 安装到 Agent 可发现目录                      | 🟢     |
 
 > daemon 标记：🟢 不需要 daemon · 🟡 需要 daemon 在跑 · 🔵 管理 daemon 自身。
@@ -205,6 +205,27 @@ yoooclaw config init --no-autostart  # 当前启动，但不开启自启
 自启服务始终跟随 active profile；`profile use` 会在 profile 间转移正在运行的
 daemon，但会保留用户手动 stop 后的停止状态。Linux 默认随用户服务管理器启动；是否
 通过 `loginctl enable-linger` 扩展为登录前启动，仍由系统管理员显式决定。
+
+`profile use` / `profile delete` 切换时会先等旧 profile 的 daemon 真正释放**账号级
+Relay 消费锁**再继续（防止旧进程还没退干净就把生产消息落错 profile），OS 托管自启
+动的一并跟着停 / 起。
+
+## 存储所有权：CLI ↔ Hermes 插件
+
+`~/.yoooclaw/profiles/<profile>/writer.lock` 保证同一 profile 同一时刻只有一个存储
+写者。Hermes 插件以 daemonless 模式运行时持有这把锁，此时 `daemon start` /
+`daemon run-foreground` 会被拒绝并返回 `YOOOCLAW_DAEMON_DISABLED_BY_PLUGIN`；
+Windows 上探测锁本身失败（如权限错误）是 **fail-closed**——直接拒绝启动并返回
+`YOOOCLAW_STORAGE_UNAVAILABLE`，不会把探测失败当成"未持有"。
+
+```bash
+yoooclaw owner activate cli                          # 把所有权从 Hermes 插件转交给独立 CLI
+yoooclaw owner activate cli --hermes-profile work --no-start
+```
+
+`install.sh` 升级时默认**保留升级前的所有权归属**，不会因为一次升级悄悄换手；只有
+显式传 `--activate`（或 `YOOOCLAW_ACTIVATE_OWNER=cli`）才会在装完后主动把所有权转
+交给独立 CLI。
 
 ## Daemon lifecycle protocol
 
@@ -391,7 +412,7 @@ yoooclaw recording events --since 1h --limit 50
 yoooclaw recording events --id <recording-id> --watch
 ```
 
-录音配置与事件分别落在当前 profile 的 `recordings/asr-config.json` 与 `recordings/state/events.jsonl`。
+录音配置与事件分别落在当前 profile 的 `recordings/asr-config.json` 与 `recordings/state/events.jsonl`；`transcripts/` / `summaries/` 文件名约定为 `<YYYYMMDDHH>_<标题>_<id>.md`，按文件名即可时间排序（升级前的旧文件保留原名，不做批量迁移）。经 `/gateway/recordings.*` 写入的录音会打上发起写入的 api-key 对应 `clientLabel`，读侧（`recording list/status/events`）同样按这个标签隔离——通过 Relay 隧道或某个 api-key 接入的客户端只能看到自己名下的录音，本机 loopback / gateway token 请求不受限，`synced-web-page` 与相关端点同理。
 
 ### 数据目录
 

--- a/internal/autostart/manager_darwin.go
+++ b/internal/autostart/manager_darwin.go
@@ -56,10 +56,15 @@ func (m *platformManager) Status() (Status, error) {
 		return status, fmt.Errorf("launchctl print 失败: %s (%v)", strings.TrimSpace(string(out)), err)
 	}
 	status.Loaded = true
+	serviceStateSeen := false
 	for _, line := range strings.Split(string(out), "\n") {
 		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "state = ") {
+		// launchctl also prints nested coalition blocks with their own
+		// "state = active" fields. The first state belongs to the service;
+		// later nested states must not overwrite it.
+		if !serviceStateSeen && strings.HasPrefix(line, "state = ") {
 			status.Running = strings.TrimSpace(strings.TrimPrefix(line, "state = ")) == "running"
+			serviceStateSeen = true
 		}
 		if strings.HasPrefix(line, "pid = ") {
 			status.PID, _ = strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(line, "pid = ")))

--- a/internal/autostart/manager_darwin_test.go
+++ b/internal/autostart/manager_darwin_test.go
@@ -74,6 +74,23 @@ func TestPlistUsesArgumentArrayAndEscapesValues(t *testing.T) {
 	}
 }
 
+func TestDarwinStatusIgnoresNestedCoalitionState(t *testing.T) {
+	original := launchctl
+	launchctl = func(args ...string) ([]byte, error) {
+		return []byte("state = running\npid = 123\nresource coalition = {\n\tstate = active\n}\n"), nil
+	}
+	t.Cleanup(func() { launchctl = original })
+
+	m := &platformManager{label: "com.yoooclaw.test", plist: filepath.Join(t.TempDir(), "test.plist")}
+	status, err := m.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !status.Loaded || !status.Running || status.PID != 123 {
+		t.Fatalf("unexpected status: %+v", status)
+	}
+}
+
 func TestDarwinStopAcceptsBootoutErrorWhenServiceIsGone(t *testing.T) {
 	loaded := true
 	bootoutCalls := stubLaunchctl(t, &loaded, fakeLaunchctlExitError{code: 3}, true)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -210,6 +210,42 @@ func TestConfigInitNoAutostartPersistsOptOut(t *testing.T) {
 	if code != 0 || decode(t, out)["desired"] != "disabled" {
 		t.Fatalf("opt-out was not persisted: %s", out)
 	}
+	out, code = execCLI(t, "daemon", "autostart", "migrate")
+	if code != 0 || decode(t, out)["migrated"] != false {
+		t.Fatalf("migration overwrote explicit opt-out: %s", out)
+	}
+	out, code = execCLI(t, "daemon", "autostart", "status")
+	if code != 0 || decode(t, out)["desired"] != "disabled" {
+		t.Fatalf("migration changed explicit opt-out: %s", out)
+	}
+}
+
+func TestDaemonAutostartMigrateLegacyInitializedProfile(t *testing.T) {
+	home := sandbox(t)
+	cfgFile := filepath.Join(home, "import.json")
+	if err := os.WriteFile(cfgFile, []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if out, code := execCLI(t, "config", "init", "--non-interactive", "--from-file", cfgFile, "--no-start"); code != 0 {
+		t.Fatalf("config init failed: %s", out)
+	}
+	// Simulate an initialized pre-autostart installation: it has config but no
+	// desired-state file or native service registration.
+	if err := os.Remove(filepath.Join(home, "autostart.json")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(filepath.Join(home, "test-services")); err != nil {
+		t.Fatal(err)
+	}
+
+	out, code := execCLI(t, "daemon", "autostart", "migrate")
+	if code != 0 {
+		t.Fatalf("autostart migrate failed: %s", out)
+	}
+	result := decode(t, out)
+	if result["migrated"] != true || result["desired"] != "enabled" || result["installed"] != true || result["running"] != false {
+		t.Fatalf("legacy profile was not migrated cold: %+v", result)
+	}
 }
 
 func TestConfigShowBeforeInit(t *testing.T) {

--- a/internal/cli/cmd_daemon_autostart.go
+++ b/internal/cli/cmd_daemon_autostart.go
@@ -25,7 +25,8 @@ func newDaemonAutostartCmd() *cobra.Command {
 	enable.Flags().Bool("no-start", false, "只启用自启，当前不启动")
 	disable := &cobra.Command{Use: "disable", Short: "停止 daemon 并关闭自启", Args: cobra.NoArgs, RunE: run(daemonAutostartDisable)}
 	status := &cobra.Command{Use: "status", Short: "显示自启期望与系统服务状态", Args: cobra.NoArgs, RunE: run(daemonAutostartStatus)}
-	c.AddCommand(enable, disable, status)
+	migrate := &cobra.Command{Use: "migrate", Short: "迁移旧版本的 daemon 自启状态", Hidden: true, Args: cobra.NoArgs, RunE: run(daemonAutostartMigrate)}
+	c.AddCommand(enable, disable, status, migrate)
 	return c
 }
 
@@ -73,6 +74,14 @@ func autostartSnapshot() (map[string]any, error) {
 	if status.PID > 0 {
 		result["pid"] = status.PID
 	}
+	if exists && state.Executable != "" {
+		result["executable"] = state.Executable
+		_, executableErr := os.Stat(state.Executable)
+		result["executableExists"] = executableErr == nil
+		if os.IsNotExist(executableErr) {
+			result["drift"] = true
+		}
+	}
 	if stateErr != nil {
 		result["stateError"] = stateErr.Error()
 	}
@@ -92,6 +101,63 @@ func daemonAutostartStatus(_ *clictx.Context, _ *cobra.Command, _ []string) (any
 		return nil, autostartError(err)
 	}
 	return result, nil
+}
+
+// daemonAutostartMigrate is called by installers after an upgrade. It only
+// supplies the new default for installations that predate autostart.json;
+// an explicit user opt-out is never overwritten. Registration is deliberately
+// cold: a daemon that was stopped before the upgrade remains stopped until the
+// next login, while an installer can separately restore one that was running.
+func daemonAutostartMigrate(ctx *clictx.Context, _ *cobra.Command, _ []string) (any, error) {
+	root := paths.RootDir()
+	desired, err := autostart.Desired(root)
+	if err != nil {
+		return nil, err
+	}
+	if desired == autostart.DesiredDisabled {
+		return map[string]any{"ok": true, "migrated": false, "desired": desired, "reason": "用户已明确关闭自启"}, nil
+	}
+	if ctx.Profile != persistentActiveProfile() {
+		return map[string]any{"ok": true, "migrated": false, "desired": desiredOrUnknown(desired), "reason": "只迁移 active profile"}, nil
+	}
+	if !config.Exists(ctx.Paths) {
+		return map[string]any{"ok": true, "migrated": false, "desired": desiredOrUnknown(desired), "reason": "active profile 尚未初始化"}, nil
+	}
+	// A running daemon already proves that the active standalone owner is
+	// valid. Probing the account Relay lock in that state would mistake the
+	// daemon's own lock for a conflicting profile.
+	if state := daemon.State(ctx.Paths); !state.Running {
+		if err := daemon.PrecheckStart(ctx, daemon.StartOpts{}); err != nil {
+			var structured *errs.Error
+			if errors.As(err, &structured) && structured.Code == errs.CodeDaemonDisabledByPlugin {
+				return map[string]any{"ok": true, "migrated": false, "desired": desiredOrUnknown(desired), "reason": structured.Message}, nil
+			}
+			return nil, err
+		}
+	}
+	spec, err := autostartSpec()
+	if err != nil {
+		return nil, autostartError(err)
+	}
+	status, err := autostart.Enable(autostartManager(), spec, false)
+	if err != nil {
+		return nil, autostartError(err)
+	}
+	result, snapshotErr := autostartSnapshot()
+	if snapshotErr != nil {
+		return nil, autostartError(snapshotErr)
+	}
+	result["migrated"] = desired == ""
+	result["repaired"] = desired == autostart.DesiredEnabled
+	result["manager"] = status.Manager
+	return result, nil
+}
+
+func desiredOrUnknown(desired string) string {
+	if desired == "" {
+		return "unknown"
+	}
+	return desired
 }
 
 func daemonAutostartEnable(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error) {

--- a/internal/cli/cmd_owner.go
+++ b/internal/cli/cmd_owner.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/YoooClaw/cli/internal/autostart"
 	"github.com/YoooClaw/cli/internal/clictx"
 	"github.com/YoooClaw/cli/internal/config"
 	"github.com/YoooClaw/cli/internal/daemon"
@@ -123,6 +124,34 @@ func activateCLIOwner(ctx *clictx.Context, hermesProfile string, start bool) (ma
 	if !config.Exists(ctx.Paths) {
 		result["activation"] = "pending-config"
 		result["hint"] = "运行 `yoooclaw config init`；配置完成后 daemon 会自动启动"
+		return result, nil
+	}
+	desired, desiredErr := autostart.Desired(paths.RootDir())
+	if desiredErr != nil {
+		return nil, desiredErr
+	}
+	if desired != autostart.DesiredDisabled {
+		spec, specErr := autostartSpec()
+		if specErr != nil {
+			return nil, autostartError(specErr)
+		}
+		status, enableErr := autostart.Enable(autostartManager(), spec, true)
+		if enableErr != nil {
+			return nil, autostartError(enableErr)
+		}
+		if status.Manager != "test" {
+			if readyErr := waitForManagedDaemon(ctx); readyErr != nil {
+				return nil, readyErr
+			}
+		}
+		state := daemon.State(ctx.Paths)
+		result["activation"] = "active"
+		result["daemonStarted"] = true
+		result["supervised"] = true
+		result["autostart"] = true
+		if state.Lock != nil {
+			result["pid"] = state.Lock.PID
+		}
 		return result, nil
 	}
 	lock, err := startStandalone(ctx)

--- a/internal/cli/cmd_owner_test.go
+++ b/internal/cli/cmd_owner_test.go
@@ -7,7 +7,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/YoooClaw/cli/internal/autostart"
 	"github.com/YoooClaw/cli/internal/clictx"
+	"github.com/YoooClaw/cli/internal/config"
 	"github.com/YoooClaw/cli/internal/paths"
 )
 
@@ -48,6 +50,34 @@ func TestActivateCLIOwnerDisablesHermesAndLeavesUnconfiguredInstallPending(t *te
 	}
 	if result["gatewayRestarted"] != false || result["daemonStarted"] != false {
 		t.Fatalf("unheld/unconfigured install should not restart/start: %#v", result)
+	}
+}
+
+func TestActivateCLIOwnerDefaultsLegacyInstallToManagedAutostart(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("LOCALAPPDATA", "")
+	t.Setenv("YOOOCLAW_HOME", root)
+	t.Setenv("YOOOCLAW_AUTOSTART_TEST_DIR", filepath.Join(root, "test-services"))
+
+	oldFind := findExecutable
+	t.Cleanup(func() { findExecutable = oldFind })
+	findExecutable = func(string) (string, error) { return "", errors.New("not installed") }
+
+	p := paths.For("default")
+	if err := config.Save(p, config.Default(p.Credentials)); err != nil {
+		t.Fatal(err)
+	}
+	ctx := &clictx.Context{Profile: "default", Paths: p}
+	result, err := activateCLIOwner(ctx, "", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result["daemonStarted"] != true || result["supervised"] != true || result["autostart"] != true {
+		t.Fatalf("owner activation did not enable managed autostart: %#v", result)
+	}
+	if desired, err := autostart.Desired(root); err != nil || desired != autostart.DesiredEnabled {
+		t.Fatalf("desired=%q err=%v", desired, err)
 	}
 }
 

--- a/npm/cli/bin/activate-owner.js
+++ b/npm/cli/bin/activate-owner.js
@@ -86,6 +86,12 @@ if (activationRequested) {
   }
 }
 
+if (!tryRun(["daemon", "autostart", "migrate", "--format", "json"])) {
+  process.stderr.write(
+    "@yoooclaw/cli: could not migrate daemon autostart; run `yoooclaw daemon autostart enable` manually\n",
+  );
+}
+
 try {
   fs.unlinkSync(statePath);
 } catch {}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -387,4 +387,13 @@ else
   done
   info "已保留当前 Relay owner（如需切换到 CLI，请重新运行并加 --activate）"
 fi
+
+# Older releases had no persisted autostart preference. Register the active
+# profile on first upgrade even when its daemon happened to be stopped. The
+# migration command preserves an explicit opt-out and skips Hermes-owned data.
+if yoooclaw daemon autostart migrate --format json >/dev/null; then
+  info "daemon 登录自启状态已核对"
+else
+  warn "无法迁移 daemon 登录自启；可稍后运行: yoooclaw daemon autostart enable"
+fi
 HANDOFF_PENDING=0

--- a/scripts/install_test.go
+++ b/scripts/install_test.go
@@ -129,7 +129,7 @@ func TestInstallScriptRequiresExplicitOwnerActivation(t *testing.T) {
 		t.Fatal(err)
 	}
 	script := string(text)
-	for _, want := range []string{"--activate", "YOOOCLAW_ACTIVATE_OWNER", "stop_existing_daemons", "yoooclaw owner activate cli", "已保留当前 Relay owner"} {
+	for _, want := range []string{"--activate", "YOOOCLAW_ACTIVATE_OWNER", "stop_existing_daemons", "yoooclaw owner activate cli", "daemon autostart migrate", "已保留当前 Relay owner"} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("install.sh missing %q", want)
 		}
@@ -209,6 +209,7 @@ esac
 		"old:--profile default daemon status",
 		"old:--profile default daemon stop",
 		"new:--profile default daemon autostart enable",
+		"new:daemon autostart migrate --format json",
 	} {
 		if !strings.Contains(logText, want) {
 			t.Fatalf("update did not preserve CLI owner (%q missing):\n%s", want, logText)
@@ -238,7 +239,7 @@ func TestNpmPackagePreservesOwnerUnlessExplicitlyActivated(t *testing.T) {
 	if !strings.Contains(string(activation), `"owner", "activate", "cli"`) {
 		t.Fatal("npm postinstall does not activate CLI owner")
 	}
-	for _, want := range []string{"YOOOCLAW_ACTIVATE_OWNER", "runningProfiles", "current Relay owner preserved"} {
+	for _, want := range []string{"YOOOCLAW_ACTIVATE_OWNER", "runningProfiles", "daemon\", \"autostart\", \"migrate", "current Relay owner preserved"} {
 		if !strings.Contains(string(activation), want) {
 			t.Fatalf("npm postinstall missing owner-preservation marker %q", want)
 		}
@@ -310,6 +311,7 @@ exit 0
 		"old:--profile default daemon status",
 		"old:--profile default daemon stop",
 		"new:--profile default daemon autostart enable",
+		"new:daemon autostart migrate --format json",
 	} {
 		if !strings.Contains(logText, want) {
 			t.Fatalf("npm lifecycle did not restore CLI owner (%q missing):\n%s", want, logText)


### PR DESCRIPTION
## Summary

- release YoooClaw CLI 0.9.1
- migrate legacy configured installs to daemon login autostart
- preserve explicit autostart opt-out and Hermes ownership
- fix macOS launchd running-state parsing

## Validation

- `go test ./...`
- `go vet ./...`
- release branch CI passed
- `cli-v0.9.1` release workflow passed