### PR TITLE
支持录音 audio-only 有序写入与能力声明

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ yoooclaw --profile work notification +today
 ### Recording & Relay
 
 The standalone daemon uses a Go implementation of recording storage, the state machine, OSS download, and ASR scheduling, and receives the app/cloud's `recordings.result.write` (writing transcripts/summaries, optionally downloading audio) via `RelayClient + RelayDispatcher`.
+Newer app clients can write the original audio first and add transcript and summary with a higher `writeRevision`. The same `recordingId + writeRevision` is reserved for idempotent retries of an unchanged request; business-content changes must advance the revision. Every successful `recordings.list` response permanently includes `protocol: {orderedWrite: 1, audioOnlyWrite: true}`, and `limit: 0` can probe this capability without returning list items.
 New-recording payloads should include `recording.created_at` (or top-level `createdAt` / `created_at`); `transcript.generatedAt` is artifact-generation time and is never used as the recording time.
 Top-level `durationMillis` is truncated down to integer seconds and stored as numeric `duration_sec`; `duration_display` adds a human-readable unit form such as `16s`, `1m 16s`, or `1h 1m 1s`. After the audio is downloaded, the CLI stores `file_size_display` using the Android `Formatter.formatShortFileSize()`-compatible SI short format; the removed `file_size_bytes` field is not emitted.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -407,6 +407,7 @@ yoooclaw --profile work notification +today
 ### 录音与 Relay
 
 独立 daemon 用 Go 版录音存储、状态机、OSS 下载与 ASR 调度，并通过 `RelayClient + RelayDispatcher` 接收 App/云端的 `recordings.result.write`（写入转录/总结，可选下载音频）。
+新版 App 可先用 audio-only 写入原音频，再用更高的 `writeRevision` 补齐转写和总结；同一 `recordingId + writeRevision` 仅用于原请求的幂等重试，业务内容变化必须提升 revision。`recordings.list` 的成功响应会永久携带 `protocol: {orderedWrite: 1, audioOnlyWrite: true}`，并支持用 `limit: 0` 只探测能力而不返回列表项。
 新录音请求应携带 `recording.created_at`（也兼容顶层 `createdAt` / `created_at`）；`transcript.generatedAt` 只表示转写产物生成时间，不再充当录音时间。
 顶层 `durationMillis` 向下截断为整数秒，并以数值字段 `duration_sec` 保存；`duration_display` 提供 `16s`、`1m 16s`、`1h 1m 1s` 等带单位展示。音频下载落盘后，CLI 按兼容 Android `Formatter.formatShortFileSize()` 的 SI 短格式保存 `file_size_display`；已删除的 `file_size_bytes` 不再输出。
 

--- a/internal/daemon/server_ingest.go
+++ b/internal/daemon/server_ingest.go
@@ -1,7 +1,12 @@
 package daemon
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"math"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/YoooClaw/cli/internal/clientlabel"
@@ -36,7 +41,7 @@ func (s *server) handleRecordingGateway(w http.ResponseWriter, r *http.Request, 
 			gatewayErr(w, "INVALID_PARAMS", "recordingId 含非法字符（不允许路径分隔符等）")
 			return
 		}
-		if body.Transcript == nil && body.Summary == nil {
+		if !body.HasWriteRevision() && body.Transcript == nil && body.Summary == nil {
 			gatewayErr(w, "INVALID_PARAMS", "transcript or summary is required")
 			return
 		}
@@ -46,6 +51,12 @@ func (s *server) handleRecordingGateway(w http.ResponseWriter, r *http.Request, 
 			ClientLabel:  auth.clientLabel,
 		})
 		if err != nil {
+			var writeErr *recording.WriteError
+			if errors.As(err, &writeErr) {
+				s.logRecordingWriteFailure(recordingID, r.Header.Get(relay.InternalRequestIDHeader), err)
+				gatewayErrData(w, writeErr)
+				return
+			}
 			code := "RESULT_WRITE_FAILED"
 			switch {
 			case strings.HasPrefix(err.Error(), "Recording not found:"):
@@ -122,7 +133,10 @@ func (s *server) handleRecordingGateway(w http.ResponseWriter, r *http.Request, 
 
 	case "recordings.list":
 		var body struct {
-			Status string `json:"status"`
+			Status string          `json:"status"`
+			From   string          `json:"from"`
+			To     string          `json:"to"`
+			Limit  json.RawMessage `json:"limit"`
 		}
 		if !decodeBody(w, r, &body) {
 			return
@@ -132,19 +146,54 @@ func (s *server) handleRecordingGateway(w http.ResponseWriter, r *http.Request, 
 			gatewayErr(w, "INVALID_PARAMS", "invalid recording status: "+status)
 			return
 		}
-		entries := s.recordingStorage.ListAll()
-		if status != "" {
-			entries = s.recordingStorage.ListByStatus(status)
+		fromValue := strings.TrimSpace(body.From)
+		toValue := strings.TrimSpace(body.To)
+		from, fromOK := recording.ParseTime(fromValue)
+		to, toOK := recording.ParseTime(toValue)
+		if fromValue != "" && !fromOK {
+			gatewayErr(w, "INVALID_PARAMS", "from must be an ISO 8601 timestamp or YYYY-MM-DD date")
+			return
 		}
+		if toValue != "" && !toOK {
+			gatewayErr(w, "INVALID_PARAMS", "to must be an ISO 8601 timestamp or YYYY-MM-DD date")
+			return
+		}
+		if fromOK && toOK && !from.Before(to) {
+			gatewayErr(w, "INVALID_PARAMS", "from must be earlier than to")
+			return
+		}
+		limit, hasLimit, limitErr := parseRecordingListLimit(body.Limit)
+		if limitErr != nil {
+			gatewayErr(w, "INVALID_PARAMS", limitErr.Error())
+			return
+		}
+		entries := s.recordingStorage.ListAll()
 		scope := auth.scope()
 		items := make([]map[string]any, 0, len(entries))
 		for _, entry := range entries {
 			if !clientlabel.Visible(entry.ClientLabel, scope) {
 				continue
 			}
+			if status != "" && entry.Status != status {
+				continue
+			}
+			if fromOK || toOK {
+				occurredAt, ok := recording.EffectiveTime(entry)
+				if !ok || (fromOK && occurredAt.Before(from)) || (toOK && !occurredAt.Before(to)) {
+					continue
+				}
+			}
 			items = append(items, recordingListItem(entry))
 		}
-		gatewayOK(w, map[string]any{"total": len(items), "recordings": items})
+		total := len(items)
+		if hasLimit && limit < len(items) {
+			items = items[:limit]
+		}
+		gatewayOK(w, map[string]any{
+			"total":      total,
+			"recordings": items,
+			"protocol":   map[string]any{"orderedWrite": 1, "audioOnlyWrite": true},
+		})
 
 	case "recordings.status":
 		var body recordingIDBody
@@ -285,7 +334,7 @@ func (s *server) notifyRecordingStatus(event recording.StatusEvent) {
 }
 
 func recordingListItem(entry recording.Entry) map[string]any {
-	return map[string]any{
+	item := map[string]any{
 		"recordingId":        entry.ID,
 		"name":               entry.Metadata.Name,
 		"duration_sec":       entry.Metadata.DurationSec,
@@ -304,11 +353,15 @@ func recordingListItem(entry recording.Entry) map[string]any {
 		"updatedAt":          entry.UpdatedAt,
 		"error":              nilIfEmptyStr(entry.LastError),
 	}
+	if entry.WriteRevision != nil {
+		item["writeRevision"] = *entry.WriteRevision
+	}
+	return item
 }
 
 func recordingDetail(entry recording.Entry) map[string]any {
 	title := firstNonEmptyStr(entry.Title, entry.Metadata.Name, entry.ID)
-	return map[string]any{
+	detail := map[string]any{
 		"recordingId":        entry.ID,
 		"name":               entry.Metadata.Name,
 		"duration_sec":       entry.Metadata.DurationSec,
@@ -320,6 +373,7 @@ func recordingDetail(entry recording.Entry) map[string]any {
 		"oss_srt_url":        nilIfEmptyStr(entry.Metadata.OssSrtURL),
 		"markers":            entry.Metadata.Markers,
 		"transfer_status":    entry.Status,
+		"audio_status":       entry.AudioStatus,
 		"audioFile":          nilIfEmptyStr(entry.AudioFile),
 		"srtFile":            nilIfEmptyStr(entry.SrtFile),
 		"transcriptDataFile": nilIfEmptyStr(entry.TranscriptDataFile),
@@ -330,6 +384,34 @@ func recordingDetail(entry recording.Entry) map[string]any {
 		"updatedAt":          entry.UpdatedAt,
 		"error":              nilIfEmptyStr(entry.LastError),
 	}
+	if entry.WriteRevision != nil {
+		detail["writeRevision"] = *entry.WriteRevision
+	}
+	return detail
+}
+
+func parseRecordingListLimit(raw json.RawMessage) (int, bool, error) {
+	if len(raw) == 0 {
+		return 0, false, nil
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return 0, true, errors.New("limit must be a non-negative safe integer")
+	}
+	number, ok := value.(json.Number)
+	if !ok {
+		return 0, true, errors.New("limit must be a non-negative safe integer")
+	}
+	parsed, err := strconv.ParseFloat(number.String(), 64)
+	if err != nil || math.IsNaN(parsed) || math.IsInf(parsed, 0) || math.Trunc(parsed) != parsed || parsed < 0 || parsed > 9007199254740991 {
+		return 0, true, errors.New("limit must be a non-negative safe integer")
+	}
+	if parsed > float64(^uint(0)>>1) {
+		return 0, true, errors.New("limit exceeds platform integer range")
+	}
+	return int(parsed), true, nil
 }
 
 func maskedKeyLog(asr *recording.AsrConfig) string {

--- a/internal/daemon/server_light.go
+++ b/internal/daemon/server_light.go
@@ -69,6 +69,10 @@ func gatewayErr(w http.ResponseWriter, code, message string) {
 	writeJSON(w, 200, map[string]any{"ok": false, "error": map[string]any{"code": code, "message": message}})
 }
 
+func gatewayErrData(w http.ResponseWriter, payload any) {
+	writeJSON(w, 200, map[string]any{"ok": false, "error": payload})
+}
+
 func asString(v any) string {
 	s, _ := v.(string)
 	return s

--- a/internal/daemon/server_recording_ordered_test.go
+++ b/internal/daemon/server_recording_ordered_test.go
@@ -1,0 +1,93 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/YoooClaw/cli/internal/recording"
+	"github.com/YoooClaw/cli/internal/relay"
+)
+
+func postInternalGateway(t *testing.T, url, body string) map[string]any {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set(relay.InternalHTTPHeader, "1")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var envelope map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatal(err)
+	}
+	return envelope
+}
+
+func TestRecordingListAlwaysReturnsProtocolAndSupportsLimitZero(t *testing.T) {
+	srv, ts := newTestServer(t, "")
+	dir := filepath.Join(t.TempDir(), "recordings")
+	storage := recording.NewStorage(dir, srv.logger)
+	if err := storage.Init(); err != nil {
+		t.Fatal(err)
+	}
+	srv.recordingStorage = storage
+	if _, err := storage.Ingest("list-1", recording.Metadata{Name: "录音", CreatedAt: "2026-08-27T11:00:00+08:00"}, "default"); err != nil {
+		t.Fatal(err)
+	}
+
+	envelope := postInternalGateway(t, ts.URL+"/gateway/recordings.list", `{"limit":0}`)
+	if envelope["ok"] != true {
+		t.Fatalf("unexpected envelope: %+v", envelope)
+	}
+	data := envelope["data"].(map[string]any)
+	if data["total"] != float64(1) || len(data["recordings"].([]any)) != 0 {
+		t.Fatalf("unexpected limit=0 result: %+v", data)
+	}
+	protocol := data["protocol"].(map[string]any)
+	if protocol["orderedWrite"] != float64(1) || protocol["audioOnlyWrite"] != true {
+		t.Fatalf("unexpected protocol: %+v", protocol)
+	}
+
+	invalid := postInternalGateway(t, ts.URL+"/gateway/recordings.list", `{"limit":null}`)
+	if invalid["ok"] != false || invalid["error"].(map[string]any)["code"] != "INVALID_PARAMS" {
+		t.Fatalf("null limit must fail: %+v", invalid)
+	}
+}
+
+func TestOrderedGatewayAcceptsExplicitEmptyFullResultAndIsIdempotent(t *testing.T) {
+	srv, ts := newTestServer(t, "")
+	dir := filepath.Join(t.TempDir(), "recordings")
+	storage := recording.NewStorage(dir, srv.logger)
+	if err := storage.Init(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = storage.Close() })
+	srv.recordingStorage = storage
+
+	base := `{"recordingId":"gateway-ordered","writeRevision":1,"ossUrl":"` + ts.URL + `/audio.m4a","recording":{"name":"录音","duration_sec":0,"created_at":"2026-08-27T11:00:00+08:00","oss_audio_url":"` + ts.URL + `/audio.m4a","markers":[]},"transcript":{"text":""},"summary":{"markdown":""}}`
+	envelope := postInternalGateway(t, ts.URL+"/gateway/recordings.result.write", base)
+	if envelope["ok"] != true {
+		t.Fatalf("ordered empty result rejected: %+v", envelope)
+	}
+	data := envelope["data"].(map[string]any)
+	if data["writeRevision"] != float64(1) || data["transfer_status"] != "transcribed" {
+		t.Fatalf("unexpected ordered result: %+v", data)
+	}
+
+	retry := postInternalGateway(t, ts.URL+"/gateway/recordings.result.write", base)
+	if retry["ok"] != true {
+		t.Fatalf("idempotent retry failed: %+v", retry)
+	}
+
+	invalidRevision := postInternalGateway(t, ts.URL+"/gateway/recordings.result.write", strings.Replace(base, `"writeRevision":1`, `"writeRevision":null`, 1))
+	if invalidRevision["ok"] != false || invalidRevision["error"].(map[string]any)["code"] != "INVALID_PARAMS" {
+		t.Fatalf("null revision must fail: %+v", invalidRevision)
+	}
+}

--- a/internal/recording/asr.go
+++ b/internal/recording/asr.go
@@ -200,6 +200,9 @@ type WorkflowResult struct {
 // RunTranscriptionWorkflow 转写并写 transcript-data/transcripts/summaries。
 func RunTranscriptionWorkflow(storage *Storage, entry Entry, cfg AsrConfig, logger Logger) WorkflowResult {
 	audioPath := storage.AudioFilePath(entry.ID, entry.Metadata.OssAudioURL)
+	if strings.TrimSpace(entry.AudioFile) != "" {
+		audioPath = filepath.Join(storage.dir, entry.AudioFile)
+	}
 	durationMS := entry.Metadata.DurationSec * 1000
 	result := TranscribeAudio(audioPath, cfg, logger, entry.Metadata.OssAudioURL, durationMS)
 	if !result.OK {

--- a/internal/recording/asr_revision.go
+++ b/internal/recording/asr_revision.go
@@ -1,0 +1,90 @@
+package recording
+
+import "strings"
+
+func sameWriteRevision(left, right *int64) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
+}
+
+func (s *Storage) beginTranscriptionAtRevision(recordingID string, baseRevision *int64) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	idx := s.findIndexLocked(recordingID)
+	if idx < 0 || !sameWriteRevision(s.index.Recordings[idx].WriteRevision, baseRevision) {
+		return false, nil
+	}
+	if !CanStartTranscription(s.index.Recordings[idx].Status) {
+		return false, nil
+	}
+	nextIndex, err := cloneRecordingIndex(s.index)
+	if err != nil {
+		return false, err
+	}
+	next := &nextIndex.Recordings[idx]
+	next.Status = StatusTranscribing
+	next.Metadata.Status = next.Status
+	next.LastError = ""
+	next.UpdatedAt = nowISO()
+	if err := fsWriteIndex(s.indexPath, nextIndex); err != nil {
+		return false, err
+	}
+	s.index = nextIndex
+	return true, nil
+}
+
+func (s *Storage) failTranscriptionAtRevision(recordingID string, baseRevision *int64, message string) (bool, error) {
+	return s.mutateTranscriptionAtRevision(recordingID, baseRevision, func(entry *Entry) {
+		entry.Status = StatusTranscribeFailed
+		entry.Metadata.Status = entry.Status
+		entry.LastError = strings.TrimSpace(message)
+	})
+}
+
+func (s *Storage) commitTranscriptionAtRevision(recordingID string, baseRevision *int64, result WorkflowResult) (bool, error) {
+	return s.mutateTranscriptionAtRevision(recordingID, baseRevision, func(entry *Entry) {
+		entry.TranscriptDataFile = transcriptDataDirName + "/" + result.TranscriptDataFilename
+		entry.TranscriptFile = transcriptsDirName + "/" + result.TranscriptFilename
+		if result.SummaryFilename != "" {
+			entry.SummaryFile = summariesDirName + "/" + result.SummaryFilename
+		}
+		entry.Title = strings.TrimSpace(result.Title)
+		entry.Status = StatusTranscribed
+		entry.Metadata.Status = entry.Status
+		entry.LastError = ""
+	})
+}
+
+func (s *Storage) mutateTranscriptionAtRevision(recordingID string, baseRevision *int64, mutate func(*Entry)) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	idx := s.findIndexLocked(recordingID)
+	if idx < 0 || !sameWriteRevision(s.index.Recordings[idx].WriteRevision, baseRevision) {
+		return false, nil
+	}
+	nextIndex, err := cloneRecordingIndex(s.index)
+	if err != nil {
+		return false, err
+	}
+	next := &nextIndex.Recordings[idx]
+	mutate(next)
+	next.UpdatedAt = nowISO()
+	if err := fsWriteIndex(s.indexPath, nextIndex); err != nil {
+		return false, err
+	}
+	s.index = nextIndex
+	return true, nil
+}
+
+func (s *Storage) cleanupSupersededTranscription(result WorkflowResult) {
+	paths := []string{
+		transcriptDataDirName + "/" + result.TranscriptDataFilename,
+		transcriptsDirName + "/" + result.TranscriptFilename,
+	}
+	if result.SummaryFilename != "" {
+		paths = append(paths, summariesDirName+"/"+result.SummaryFilename)
+	}
+	s.removeUnreferencedOrderedPaths(paths)
+}

--- a/internal/recording/downloader.go
+++ b/internal/recording/downloader.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -33,6 +34,7 @@ type DownloadOptions struct {
 // DownloadResult 是单个文件下载结果。
 type DownloadResult struct {
 	OK        bool          `json:"ok"`
+	Cancelled bool          `json:"cancelled,omitempty"`
 	SizeBytes int64         `json:"sizeBytes,omitempty"`
 	Elapsed   time.Duration `json:"-"`
 	Error     string        `json:"error,omitempty"`
@@ -49,6 +51,16 @@ func (e *downloadHTTPStatusError) Error() string {
 
 // DownloadFile 从 URL 下载文件到 destPath。
 func DownloadFile(rawURL, destPath string, logger Logger, opts DownloadOptions) DownloadResult {
+	return downloadFileContext(context.Background(), rawURL, destPath, logger, opts, false)
+}
+
+// DownloadFileContext 为有序录音写入提供可取消下载；严格校验非空文件和
+// Content-Length，取消不会被上报为业务失败。
+func DownloadFileContext(ctx context.Context, rawURL, destPath string, logger Logger, opts DownloadOptions) DownloadResult {
+	return downloadFileContext(ctx, rawURL, destPath, logger, opts, true)
+}
+
+func downloadFileContext(parent context.Context, rawURL, destPath string, logger Logger, opts DownloadOptions, strict bool) DownloadResult {
 	timeout := opts.Timeout
 	if timeout <= 0 {
 		timeout = defaultDownloadTimeout
@@ -69,9 +81,12 @@ func DownloadFile(rawURL, destPath string, logger Logger, opts DownloadOptions) 
 	_ = fsutil.EnsureDir(filepath.Dir(destPath), fsutil.DirMode)
 	var lastErr string
 	for attempt := 1; attempt <= retries; attempt++ {
+		if err := parent.Err(); err != nil {
+			return DownloadResult{OK: false, Cancelled: true, Error: err.Error()}
+		}
 		start := time.Now()
 		logger.Info(fmt.Sprintf("[downloader] 开始下载 (attempt %d/%d): %s", attempt, retries, rawURL))
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithTimeout(parent, timeout)
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 		if err != nil {
 			cancel()
@@ -85,7 +100,7 @@ func DownloadFile(rawURL, destPath string, logger Logger, opts DownloadOptions) 
 			resp, err = fallbackClient.Do(req.Clone(ctx))
 		}
 		if err == nil && resp != nil {
-			err = writeDownloadResponse(resp, destPath)
+			err = writeDownloadResponseChecked(resp, destPath, strict)
 		}
 		if resp != nil && resp.Body != nil {
 			_ = resp.Body.Close()
@@ -106,19 +121,38 @@ func DownloadFile(rawURL, destPath string, logger Logger, opts DownloadOptions) 
 			return DownloadResult{OK: true, SizeBytes: size, Elapsed: elapsed}
 		}
 
+		if parent.Err() != nil || errors.Is(err, context.Canceled) {
+			message := err.Error()
+			if parent.Err() != nil {
+				message = parent.Err().Error()
+			}
+			return DownloadResult{OK: false, Cancelled: true, Error: message}
+		}
 		lastErr = err.Error()
 		logger.Warn(fmt.Sprintf("[downloader] 下载失败 (attempt %d/%d): %s", attempt, retries, lastErr))
 		if !isRetryableDownloadError(err) {
 			break
 		}
 		if attempt < retries {
-			time.Sleep(backoff * time.Duration(1<<(attempt-1)))
+			timer := time.NewTimer(backoff * time.Duration(1<<(attempt-1)))
+			select {
+			case <-parent.Done():
+				if !timer.Stop() {
+					<-timer.C
+				}
+				return DownloadResult{OK: false, Cancelled: true, Error: parent.Err().Error()}
+			case <-timer.C:
+			}
 		}
 	}
 	return DownloadResult{OK: false, Error: lastErr}
 }
 
 func writeDownloadResponse(resp *http.Response, destPath string) error {
+	return writeDownloadResponseChecked(resp, destPath, false)
+}
+
+func writeDownloadResponseChecked(resp *http.Response, destPath string, strict bool) error {
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return &downloadHTTPStatusError{Code: resp.StatusCode, Status: resp.Status}
 	}
@@ -142,8 +176,23 @@ func writeDownloadResponse(resp *http.Response, destPath string) error {
 		}
 	}()
 	_ = f.Chmod(0o600)
-	if _, err := io.Copy(f, resp.Body); err != nil {
+	written, err := io.Copy(f, resp.Body)
+	if err != nil {
 		return err
+	}
+	if strict && written <= 0 {
+		return fmt.Errorf("downloaded audio is empty")
+	}
+	if strict {
+		if rawLength := strings.TrimSpace(resp.Header.Get("Content-Length")); rawLength != "" {
+			declared, parseErr := strconv.ParseInt(rawLength, 10, 64)
+			if parseErr != nil || declared < 0 {
+				return fmt.Errorf("invalid Content-Length")
+			}
+			if written != declared {
+				return fmt.Errorf("downloaded size %d does not match Content-Length %d", written, declared)
+			}
+		}
 	}
 	if err := f.Close(); err != nil {
 		return err

--- a/internal/recording/events.go
+++ b/internal/recording/events.go
@@ -11,6 +11,7 @@ import (
 // StatusEvent 是录音状态变化事件。
 type StatusEvent struct {
 	RecordingID        string           `json:"recordingId"`
+	WriteRevision      *int64           `json:"writeRevision,omitempty"`
 	TransferStatus     string           `json:"transfer_status"`
 	AudioStatus        string           `json:"audio_status,omitempty"`
 	AudioFile          string           `json:"audioFile,omitempty"`

--- a/internal/recording/handler.go
+++ b/internal/recording/handler.go
@@ -22,10 +22,15 @@ func TriggerTranscription(recordingID string, storage *Storage, asr AsrConfig, l
 		logger.Warn("[asr-trigger] 当前状态不允许转写: " + recordingID + " (status=" + entry.Status + ")")
 		return nil
 	}
-	if _, err := storage.UpdateStatus(recordingID, StatusTranscribing); err != nil {
+	baseRevision := cloneInt64(entry.WriteRevision)
+	started, err := storage.beginTranscriptionAtRevision(recordingID, baseRevision)
+	if err != nil {
 		return err
 	}
-	_ = storage.SetLastError(recordingID, "")
+	if !started {
+		logger.Info("[asr-trigger] revision 已变化或状态不允许，跳过: " + recordingID)
+		return nil
+	}
 	emitRecordingStatus(recordingID, storage, logger, opts.NotifyStatus, "", nil)
 
 	entry, _ = storage.FindByID(recordingID)
@@ -33,19 +38,25 @@ func TriggerTranscription(recordingID string, storage *Storage, asr AsrConfig, l
 	if !result.OK {
 		message := "转写失败: " + result.Error
 		logger.Error("[asr-trigger] " + message + ": " + recordingID)
-		_, _ = storage.UpdateStatus(recordingID, StatusTranscribeFailed)
-		_ = storage.SetLastError(recordingID, message)
-		emitRecordingStatus(recordingID, storage, logger, opts.NotifyStatus, message, nil)
+		applied, applyErr := storage.failTranscriptionAtRevision(recordingID, baseRevision, message)
+		if applyErr != nil {
+			return applyErr
+		}
+		if applied {
+			emitRecordingStatus(recordingID, storage, logger, opts.NotifyStatus, message, nil)
+		}
 		return nil
 	}
-	_ = storage.SetTranscriptDataFile(recordingID, result.TranscriptDataFilename)
-	_ = storage.SetTranscriptFile(recordingID, result.TranscriptFilename)
-	if result.SummaryFilename != "" {
-		_ = storage.SetSummaryFile(recordingID, result.SummaryFilename)
+	applied, applyErr := storage.commitTranscriptionAtRevision(recordingID, baseRevision, result)
+	if applyErr != nil {
+		storage.cleanupSupersededTranscription(result)
+		return applyErr
 	}
-	_ = storage.SetTitle(recordingID, result.Title)
-	_, _ = storage.UpdateStatus(recordingID, StatusTranscribed)
-	_ = storage.SetLastError(recordingID, "")
+	if !applied {
+		storage.cleanupSupersededTranscription(result)
+		logger.Info("[asr-trigger] 转写结果已被更高 writeRevision 取代: " + recordingID)
+		return nil
+	}
 	logger.Info("[asr-trigger] 转写完成: " + recordingID + ", summary=\"" + result.Title + "\"")
 	emitRecordingStatus(recordingID, storage, logger, opts.NotifyStatus, "", &StatusEvent{
 		Transcript: result.Transcript,
@@ -79,6 +90,7 @@ func emitRecordingStatus(recordingID string, storage *Storage, logger Logger, no
 	}
 	event := StatusEvent{
 		RecordingID:        entry.ID,
+		WriteRevision:      cloneInt64(entry.WriteRevision),
 		TransferStatus:     entry.Status,
 		AudioStatus:        entry.AudioStatus,
 		AudioFile:          entry.AudioFile,

--- a/internal/recording/ordered_audio.go
+++ b/internal/recording/ordered_audio.go
@@ -1,0 +1,253 @@
+package recording
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var orderedArtifactName = regexp.MustCompile(`^[^/\\]+\.r[1-9][0-9]*\.[0-9a-f]{32}(?:\.(?:json|transcript\.md|summary\.md)|\.[A-Za-z0-9]+)(?:\.staged)?$`)
+
+func queueOrderedAudioDownload(request validatedOrderedWrite, storage *Storage, logger Logger, opts SyncOptions) {
+	ctx, cancel := context.WithCancel(context.Background())
+	if !storage.registerOrderedAudioTask(request.recordingID, request.revision, request.ossURL, cancel) {
+		cancel()
+		return
+	}
+	go func() {
+		defer storage.orderedTasksWG.Done()
+		defer storage.finishOrderedAudioTask(request.recordingID, request.revision, request.ossURL)
+		downloadOrderedAudio(ctx, request.recordingID, request.revision, request.ossURL, storage, logger, opts)
+	}()
+}
+
+func (s *Storage) registerOrderedAudioTask(recordingID string, revision int64, ossURL string, cancel context.CancelFunc) bool {
+	s.orderedTasksMu.Lock()
+	defer s.orderedTasksMu.Unlock()
+	if s.orderedClosed {
+		return false
+	}
+	if current := s.orderedAudioTasks[recordingID]; current != nil {
+		if current.writeRevision == revision && current.ossURL == ossURL {
+			return false
+		}
+		current.cancel()
+	}
+	s.orderedAudioTasks[recordingID] = &orderedAudioTask{writeRevision: revision, ossURL: ossURL, cancel: cancel}
+	s.orderedTasksWG.Add(1)
+	return true
+}
+
+func (s *Storage) finishOrderedAudioTask(recordingID string, revision int64, ossURL string) {
+	s.orderedTasksMu.Lock()
+	defer s.orderedTasksMu.Unlock()
+	current := s.orderedAudioTasks[recordingID]
+	if current != nil && current.writeRevision == revision && current.ossURL == ossURL {
+		delete(s.orderedAudioTasks, recordingID)
+	}
+}
+
+func (s *Storage) cancelSupersededOrderedTask(recordingID string, revision int64, ossURL string) {
+	s.orderedTasksMu.Lock()
+	defer s.orderedTasksMu.Unlock()
+	current := s.orderedAudioTasks[recordingID]
+	if current != nil && (current.writeRevision != revision || current.ossURL != ossURL) {
+		current.cancel()
+		delete(s.orderedAudioTasks, recordingID)
+	}
+}
+
+func downloadOrderedAudio(ctx context.Context, recordingID string, revision int64, ossURL string, storage *Storage, logger Logger, opts SyncOptions) {
+	applied, err := storage.setOrderedAudioDownloading(recordingID, revision, ossURL)
+	if err != nil {
+		logger.Error("[recording-result] 音频下载状态写入失败: " + err.Error() + ": " + recordingID)
+		return
+	}
+	if !applied {
+		return
+	}
+	attempt, err := randomAttemptID()
+	if err != nil {
+		logger.Error("[recording-result] 音频 attempt 创建失败: " + err.Error())
+		return
+	}
+	filename := fmt.Sprintf("%s.r%d.%s%s", recordingID, revision, attempt, extractAudioExt(ossURL))
+	staged := filepath.Join(storage.audioDir, "."+filename+".incoming")
+	defer os.Remove(staged)
+	logger.Info(fmt.Sprintf("[recording-result] 开始下载音频: %s, writeRevision=%d", recordingID, revision))
+	result := DownloadFileContext(ctx, ossURL, staged, logger, opts.DownloadOptions)
+	if result.Cancelled {
+		logger.Info(fmt.Sprintf("[recording-result] 音频下载已取消: %s, writeRevision=%d", recordingID, revision))
+		return
+	}
+	if !result.OK {
+		message := "音频下载失败: " + result.Error
+		applied, setErr := storage.setOrderedAudioFailed(recordingID, revision, ossURL, message)
+		if setErr != nil {
+			logger.Error("[recording-result] 音频失败状态写入失败: " + setErr.Error())
+			return
+		}
+		if applied {
+			emitResultDownloadStatusAtRevision(recordingID, &revision, storage, logger, opts.NotifyStatus)
+		}
+		return
+	}
+	applied, err = storage.commitOrderedAudio(recordingID, revision, ossURL, staged, filename)
+	if err != nil {
+		logger.Error("[recording-result] 音频提交失败: " + err.Error())
+		return
+	}
+	if applied {
+		logger.Info(fmt.Sprintf("[recording-result] 音频已更新: %s, writeRevision=%d", recordingID, revision))
+		emitResultDownloadStatusAtRevision(recordingID, &revision, storage, logger, opts.NotifyStatus)
+	}
+}
+
+func (s *Storage) mutateOrderedAudio(recordingID string, revision int64, ossURL string, mutate func(*Entry) bool) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	idx := s.findIndexLocked(recordingID)
+	if idx < 0 {
+		return false, nil
+	}
+	current := s.index.Recordings[idx]
+	if current.WriteRevision == nil || *current.WriteRevision != revision || strings.TrimSpace(current.Metadata.OssAudioURL) != strings.TrimSpace(ossURL) {
+		return false, nil
+	}
+	nextIndex, err := cloneRecordingIndex(s.index)
+	if err != nil {
+		return false, err
+	}
+	next := &nextIndex.Recordings[idx]
+	if !mutate(next) {
+		return false, nil
+	}
+	if err := fsWriteIndex(s.indexPath, nextIndex); err != nil {
+		return false, err
+	}
+	s.index = nextIndex
+	return true, nil
+}
+
+func (s *Storage) setOrderedAudioDownloading(recordingID string, revision int64, ossURL string) (bool, error) {
+	return s.mutateOrderedAudio(recordingID, revision, ossURL, func(entry *Entry) bool {
+		if entry.AudioStatus == AudioStatusDownloaded && s.hasReusableAudioLocked(*entry) {
+			return false
+		}
+		entry.AudioStatus = AudioStatusDownloading
+		if entry.Status == "sync_failed" {
+			entry.Status = "syncing_openclaw"
+			entry.Metadata.Status = entry.Status
+		}
+		entry.UpdatedAt = nowISO()
+		return true
+	})
+}
+
+func (s *Storage) setOrderedAudioFailed(recordingID string, revision int64, ossURL, message string) (bool, error) {
+	return s.mutateOrderedAudio(recordingID, revision, ossURL, func(entry *Entry) bool {
+		entry.AudioStatus = AudioStatusFailed
+		if entry.Status == "syncing_openclaw" || entry.Status == "sync_failed" {
+			entry.Status = "sync_failed"
+			entry.Metadata.Status = entry.Status
+		}
+		entry.LastError = strings.TrimSpace(message)
+		entry.UpdatedAt = nowISO()
+		return true
+	})
+}
+
+func (s *Storage) commitOrderedAudio(recordingID string, revision int64, ossURL, staged, filename string) (bool, error) {
+	if filepath.Base(filename) != filename {
+		return false, os.ErrInvalid
+	}
+	info, err := os.Stat(staged)
+	if err != nil || !info.Mode().IsRegular() || info.Size() <= 0 {
+		if err != nil {
+			return false, err
+		}
+		return false, fmt.Errorf("downloaded audio staging path is not a non-empty file")
+	}
+	s.mu.Lock()
+	idx := s.findIndexLocked(recordingID)
+	if idx < 0 {
+		s.mu.Unlock()
+		return false, nil
+	}
+	current := s.index.Recordings[idx]
+	if current.WriteRevision == nil || *current.WriteRevision != revision || strings.TrimSpace(current.Metadata.OssAudioURL) != strings.TrimSpace(ossURL) {
+		s.mu.Unlock()
+		return false, nil
+	}
+	nextIndex, err := cloneRecordingIndex(s.index)
+	if err != nil {
+		s.mu.Unlock()
+		return false, err
+	}
+	next := &nextIndex.Recordings[idx]
+	destination := filepath.Join(s.audioDir, filename)
+	if err := os.Rename(staged, destination); err != nil {
+		s.mu.Unlock()
+		return false, err
+	}
+	_ = os.Chmod(destination, 0o600)
+	previous := next.AudioFile
+	next.AudioFile = filepath.ToSlash(filepath.Join(audioDirName, filename))
+	next.AudioSourceURL = strings.TrimSpace(ossURL)
+	next.AudioStatus = AudioStatusDownloaded
+	next.Metadata.FileSizeDisplay = FormatShortFileSize(info.Size())
+	if next.Status == "syncing_openclaw" || next.Status == "sync_failed" {
+		next.Status = StatusSynced
+		next.Metadata.Status = next.Status
+	}
+	next.LastError = ""
+	next.UpdatedAt = nowISO()
+	if err := fsWriteIndex(s.indexPath, nextIndex); err != nil {
+		_ = os.Remove(destination)
+		s.mu.Unlock()
+		return false, err
+	}
+	s.index = nextIndex
+	s.mu.Unlock()
+	if previous != "" && previous != next.AudioFile {
+		s.removeUnreferencedOrderedPaths([]string{previous})
+	}
+	return true, nil
+}
+
+func (s *Storage) cleanupUnreferencedOrderedArtifacts() {
+	s.mu.Lock()
+	referenced := map[string]bool{}
+	for _, entry := range s.index.Recordings {
+		for _, relative := range []string{entry.AudioFile, entry.TranscriptDataFile, entry.TranscriptFile, entry.SummaryFile} {
+			if relative != "" {
+				referenced[filepath.Clean(relative)] = true
+			}
+		}
+	}
+	s.mu.Unlock()
+	for _, directory := range []string{s.audioDir, s.transcriptDataDir, s.transcriptsDir, s.summariesDir} {
+		entries, err := os.ReadDir(directory)
+		if err != nil {
+			continue
+		}
+		for _, item := range entries {
+			if item.IsDir() {
+				continue
+			}
+			name := item.Name()
+			candidate := strings.TrimPrefix(name, ".")
+			isIncoming := strings.Contains(name, ".incoming")
+			if !isIncoming && !orderedArtifactName.MatchString(candidate) {
+				continue
+			}
+			relative, _ := filepath.Rel(s.dir, filepath.Join(directory, name))
+			if !referenced[filepath.Clean(relative)] {
+				_ = os.Remove(filepath.Join(directory, name))
+			}
+		}
+	}
+}

--- a/internal/recording/ordered_writer.go
+++ b/internal/recording/ordered_writer.go
@@ -1,0 +1,839 @@
+package recording
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/YoooClaw/cli/internal/fsutil"
+)
+
+const maxSafeWriteRevision int64 = 9007199254740991
+
+// WriteError 是 Gateway 与 Relay 共用的有序写入错误。
+type WriteError struct {
+	Code                 string `json:"code"`
+	Message              string `json:"message"`
+	RecordingID          string `json:"recordingId,omitempty"`
+	WriteRevision        *int64 `json:"writeRevision,omitempty"`
+	CurrentWriteRevision *int64 `json:"currentWriteRevision,omitempty"`
+}
+
+func (e *WriteError) Error() string { return e.Message }
+
+func newWriteError(code, message, recordingID string, revision, current *int64) *WriteError {
+	return &WriteError{
+		Code: code, Message: message, RecordingID: recordingID,
+		WriteRevision: cloneInt64(revision), CurrentWriteRevision: cloneInt64(current),
+	}
+}
+
+func cloneInt64(value *int64) *int64 {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+// UnmarshalJSON 保留 writeRevision 的字段存在性；null/字符串/浮点不能退回 legacy。
+func (p *ResultWriteParams) UnmarshalJSON(data []byte) error {
+	type alias ResultWriteParams
+	var decoded alias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*p = ResultWriteParams(decoded)
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	if raw, ok := fields["writeRevision"]; ok {
+		p.writeRevisionPresent = true
+		var number json.Number
+		decoder := json.NewDecoder(bytes.NewReader(raw))
+		decoder.UseNumber()
+		var value any
+		if decoder.Decode(&value) == nil {
+			if parsed, ok := value.(json.Number); ok {
+				number = parsed
+				if floatValue, err := strconv.ParseFloat(number.String(), 64); err == nil &&
+					!math.IsNaN(floatValue) && !math.IsInf(floatValue, 0) &&
+					math.Trunc(floatValue) == floatValue && floatValue >= 1 &&
+					floatValue <= float64(maxSafeWriteRevision) {
+					revision := int64(floatValue)
+					p.WriteRevision = &revision
+					p.writeRevisionValid = true
+				}
+			}
+		}
+	}
+	if raw, ok := fields["recording"]; ok && string(raw) != "null" {
+		var recordingFields map[string]json.RawMessage
+		if json.Unmarshal(raw, &recordingFields) == nil {
+			if markerRaw, ok := recordingFields["markers"]; ok {
+				p.recordingMarkersPresent = true
+				p.recordingMarkersValid = validRawMarkers(markerRaw)
+			}
+			if durationRaw, ok := recordingFields["duration_sec"]; ok {
+				p.recordingDurationPresent = true
+				p.recordingDurationValid = validRawNonNegativeNumber(durationRaw)
+			}
+			_, p.recordingLocationPresent = recordingFields["location"]
+		}
+	}
+	return nil
+}
+
+func (p ResultWriteParams) hasWriteRevision() bool {
+	return p.writeRevisionPresent || p.WriteRevision != nil
+}
+
+// HasWriteRevision 返回 JSON 是否显式携带有序写入字段。
+func (p ResultWriteParams) HasWriteRevision() bool { return p.hasWriteRevision() }
+
+func (t *ResultTranscript) UnmarshalJSON(data []byte) error {
+	type alias ResultTranscript
+	var decoded alias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*t = ResultTranscript(decoded)
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	if raw, ok := fields["text"]; ok {
+		t.textPresent = rawJSONString(raw)
+	}
+	if raw, ok := fields["markdown"]; ok {
+		t.markdownPresent = rawJSONString(raw)
+	}
+	if raw, ok := fields["segments"]; ok {
+		t.segmentsPresent = true
+		t.segmentsValid = validRawTranscriptSegments(raw)
+	}
+	return nil
+}
+
+func (s *ResultSummary) UnmarshalJSON(data []byte) error {
+	type alias ResultSummary
+	var decoded alias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*s = ResultSummary(decoded)
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	if raw, ok := fields["markdown"]; ok {
+		s.markdownPresent = rawJSONString(raw)
+	}
+	if raw, ok := fields["structured"]; ok {
+		s.structuredPresent = true
+		trimmed := bytes.TrimSpace(raw)
+		s.structuredValid = len(trimmed) > 0 && !bytes.Equal(trimmed, []byte("null"))
+	}
+	return nil
+}
+
+func rawJSONString(raw json.RawMessage) bool {
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return false
+	}
+	var value string
+	return json.Unmarshal(raw, &value) == nil
+}
+
+func validRawNonNegativeNumber(raw json.RawMessage) bool {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if decoder.Decode(&value) != nil {
+		return false
+	}
+	number, ok := value.(json.Number)
+	if !ok {
+		return false
+	}
+	parsed, err := number.Float64()
+	return err == nil && !math.IsNaN(parsed) && !math.IsInf(parsed, 0) && parsed >= 0
+}
+
+func validRawMarkers(raw json.RawMessage) bool {
+	var markers []map[string]json.RawMessage
+	if json.Unmarshal(raw, &markers) != nil || markers == nil || len(markers) > 100 {
+		return false
+	}
+	for _, marker := range markers {
+		indexRaw, indexOK := marker["index"]
+		timestampRaw, timestampOK := marker["timestamp_ms"]
+		if !indexOK || !timestampOK || !validRawNonNegativeInteger(indexRaw) || !validRawNonNegativeNumber(timestampRaw) {
+			return false
+		}
+	}
+	return true
+}
+
+func validRawNonNegativeInteger(raw json.RawMessage) bool {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if decoder.Decode(&value) != nil {
+		return false
+	}
+	number, ok := value.(json.Number)
+	if !ok {
+		return false
+	}
+	parsed, err := number.Float64()
+	return err == nil && !math.IsNaN(parsed) && !math.IsInf(parsed, 0) && parsed >= 0 && math.Trunc(parsed) == parsed && parsed <= float64(maxSafeWriteRevision)
+}
+
+func validRawTranscriptSegments(raw json.RawMessage) bool {
+	var segments []map[string]json.RawMessage
+	if json.Unmarshal(raw, &segments) != nil || segments == nil {
+		return false
+	}
+	for _, segment := range segments {
+		textRaw, ok := segment["text"]
+		if !ok || !rawJSONString(textRaw) {
+			return false
+		}
+		for _, key := range []string{"startMs", "endMs"} {
+			if numberRaw, present := segment[key]; present && !validRawFiniteNumber(numberRaw) {
+				return false
+			}
+		}
+		if speakerRaw, present := segment["speakerId"]; present && !validRawInteger(speakerRaw) {
+			return false
+		}
+	}
+	return true
+}
+
+func validRawFiniteNumber(raw json.RawMessage) bool {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if decoder.Decode(&value) != nil {
+		return false
+	}
+	number, ok := value.(json.Number)
+	if !ok {
+		return false
+	}
+	parsed, err := number.Float64()
+	return err == nil && !math.IsNaN(parsed) && !math.IsInf(parsed, 0)
+}
+
+func validRawInteger(raw json.RawMessage) bool {
+	if !validRawFiniteNumber(raw) {
+		return false
+	}
+	var number json.Number
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	_ = decoder.Decode(&value)
+	number, _ = value.(json.Number)
+	parsed, _ := number.Float64()
+	return math.Trunc(parsed) == parsed && math.Abs(parsed) <= float64(maxSafeWriteRevision)
+}
+
+type orderedWriteMode string
+
+const (
+	orderedAudioOnly orderedWriteMode = "audio-only"
+	orderedFull      orderedWriteMode = "full"
+)
+
+type validatedOrderedWrite struct {
+	recordingID string
+	revision    int64
+	ossURL      string
+	metadata    Metadata
+	mode        orderedWriteMode
+	transcript  *ResultTranscript
+	summary     *ResultSummary
+	clientLabel string
+}
+
+type orderedArtifact struct {
+	key      string
+	relative string
+	staged   string
+	final    string
+}
+
+type preparedOrderedArtifacts struct {
+	artifacts  []orderedArtifact
+	transcript []TranscriptItem
+	summary    string
+	title      string
+}
+
+func handleOrderedRecordingResultWrite(params ResultWriteParams, storage *Storage, logger Logger, opts SyncOptions) (ResultWriteResult, error) {
+	request, err := validateOrderedWrite(params, opts.ClientLabel)
+	if err != nil {
+		return ResultWriteResult{}, err
+	}
+	apply, entry, err := storage.preflightOrderedWrite(request)
+	if err != nil {
+		return ResultWriteResult{}, err
+	}
+	prepared := preparedOrderedArtifacts{}
+	if apply && request.mode == orderedFull {
+		prepared, err = prepareOrderedArtifacts(request, storage)
+		if err != nil {
+			return ResultWriteResult{}, newWriteError("RESULT_APPLY_FAILED", err.Error(), request.recordingID, &request.revision, nil)
+		}
+	}
+	committed := false
+	if apply {
+		entry, committed, err = storage.commitOrderedWrite(request, prepared)
+		if err != nil {
+			storage.cleanupOrderedArtifacts(prepared.artifacts)
+			return ResultWriteResult{}, err
+		}
+		if !committed {
+			storage.cleanupOrderedArtifacts(prepared.artifacts)
+		}
+	}
+	entry, err = storage.reconcileOrderedAudio(request.recordingID, request.revision, request.ossURL)
+	if err != nil {
+		return ResultWriteResult{}, err
+	}
+	if entry == nil || entry.WriteRevision == nil || *entry.WriteRevision != request.revision {
+		var current *int64
+		if entry != nil {
+			current = entry.WriteRevision
+		}
+		return ResultWriteResult{}, newWriteError("STALE_WRITE", fmt.Sprintf("writeRevision %d was superseded", request.revision), request.recordingID, &request.revision, current)
+	}
+	if entry.AudioStatus == AudioStatusFailed {
+		return ResultWriteResult{}, newWriteError("AUDIO_DOWNLOAD_FAILED", firstNonEmpty(entry.LastError, "audio download failed"), request.recordingID, &request.revision, entry.WriteRevision)
+	}
+
+	if committed {
+		storage.cancelSupersededOrderedTask(request.recordingID, request.revision, request.ossURL)
+		emitResultStatusAtRevision(request.recordingID, &request.revision, storage, logger, opts.NotifyStatus, prepared.transcript, prepared.summary, prepared.title)
+	}
+	if entry.AudioStatus == AudioStatusPending || entry.AudioStatus == AudioStatusDownloading {
+		queueOrderedAudioDownload(request, storage, logger, opts)
+	}
+	current, _ := storage.FindByID(request.recordingID)
+	return orderedWriteResult(current), nil
+}
+
+func validateOrderedWrite(params ResultWriteParams, clientLabel string) (validatedOrderedWrite, error) {
+	recordingID := strings.TrimSpace(params.RecordingID)
+	if recordingID == "" || !isSafeRecordingID(recordingID) {
+		return validatedOrderedWrite{}, newWriteError("INVALID_PARAMS", "recordingId is required and must be a safe storage id", recordingID, nil, nil)
+	}
+	validRevision := params.WriteRevision != nil && (params.writeRevisionValid || !params.writeRevisionPresent)
+	if !validRevision || *params.WriteRevision < 1 || *params.WriteRevision > maxSafeWriteRevision {
+		return validatedOrderedWrite{}, newWriteError("INVALID_PARAMS", "writeRevision must be a safe integer greater than or equal to 1", recordingID, nil, nil)
+	}
+	revision := *params.WriteRevision
+	ossURL := strings.TrimSpace(params.OssURL)
+	if ossURL == "" {
+		return validatedOrderedWrite{}, newWriteError("INVALID_PARAMS", "ossUrl is required for ordered recording writes", recordingID, &revision, nil)
+	}
+	if params.Recording == nil {
+		return validatedOrderedWrite{}, newWriteError("INVALID_PARAMS", "recording metadata is required for ordered recording writes", recordingID, &revision, nil)
+	}
+	metadata := *params.Recording
+	metadata.Name = strings.TrimSpace(metadata.Name)
+	if metadata.Name == "" {
+		return validatedOrderedWrite{}, newWriteError("INVALID_PARAMS", "recording.name is required", recordingID, &revision, nil)
+	}
+	if strings.TrimSpace(metadata.OssAudioURL) != ossURL {
+		return validatedOrderedWrite{}, newWriteError("INVALID_PARAMS", "recording.oss_audio_url must equal ossUrl", recordingID, &revision, nil)
+	}
+	if params.writeRevisionPresent && (!params.recordingDurationPresent || !params.recordingDurationValid) {
+		return validatedOrderedWrite{}, newWriteError("INVALID_PARAMS", "recording.duration_sec must be a non-negative finite number", recordingID, &revision, nil)
+	}
+	if math.IsNaN(metadata.DurationSec) || math.IsInf(metadata.DurationSec, 0) || metadata.DurationSec < 0 {
+		return validatedOrderedWrite{}, newWriteError("INVALID_PARAMS", "recording.duration_sec must be a non-negative finite number", recordingID, &revision, nil)
+	}
+	metadata.DurationSec = normalizeDurationSeconds(metadata.DurationSec)
+	metadata.DurationDisplay = FormatDurationDisplay(metadata.DurationSec)
+	metadata.CreatedAt = strings.TrimSpace(metadata.CreatedAt)
+	if _, ok := ParseTime(metadata.CreatedAt); !ok {
+		return validatedOrderedWrite{}, newWriteError("INVALID_PARAMS", "recording.created_at must be a valid timestamp", recordingID, &revision, nil)
+	}
+	markersPresent := params.recordingMarkersPresent || (!params.writeRevisionPresent && metadata.Markers != nil)
+	if !markersPresent || (params.writeRevisionPresent && !params.recordingMarkersValid) || len(metadata.Markers) > 100 {
+		return validatedOrderedWrite{}, newWriteError("INVALID_PARAMS", "recording.markers must be an array with at most 100 items", recordingID, &revision, nil)
+	}
+	for index, marker := range metadata.Markers {
+		if marker.Index < 0 || math.IsNaN(marker.TimestampMS) || math.IsInf(marker.TimestampMS, 0) || marker.TimestampMS < 0 {
+			return validatedOrderedWrite{}, newWriteError("INVALID_PARAMS", fmt.Sprintf("recording.markers[%d] is invalid", index), recordingID, &revision, nil)
+		}
+	}
+	if (params.recordingLocationPresent && metadata.Location == nil) || (metadata.Location != nil && !validLocation(metadata.Location)) {
+		return validatedOrderedWrite{}, newWriteError("INVALID_PARAMS", "recording.location must contain finite latitude and longitude", recordingID, &revision, nil)
+	}
+	hasTranscript, hasSummary := params.Transcript != nil, params.Summary != nil
+	if hasTranscript != hasSummary {
+		return validatedOrderedWrite{}, newWriteError("INVALID_PARAMS", "ordered full results must provide both transcript and summary", recordingID, &revision, nil)
+	}
+	mode := orderedAudioOnly
+	if hasTranscript {
+		if !validOrderedTranscript(params.Transcript) {
+			return validatedOrderedWrite{}, newWriteError("INVALID_PARAMS", "transcript must contain an explicit text, markdown, or segments field", recordingID, &revision, nil)
+		}
+		if !validOrderedSummary(params.Summary) {
+			return validatedOrderedWrite{}, newWriteError("INVALID_PARAMS", "summary must contain an explicit markdown or non-null structured field", recordingID, &revision, nil)
+		}
+		mode = orderedFull
+	}
+	metadata.OssAudioURL = ossURL
+	metadata.Status = "syncing_openclaw"
+	request := validatedOrderedWrite{
+		recordingID: recordingID, revision: revision, ossURL: ossURL, metadata: metadata,
+		mode: mode, transcript: params.Transcript, summary: params.Summary,
+		clientLabel: firstNonEmpty(strings.TrimSpace(clientLabel), "default"),
+	}
+	return request, nil
+}
+
+func isSafeRecordingID(value string) bool {
+	return fsutil.IsSafeName(value)
+}
+
+func validLocation(value any) bool {
+	raw, ok := value.(map[string]any)
+	if !ok {
+		data, err := json.Marshal(value)
+		if err != nil || json.Unmarshal(data, &raw) != nil {
+			return false
+		}
+	}
+	latitude, latOK := numericValue(raw["latitude"])
+	longitude, lonOK := numericValue(raw["longitude"])
+	return latOK && lonOK && !math.IsNaN(latitude) && !math.IsInf(latitude, 0) && !math.IsNaN(longitude) && !math.IsInf(longitude, 0)
+}
+
+func numericValue(value any) (float64, bool) {
+	switch number := value.(type) {
+	case float64:
+		return number, true
+	case float32:
+		return float64(number), true
+	case int:
+		return float64(number), true
+	case int64:
+		return float64(number), true
+	case json.Number:
+		parsed, err := number.Float64()
+		return parsed, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func validOrderedTranscript(value *ResultTranscript) bool {
+	if value == nil {
+		return false
+	}
+	explicit := value.textPresent || value.markdownPresent || value.segmentsPresent
+	if !explicit {
+		explicit = value.Text != "" || value.Markdown != "" || value.Segments != nil
+	}
+	if !explicit {
+		return false
+	}
+	if value.segmentsPresent && !value.segmentsValid {
+		return false
+	}
+	for _, segment := range value.Segments {
+		if segment.StartMS != nil && (math.IsNaN(*segment.StartMS) || math.IsInf(*segment.StartMS, 0)) {
+			return false
+		}
+		if segment.EndMS != nil && (math.IsNaN(*segment.EndMS) || math.IsInf(*segment.EndMS, 0)) {
+			return false
+		}
+	}
+	return true
+}
+
+func validOrderedSummary(value *ResultSummary) bool {
+	if value == nil {
+		return false
+	}
+	if value.markdownPresent || value.Markdown != "" {
+		return true
+	}
+	if value.structuredPresent {
+		return value.structuredValid
+	}
+	trimmed := bytes.TrimSpace(value.Structured)
+	return len(trimmed) > 0 && !bytes.Equal(trimmed, []byte("null"))
+}
+
+func prepareOrderedArtifacts(request validatedOrderedWrite, storage *Storage) (preparedOrderedArtifacts, error) {
+	transcript := *request.transcript
+	summary := *request.summary
+	title := firstNonEmpty(strings.TrimSpace(transcript.Title), request.metadata.Name, request.recordingID)
+	segments := normalizeResultSegments(transcript.Segments)
+	textValue := firstNonEmpty(normalizeMultiline(transcript.Text), joinSegmentTexts(segments), normalizeMultiline(transcript.Markdown))
+	source := TranscriptSource{Provider: "app", Delivery: "result-write"}
+	if transcript.Source != nil {
+		source.Provider = firstNonEmpty(strings.TrimSpace(transcript.Source.Provider), "app")
+		source.TaskID = strings.TrimSpace(transcript.Source.TaskID)
+		source.RequestID = strings.TrimSpace(transcript.Source.RequestID)
+		source.Status = strings.TrimSpace(transcript.Source.Status)
+	}
+	doc := BuildTranscriptDocument(request.recordingID, source, title, strings.TrimSpace(transcript.Category), normalizeMultiline(transcript.Brief), textValue, segments, transcript)
+	if generated := strings.TrimSpace(transcript.GeneratedAt); generated != "" {
+		doc.GeneratedAt = generated
+	}
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return preparedOrderedArtifacts{}, err
+	}
+	data = append(data, '\n')
+	markdown := normalizeMultiline(transcript.Markdown)
+	if strings.TrimSpace(markdown) == "" {
+		markdown = buildResultTranscriptMarkdown(request.metadata, title, textValue, segments)
+	}
+	summaryMarkdown := normalizeMultiline(summary.Markdown)
+	if strings.TrimSpace(summaryMarkdown) == "" {
+		summaryMarkdown = buildStructuredSummaryMarkdown(summary.Structured)
+	}
+	attempt, err := randomAttemptID()
+	if err != nil {
+		return preparedOrderedArtifacts{}, err
+	}
+	base := fmt.Sprintf("%s.r%d.%s", request.recordingID, request.revision, attempt)
+	specs := []struct {
+		key, dir, name string
+		data           []byte
+	}{
+		{"transcriptDataFile", transcriptDataDirName, base + ".json", data},
+		{"transcriptFile", transcriptsDirName, base + ".transcript.md", []byte(ensureTrailingNewline(markdown))},
+		{"summaryFile", summariesDirName, base + ".summary.md", []byte(ensureTrailingNewline(summaryMarkdown))},
+	}
+	prepared := preparedOrderedArtifacts{title: title, transcript: ExtractSourceTextListFromDocument(doc), summary: strings.TrimSpace(summaryMarkdown)}
+	for _, spec := range specs {
+		final := filepath.Join(storage.dir, spec.dir, spec.name)
+		staged := final + ".staged"
+		artifact := orderedArtifact{key: spec.key, relative: filepath.ToSlash(filepath.Join(spec.dir, spec.name)), staged: staged, final: final}
+		prepared.artifacts = append(prepared.artifacts, artifact)
+		file, openErr := os.OpenFile(staged, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if openErr != nil {
+			storage.cleanupOrderedArtifacts(prepared.artifacts)
+			return preparedOrderedArtifacts{}, openErr
+		}
+		_, writeErr := file.Write(spec.data)
+		closeErr := file.Close()
+		if writeErr != nil || closeErr != nil {
+			storage.cleanupOrderedArtifacts(prepared.artifacts)
+			if writeErr != nil {
+				return preparedOrderedArtifacts{}, writeErr
+			}
+			return preparedOrderedArtifacts{}, closeErr
+		}
+	}
+	return prepared, nil
+}
+
+func randomAttemptID() (string, error) {
+	value := make([]byte, 16)
+	if _, err := rand.Read(value); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(value), nil
+}
+
+func (s *Storage) preflightOrderedWrite(request validatedOrderedWrite) (bool, *Entry, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	idx := s.findIndexLocked(request.recordingID)
+	if idx < 0 {
+		return true, nil, nil
+	}
+	entry := s.index.Recordings[idx]
+	if entry.WriteRevision != nil && *entry.WriteRevision > request.revision {
+		return false, nil, newWriteError("STALE_WRITE", fmt.Sprintf("writeRevision %d is older than current revision %d", request.revision, *entry.WriteRevision), request.recordingID, &request.revision, entry.WriteRevision)
+	}
+	if entry.WriteRevision != nil && *entry.WriteRevision == request.revision {
+		if request.mode == orderedAudioOnly || s.hasCompleteOrderedTextLocked(entry) {
+			return false, &entry, nil
+		}
+	}
+	return true, &entry, nil
+}
+
+func (s *Storage) commitOrderedWrite(request validatedOrderedWrite, prepared preparedOrderedArtifacts) (*Entry, bool, error) {
+	s.mu.Lock()
+	idx := s.findIndexLocked(request.recordingID)
+	var current *Entry
+	if idx >= 0 {
+		copy := s.index.Recordings[idx]
+		current = &copy
+	}
+	if current != nil && current.WriteRevision != nil && *current.WriteRevision > request.revision {
+		s.mu.Unlock()
+		return nil, false, newWriteError("STALE_WRITE", fmt.Sprintf("writeRevision %d is older than current revision %d", request.revision, *current.WriteRevision), request.recordingID, &request.revision, current.WriteRevision)
+	}
+	if current != nil && current.WriteRevision != nil && *current.WriteRevision == request.revision {
+		if request.mode == orderedAudioOnly || s.hasCompleteOrderedTextLocked(*current) {
+			s.mu.Unlock()
+			copy := *current
+			return &copy, false, nil
+		}
+	}
+	repairing := current != nil && current.WriteRevision != nil && *current.WriteRevision == request.revision
+	audioReusable := current != nil && s.hasReusableAudioLocked(*current)
+	nextIndex, err := cloneRecordingIndex(s.index)
+	if err != nil {
+		s.mu.Unlock()
+		return nil, false, newWriteError("RESULT_APPLY_FAILED", err.Error(), request.recordingID, &request.revision, nil)
+	}
+	now := nowISO()
+	next := Entry{ID: request.recordingID, IngestedAt: now}
+	if current != nil {
+		next = *current
+	}
+	if !repairing {
+		next.Metadata = request.metadata
+		next.ClientLabel = request.clientLabel
+		next.WriteRevision = cloneInt64(&request.revision)
+		next.LastError = ""
+	}
+	if audioReusable {
+		next.AudioStatus = AudioStatusDownloaded
+		if info, statErr := os.Stat(filepath.Join(s.dir, next.AudioFile)); statErr == nil {
+			next.Metadata.FileSizeDisplay = FormatShortFileSize(info.Size())
+		}
+	} else if !repairing {
+		next.AudioFile = ""
+		next.AudioSourceURL = ""
+		next.Metadata.FileSizeDisplay = ""
+		next.AudioStatus = AudioStatusPending
+	} else if next.AudioStatus != AudioStatusFailed {
+		next.AudioStatus = AudioStatusPending
+	}
+	if request.mode == orderedFull {
+		next.Status = StatusTranscribed
+		next.Metadata.Status = next.Status
+	} else if !preserveAudioOnlyBusinessStatus(next.Status) {
+		if audioReusable {
+			next.Status = StatusSynced
+		} else {
+			next.Status = "syncing_openclaw"
+		}
+		next.Metadata.Status = next.Status
+	}
+	next.UpdatedAt = now
+
+	moved := make([]orderedArtifact, 0, len(prepared.artifacts))
+	for _, artifact := range prepared.artifacts {
+		if err := os.Rename(artifact.staged, artifact.final); err != nil {
+			for _, item := range moved {
+				_ = os.Remove(item.final)
+			}
+			s.mu.Unlock()
+			return nil, false, newWriteError("RESULT_APPLY_FAILED", err.Error(), request.recordingID, &request.revision, nil)
+		}
+		_ = os.Chmod(artifact.final, 0o600)
+		moved = append(moved, artifact)
+		switch artifact.key {
+		case "transcriptDataFile":
+			next.TranscriptDataFile = artifact.relative
+		case "transcriptFile":
+			next.TranscriptFile = artifact.relative
+		case "summaryFile":
+			next.SummaryFile = artifact.relative
+		}
+	}
+	if request.mode == orderedFull {
+		next.Title = firstNonEmpty(strings.TrimSpace(prepared.title), request.recordingID)
+	}
+	oldText := []string{}
+	if current != nil && request.mode == orderedFull {
+		oldText = []string{current.TranscriptDataFile, current.TranscriptFile, current.SummaryFile}
+	}
+	if idx >= 0 {
+		nextIndex.Recordings[idx] = next
+	} else {
+		nextIndex.Recordings = append(nextIndex.Recordings, next)
+	}
+	if err := fsWriteIndex(s.indexPath, nextIndex); err != nil {
+		for _, artifact := range moved {
+			_ = os.Remove(artifact.final)
+		}
+		s.mu.Unlock()
+		return nil, false, newWriteError("RESULT_APPLY_FAILED", err.Error(), request.recordingID, &request.revision, nil)
+	}
+	s.index = nextIndex
+	s.mu.Unlock()
+	s.removeUnreferencedOrderedPaths(oldText)
+	return &next, true, nil
+}
+
+func cloneRecordingIndex(input indexWrapper) (indexWrapper, error) {
+	data, err := json.Marshal(input)
+	if err != nil {
+		return indexWrapper{}, err
+	}
+	var output indexWrapper
+	err = json.Unmarshal(data, &output)
+	return output, err
+}
+
+func fsWriteIndex(path string, index indexWrapper) error {
+	return writeJSONAtomic(path, index)
+}
+
+func writeJSONAtomic(path string, value any) error {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return writeFileAtomic(path, data)
+}
+
+func writeFileAtomic(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	file, err := os.CreateTemp(dir, ".ordered-index-*.tmp")
+	if err != nil {
+		return err
+	}
+	temporary := file.Name()
+	committed := false
+	defer func() {
+		_ = file.Close()
+		if !committed {
+			_ = os.Remove(temporary)
+		}
+	}()
+	_ = file.Chmod(0o600)
+	if _, err := file.Write(data); err != nil {
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(temporary, path); err != nil {
+		return err
+	}
+	committed = true
+	return os.Chmod(path, 0o600)
+}
+
+func (s *Storage) hasCompleteOrderedTextLocked(entry Entry) bool {
+	for _, relative := range []string{entry.TranscriptDataFile, entry.TranscriptFile, entry.SummaryFile} {
+		if !s.relativeNonEmptyFileLocked(relative) {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *Storage) hasReusableAudioLocked(entry Entry) bool {
+	return s.relativeNonEmptyFileLocked(entry.AudioFile)
+}
+
+func (s *Storage) relativeNonEmptyFileLocked(relative string) bool {
+	if relative == "" {
+		return false
+	}
+	info, err := os.Stat(filepath.Join(s.dir, relative))
+	return err == nil && info.Mode().IsRegular() && info.Size() > 0
+}
+
+func preserveAudioOnlyBusinessStatus(status string) bool {
+	switch status {
+	case StatusSynced, StatusTranscribing, StatusTranscribeFailed, StatusTranscribed:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *Storage) cleanupOrderedArtifacts(artifacts []orderedArtifact) {
+	for _, artifact := range artifacts {
+		_ = os.Remove(artifact.staged)
+		_ = os.Remove(artifact.final)
+	}
+}
+
+func (s *Storage) removeUnreferencedOrderedPaths(paths []string) {
+	s.mu.Lock()
+	referenced := map[string]bool{}
+	for _, entry := range s.index.Recordings {
+		for _, relative := range []string{entry.AudioFile, entry.SrtFile, entry.TranscriptDataFile, entry.TranscriptFile, entry.SummaryFile} {
+			if relative != "" {
+				referenced[relative] = true
+			}
+		}
+	}
+	for _, relative := range paths {
+		if relative != "" && !referenced[relative] {
+			s.removeRelativeLocked(relative)
+		}
+	}
+	s.mu.Unlock()
+}
+
+func (s *Storage) reconcileOrderedAudio(recordingID string, revision int64, ossURL string) (*Entry, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	idx := s.findIndexLocked(recordingID)
+	if idx < 0 {
+		return nil, nil
+	}
+	current := s.index.Recordings[idx]
+	if current.WriteRevision == nil || *current.WriteRevision != revision || strings.TrimSpace(current.Metadata.OssAudioURL) != strings.TrimSpace(ossURL) {
+		return &current, nil
+	}
+	if current.AudioStatus != AudioStatusDownloaded || s.hasReusableAudioLocked(current) {
+		return &current, nil
+	}
+	nextIndex, err := cloneRecordingIndex(s.index)
+	if err != nil {
+		return nil, err
+	}
+	next := nextIndex.Recordings[idx]
+	previous := next.AudioFile
+	next.AudioFile = ""
+	next.AudioSourceURL = ""
+	next.Metadata.FileSizeDisplay = ""
+	next.AudioStatus = AudioStatusPending
+	next.UpdatedAt = nowISO()
+	nextIndex.Recordings[idx] = next
+	if err := fsWriteIndex(s.indexPath, nextIndex); err != nil {
+		return nil, err
+	}
+	s.index = nextIndex
+	if previous != "" {
+		_ = os.Remove(filepath.Join(s.dir, previous))
+	}
+	return &next, nil
+}
+
+func orderedWriteResult(entry Entry) ResultWriteResult {
+	return ResultWriteResult{
+		OK: true, RecordingID: entry.ID, WriteRevision: cloneInt64(entry.WriteRevision),
+		TransferStatus: entry.Status, AudioStatus: entry.AudioStatus,
+		AudioFile: entry.AudioFile,
+		Stored:    ResultWriteStored{TranscriptDataFile: entry.TranscriptDataFile, TranscriptFile: entry.TranscriptFile, SummaryFile: entry.SummaryFile},
+	}
+}

--- a/internal/recording/ordered_writer_test.go
+++ b/internal/recording/ordered_writer_test.go
@@ -1,0 +1,136 @@
+package recording
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func revisionPtr(value int64) *int64 { return &value }
+
+func orderedMetadata(url string) *Metadata {
+	return &Metadata{
+		Name:        "有序录音",
+		DurationSec: 12,
+		CreatedAt:   "2026-08-27T11:00:00+08:00",
+		OssAudioURL: url,
+		Markers:     []Marker{},
+	}
+}
+
+func waitForAudioStatus(t *testing.T, storage *Storage, recordingID, status string) Entry {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		entry, ok := storage.FindByID(recordingID)
+		if ok && entry.AudioStatus == status {
+			return entry
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	entry, _ := storage.FindByID(recordingID)
+	t.Fatalf("audio status = %q, want %q", entry.AudioStatus, status)
+	return Entry{}
+}
+
+func TestOrderedAudioOnlyThenFullResult(t *testing.T) {
+	storage := newResultStorage(t)
+	audio := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("audio-bytes"))
+	}))
+	defer audio.Close()
+
+	result, err := HandleRecordingResultWrite(ResultWriteParams{
+		RecordingID: "ordered-1", WriteRevision: revisionPtr(1), OssURL: audio.URL + "/a.m4a",
+		Recording: orderedMetadata(audio.URL + "/a.m4a"),
+	}, storage, testLogger{t}, SyncOptions{DownloadOptions: DownloadOptions{MaxRetries: 1}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.WriteRevision == nil || *result.WriteRevision != 1 || result.TransferStatus != "syncing_openclaw" {
+		t.Fatalf("unexpected audio-only result: %+v", result)
+	}
+	entry := waitForAudioStatus(t, storage, "ordered-1", AudioStatusDownloaded)
+	if entry.Status != StatusSynced || entry.AudioFile == "" {
+		t.Fatalf("unexpected downloaded entry: %+v", entry)
+	}
+
+	result, err = HandleRecordingResultWrite(ResultWriteParams{
+		RecordingID: "ordered-1", WriteRevision: revisionPtr(2), OssURL: audio.URL + "/changed-url.m4a",
+		Recording:  orderedMetadata(audio.URL + "/changed-url.m4a"),
+		Transcript: &ResultTranscript{Text: "正文", Title: "新标题"},
+		Summary:    &ResultSummary{Markdown: "总结"},
+	}, storage, testLogger{t}, SyncOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.TransferStatus != StatusTranscribed || result.Stored.TranscriptDataFile == "" || result.Stored.SummaryFile == "" {
+		t.Fatalf("unexpected full result: %+v", result)
+	}
+	updated, _ := storage.FindByID("ordered-1")
+	if updated.AudioFile != entry.AudioFile || updated.AudioStatus != AudioStatusDownloaded {
+		t.Fatalf("existing immutable audio was not reused: before=%+v after=%+v", entry, updated)
+	}
+	for _, relative := range []string{updated.TranscriptDataFile, updated.TranscriptFile, updated.SummaryFile} {
+		info, statErr := os.Stat(filepath.Join(storage.dir, relative))
+		if statErr != nil || !info.Mode().IsRegular() {
+			t.Fatalf("missing ordered artifact %q: %v", relative, statErr)
+		}
+	}
+}
+
+func TestOrderedSameRevisionIsIdempotent(t *testing.T) {
+	storage := newResultStorage(t)
+	audio := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("audio")) }))
+	defer audio.Close()
+	url := audio.URL + "/audio.m4a"
+	params := ResultWriteParams{
+		RecordingID: "ordered-2", WriteRevision: revisionPtr(4), OssURL: url,
+		Recording:  orderedMetadata(url),
+		Transcript: &ResultTranscript{Text: "固定正文"},
+		Summary:    &ResultSummary{Markdown: "固定总结"},
+	}
+	first, err := HandleRecordingResultWrite(params, storage, testLogger{t}, SyncOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := HandleRecordingResultWrite(params, storage, testLogger{t}, SyncOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Stored != second.Stored {
+		t.Fatalf("idempotent retry created new artifacts: first=%+v second=%+v", first.Stored, second.Stored)
+	}
+}
+
+func TestOrderedRejectsStaleAndLegacyMixing(t *testing.T) {
+	storage := newResultStorage(t)
+	audio := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("audio")) }))
+	defer audio.Close()
+	url := audio.URL + "/audio.m4a"
+	_, err := HandleRecordingResultWrite(ResultWriteParams{
+		RecordingID: "ordered-3", WriteRevision: revisionPtr(2), OssURL: url,
+		Recording: orderedMetadata(url),
+	}, storage, testLogger{t}, SyncOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = HandleRecordingResultWrite(ResultWriteParams{
+		RecordingID: "ordered-3", WriteRevision: revisionPtr(1), OssURL: url,
+		Recording: orderedMetadata(url),
+	}, storage, testLogger{t}, SyncOptions{})
+	var writeErr *WriteError
+	if !errors.As(err, &writeErr) || writeErr.Code != "STALE_WRITE" {
+		t.Fatalf("stale error = %#v", err)
+	}
+	_, err = HandleRecordingResultWrite(ResultWriteParams{
+		RecordingID: "ordered-3", Transcript: &ResultTranscript{Text: "legacy"},
+	}, storage, testLogger{t}, SyncOptions{})
+	if !errors.As(err, &writeErr) || writeErr.Code != "REVISION_REQUIRED" {
+		t.Fatalf("legacy mixing error = %#v", err)
+	}
+}

--- a/internal/recording/result_writer.go
+++ b/internal/recording/result_writer.go
@@ -30,34 +30,49 @@ type ResultTranscriptSegment struct {
 
 // ResultTranscript 是 result.write 写入的转写结果。
 type ResultTranscript struct {
-	GeneratedAt string                    `json:"generatedAt,omitempty"`
-	Source      *ResultTranscriptSource   `json:"source,omitempty"`
-	Title       string                    `json:"title,omitempty"`
-	Category    string                    `json:"category,omitempty"`
-	Brief       string                    `json:"brief,omitempty"`
-	Text        string                    `json:"text,omitempty"`
-	Segments    []ResultTranscriptSegment `json:"segments,omitempty"`
-	Markdown    string                    `json:"markdown,omitempty"`
+	GeneratedAt     string                    `json:"generatedAt,omitempty"`
+	Source          *ResultTranscriptSource   `json:"source,omitempty"`
+	Title           string                    `json:"title,omitempty"`
+	Category        string                    `json:"category,omitempty"`
+	Brief           string                    `json:"brief,omitempty"`
+	Text            string                    `json:"text,omitempty"`
+	Segments        []ResultTranscriptSegment `json:"segments,omitempty"`
+	Markdown        string                    `json:"markdown,omitempty"`
+	textPresent     bool
+	markdownPresent bool
+	segmentsPresent bool
+	segmentsValid   bool
 }
 
 // ResultSummary 是 result.write 写入的总结结果。
 type ResultSummary struct {
-	GeneratedAt string          `json:"generatedAt,omitempty"`
-	Format      string          `json:"format,omitempty"`
-	Markdown    string          `json:"markdown,omitempty"`
-	Structured  json.RawMessage `json:"structured,omitempty"`
+	GeneratedAt       string          `json:"generatedAt,omitempty"`
+	Format            string          `json:"format,omitempty"`
+	Markdown          string          `json:"markdown,omitempty"`
+	Structured        json.RawMessage `json:"structured,omitempty"`
+	markdownPresent   bool
+	structuredPresent bool
+	structuredValid   bool
 }
 
 // ResultWriteParams 是 recordings.result.write 的入参。
 type ResultWriteParams struct {
-	RecordingID    string            `json:"recordingId"`
-	OssURL         string            `json:"ossUrl,omitempty"`
-	DurationMillis *float64          `json:"durationMillis,omitempty"`
-	Recording      *Metadata         `json:"recording,omitempty"`
-	CreatedAt      string            `json:"createdAt,omitempty"`
-	CreatedAtSnake string            `json:"created_at,omitempty"`
-	Transcript     *ResultTranscript `json:"transcript,omitempty"`
-	Summary        *ResultSummary    `json:"summary,omitempty"`
+	RecordingID              string            `json:"recordingId"`
+	WriteRevision            *int64            `json:"-"`
+	OssURL                   string            `json:"ossUrl,omitempty"`
+	DurationMillis           *float64          `json:"durationMillis,omitempty"`
+	Recording                *Metadata         `json:"recording,omitempty"`
+	CreatedAt                string            `json:"createdAt,omitempty"`
+	CreatedAtSnake           string            `json:"created_at,omitempty"`
+	Transcript               *ResultTranscript `json:"transcript,omitempty"`
+	Summary                  *ResultSummary    `json:"summary,omitempty"`
+	writeRevisionPresent     bool
+	writeRevisionValid       bool
+	recordingMarkersPresent  bool
+	recordingMarkersValid    bool
+	recordingDurationPresent bool
+	recordingDurationValid   bool
+	recordingLocationPresent bool
 }
 
 // ResultWriteStored 记录 result.write 落盘的相对路径。
@@ -71,8 +86,10 @@ type ResultWriteStored struct {
 type ResultWriteResult struct {
 	OK             bool              `json:"ok"`
 	RecordingID    string            `json:"recordingId"`
+	WriteRevision  *int64            `json:"writeRevision,omitempty"`
 	TransferStatus string            `json:"transfer_status"`
 	AudioStatus    string            `json:"audio_status,omitempty"`
+	AudioFile      string            `json:"audioFile,omitempty"`
 	Stored         ResultWriteStored `json:"stored"`
 }
 
@@ -81,6 +98,9 @@ type ResultWriteResult struct {
 // 找不到录音时按占位元数据 upsert 新建；
 // 可选 ossUrl 时在后台下载并覆盖本地音频。不触发插件侧 ASR。
 func HandleRecordingResultWrite(params ResultWriteParams, storage *Storage, logger Logger, opts SyncOptions) (ResultWriteResult, error) {
+	if params.hasWriteRevision() {
+		return handleOrderedRecordingResultWrite(params, storage, logger, opts)
+	}
 	recordingID := strings.TrimSpace(params.RecordingID)
 	if recordingID == "" {
 		return ResultWriteResult{}, errors.New("recordingId is required")
@@ -88,6 +108,11 @@ func HandleRecordingResultWrite(params ResultWriteParams, storage *Storage, logg
 	// 兜底（daemon 入口已校验）：recordingID 会拼进落盘文件名。
 	if !fsutil.IsSafeName(recordingID) {
 		return ResultWriteResult{}, errors.New("recordingId is invalid")
+	}
+	if entry, ok := storage.FindByID(recordingID); ok && entry.WriteRevision != nil {
+		return ResultWriteResult{}, newWriteError("REVISION_REQUIRED",
+			fmt.Sprintf("writeRevision is required after recording %s entered the ordered write protocol", recordingID),
+			recordingID, nil, entry.WriteRevision)
 	}
 	if params.Transcript == nil && params.Summary == nil {
 		return ResultWriteResult{}, errors.New("transcript or summary is required")
@@ -429,6 +454,15 @@ func RecoverMissingResultAudio(storage *Storage, logger Logger, opts SyncOptions
 			if ossURL == "" {
 				continue
 			}
+			if entry.WriteRevision != nil {
+				logger.Info(fmt.Sprintf("[recording-recovery] 补偿缺失音频: %s, writeRevision=%d", entry.ID, *entry.WriteRevision))
+				queueOrderedAudioDownload(validatedOrderedWrite{
+					recordingID: entry.ID,
+					revision:    *entry.WriteRevision,
+					ossURL:      ossURL,
+				}, storage, logger, opts)
+				continue
+			}
 			if err := storage.SetResultAudioPending(entry.ID, ossURL); err != nil {
 				logger.Error("[recording-recovery] 音频补偿状态写入失败: " + entry.ID + ", " + err.Error())
 				continue
@@ -441,20 +475,28 @@ func RecoverMissingResultAudio(storage *Storage, logger Logger, opts SyncOptions
 }
 
 func emitResultDownloadStatus(recordingID string, storage *Storage, logger Logger, notify func(StatusEvent)) {
+	emitResultDownloadStatusAtRevision(recordingID, nil, storage, logger, notify)
+}
+
+func emitResultDownloadStatusAtRevision(recordingID string, expectedRevision *int64, storage *Storage, logger Logger, notify func(StatusEvent)) {
 	entry, ok := storage.FindByID(recordingID)
-	if !ok {
+	if !ok || (expectedRevision != nil && !sameWriteRevision(entry.WriteRevision, expectedRevision)) {
 		return
 	}
 	title := firstNonEmpty(entry.Title, entry.Metadata.Name, recordingID)
-	emitResultStatus(recordingID, storage, logger, notify, nil, readSummaryFile(storage, recordingID), title)
+	emitResultStatusAtRevision(recordingID, expectedRevision, storage, logger, notify, nil, readSummaryFile(storage, recordingID), title)
 }
 
 func emitResultStatus(recordingID string, storage *Storage, logger Logger, notify func(StatusEvent), transcript []TranscriptItem, summary, title string) {
+	emitResultStatusAtRevision(recordingID, nil, storage, logger, notify, transcript, summary, title)
+}
+
+func emitResultStatusAtRevision(recordingID string, expectedRevision *int64, storage *Storage, logger Logger, notify func(StatusEvent), transcript []TranscriptItem, summary, title string) {
 	if notify == nil {
 		return
 	}
 	entry, ok := storage.FindByID(recordingID)
-	if !ok {
+	if !ok || (expectedRevision != nil && !sameWriteRevision(entry.WriteRevision, expectedRevision)) {
 		return
 	}
 	if title == "" {
@@ -462,6 +504,7 @@ func emitResultStatus(recordingID string, storage *Storage, logger Logger, notif
 	}
 	event := StatusEvent{
 		RecordingID:        entry.ID,
+		WriteRevision:      cloneInt64(entry.WriteRevision),
 		TransferStatus:     entry.Status,
 		AudioStatus:        entry.AudioStatus,
 		AudioFile:          entry.AudioFile,

--- a/internal/recording/result_writer_test.go
+++ b/internal/recording/result_writer_test.go
@@ -19,6 +19,7 @@ func newResultStorage(t *testing.T) *Storage {
 	if err := storage.Init(); err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { _ = storage.Close() })
 	return storage
 }
 

--- a/internal/recording/store.go
+++ b/internal/recording/store.go
@@ -55,6 +55,7 @@ type Metadata struct {
 // Entry 是一条录音索引项。
 type Entry struct {
 	ID                 string   `json:"id"`
+	WriteRevision      *int64   `json:"writeRevision,omitempty"`
 	ClientLabel        string   `json:"clientLabel,omitempty"`
 	Metadata           Metadata `json:"metadata"`
 	Status             string   `json:"status"`
@@ -87,6 +88,16 @@ type Storage struct {
 	mu                sync.Mutex
 	index             indexWrapper
 	audioLocks        map[string]*sync.Mutex
+	orderedTasksMu    sync.Mutex
+	orderedAudioTasks map[string]*orderedAudioTask
+	orderedTasksWG    sync.WaitGroup
+	orderedClosed     bool
+}
+
+type orderedAudioTask struct {
+	writeRevision int64
+	ossURL        string
+	cancel        func()
 }
 
 // NewStorage 构造录音存储；dir 为 recordings 目录。
@@ -101,6 +112,7 @@ func NewStorage(dir string, logger Logger) *Storage {
 		logger:            logger,
 		index:             indexWrapper{Recordings: []Entry{}},
 		audioLocks:        map[string]*sync.Mutex{},
+		orderedAudioTasks: map[string]*orderedAudioTask{},
 	}
 }
 
@@ -112,12 +124,23 @@ func (s *Storage) Init() error {
 		}
 	}
 	s.loadIndex()
+	s.cleanupUnreferencedOrderedArtifacts()
 	s.logger.Info("录音存储已初始化: " + s.dir)
 	return nil
 }
 
-// Close 当前无需额外清理。
-func (s *Storage) Close() error { return nil }
+// Close 取消仍在执行的有序音频任务。
+func (s *Storage) Close() error {
+	s.orderedTasksMu.Lock()
+	s.orderedClosed = true
+	for _, task := range s.orderedAudioTasks {
+		task.cancel()
+	}
+	s.orderedAudioTasks = map[string]*orderedAudioTask{}
+	s.orderedTasksMu.Unlock()
+	s.orderedTasksWG.Wait()
+	return nil
+}
 
 func (s *Storage) loadIndex() {
 	var wrapper indexWrapper
@@ -146,14 +169,16 @@ func (s *Storage) loadIndex() {
 			wrapper.Recordings[i].UpdatedAt = now
 			needsRewrite = true
 		case "syncing_openclaw", "sync_failed":
-			// 旧版 recordings.sync 遗留的中间态，sync 已移除，归一到 synced。
-			wrapper.Recordings[i].Status = StatusSynced
-			wrapper.Recordings[i].UpdatedAt = now
-			needsRewrite = true
+			if entry.WriteRevision == nil {
+				// 旧版 recordings.sync 遗留的中间态，sync 已移除，归一到 synced。
+				wrapper.Recordings[i].Status = StatusSynced
+				wrapper.Recordings[i].UpdatedAt = now
+				needsRewrite = true
+			}
 		}
 		if entry.AudioFile != "" {
 			audioPath := filepath.Join(s.dir, entry.AudioFile)
-			if info, err := os.Stat(audioPath); err == nil && !info.IsDir() {
+			if info, err := os.Stat(audioPath); err == nil && info.Mode().IsRegular() && (entry.WriteRevision == nil || info.Size() > 0) {
 				display := FormatShortFileSize(info.Size())
 				if entry.Metadata.FileSizeDisplay != display {
 					entry.Metadata.FileSizeDisplay = display
@@ -183,6 +208,11 @@ func (s *Storage) loadIndex() {
 		} else if strings.TrimSpace(entry.Metadata.OssAudioURL) != "" && entry.AudioStatus == "" {
 			// 兼容旧索引：历史版本会把下载错误清掉，只留下空 audioFile。
 			entry.AudioStatus = AudioStatusPending
+			needsRewrite = true
+		}
+		if entry.WriteRevision != nil && entry.AudioStatus == AudioStatusDownloading {
+			entry.AudioStatus = AudioStatusPending
+			entry.UpdatedAt = now
 			needsRewrite = true
 		}
 	}
@@ -410,6 +440,9 @@ func (s *Storage) MarkResultWritten(recordingID string) (Entry, error) {
 		return Entry{}, os.ErrNotExist
 	}
 	entry := &s.index.Recordings[idx]
+	if entry.WriteRevision != nil {
+		return Entry{}, newWriteError("REVISION_REQUIRED", "writeRevision is required for this recording", recordingID, nil, entry.WriteRevision)
+	}
 	entry.Status = StatusTranscribed
 	if entry.AudioStatus != AudioStatusFailed {
 		entry.LastError = ""
@@ -444,23 +477,34 @@ func (s *Storage) SetAudioFile(recordingID, filename string) error {
 // SetResultAudioPending 持久化 result.write 携带的最新 OSS URL，并把本地音频
 // 标记为待下载。即使 daemon 在后台下载前退出，下一次启动也能从索引恢复任务。
 func (s *Storage) SetResultAudioPending(recordingID, ossURL string) error {
-	return s.updateEntry(recordingID, func(entry *Entry) {
-		nextURL := strings.TrimSpace(ossURL)
-		entry.Metadata.OssAudioURL = nextURL
-		if strings.TrimSpace(entry.AudioSourceURL) == nextURL && entry.AudioFile != "" {
-			if info, err := os.Stat(filepath.Join(s.dir, entry.AudioFile)); err == nil && !info.IsDir() {
-				entry.AudioStatus = AudioStatusDownloaded
-				entry.Metadata.FileSizeDisplay = FormatShortFileSize(info.Size())
-				entry.LastError = ""
-				return
-			}
-		}
-		entry.AudioStatus = AudioStatusPending
-		if strings.HasPrefix(entry.LastError, "音频下载失败:") ||
-			entry.LastError == "本地音频文件缺失，等待重新下载" {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	idx := s.findIndexLocked(recordingID)
+	if idx < 0 {
+		return os.ErrNotExist
+	}
+	entry := &s.index.Recordings[idx]
+	if entry.WriteRevision != nil {
+		return nil
+	}
+	nextURL := strings.TrimSpace(ossURL)
+	entry.Metadata.OssAudioURL = nextURL
+	if strings.TrimSpace(entry.AudioSourceURL) == nextURL && entry.AudioFile != "" {
+		if info, err := os.Stat(filepath.Join(s.dir, entry.AudioFile)); err == nil && !info.IsDir() {
+			entry.AudioStatus = AudioStatusDownloaded
+			entry.Metadata.FileSizeDisplay = FormatShortFileSize(info.Size())
 			entry.LastError = ""
+			entry.UpdatedAt = nowISO()
+			return s.saveIndexLocked()
 		}
-	})
+	}
+	entry.AudioStatus = AudioStatusPending
+	if strings.HasPrefix(entry.LastError, "音频下载失败:") ||
+		entry.LastError == "本地音频文件缺失，等待重新下载" {
+		entry.LastError = ""
+	}
+	entry.UpdatedAt = nowISO()
+	return s.saveIndexLocked()
 }
 
 // SetResultAudioDownloading 标记当前 OSS URL 正在下载。URL 已被更新时忽略旧任务，
@@ -473,6 +517,9 @@ func (s *Storage) SetResultAudioDownloading(recordingID, ossURL string) (bool, e
 		return false, os.ErrNotExist
 	}
 	entry := &s.index.Recordings[idx]
+	if entry.WriteRevision != nil {
+		return false, nil
+	}
 	if strings.TrimSpace(entry.Metadata.OssAudioURL) != strings.TrimSpace(ossURL) {
 		return false, nil
 	}
@@ -498,6 +545,9 @@ func (s *Storage) SetResultAudioFailed(recordingID, ossURL, message string) (boo
 		return false, os.ErrNotExist
 	}
 	entry := &s.index.Recordings[idx]
+	if entry.WriteRevision != nil {
+		return false, nil
+	}
 	if strings.TrimSpace(entry.Metadata.OssAudioURL) != strings.TrimSpace(ossURL) {
 		return false, nil
 	}
@@ -520,6 +570,9 @@ func (s *Storage) CommitResultAudioDownloaded(recordingID, ossURL, stagedPath, f
 		return false, os.ErrNotExist
 	}
 	entry := &s.index.Recordings[idx]
+	if entry.WriteRevision != nil {
+		return false, nil
+	}
 	if strings.TrimSpace(entry.Metadata.OssAudioURL) != strings.TrimSpace(ossURL) {
 		return false, nil
 	}
@@ -567,7 +620,13 @@ func (s *Storage) ListMissingAudio() []Entry {
 		missing := entry.AudioFile == ""
 		if !missing {
 			info, err := os.Stat(filepath.Join(s.dir, entry.AudioFile))
-			missing = err != nil || info.IsDir()
+			missing = err != nil || !info.Mode().IsRegular() || (entry.WriteRevision != nil && info.Size() <= 0)
+		}
+		if entry.WriteRevision != nil {
+			if (entry.AudioStatus == AudioStatusPending || entry.AudioStatus == AudioStatusDownloading) && missing {
+				out = append(out, entry)
+			}
+			continue
 		}
 		sourceOutdated := strings.TrimSpace(entry.AudioSourceURL) != strings.TrimSpace(entry.Metadata.OssAudioURL)
 		if missing || sourceOutdated || entry.AudioStatus == AudioStatusFailed {
@@ -594,6 +653,9 @@ func (s *Storage) lockAudioDownload(recordingID string) func() {
 // SetTranscriptDataFile 记录转写 JSON 文件。
 func (s *Storage) SetTranscriptDataFile(recordingID, filename string) error {
 	return s.updateEntry(recordingID, func(entry *Entry) {
+		if entry.WriteRevision != nil {
+			return
+		}
 		next := transcriptDataDirName + "/" + filename
 		if entry.TranscriptDataFile != "" && entry.TranscriptDataFile != next {
 			s.removeRelativeLocked(entry.TranscriptDataFile)
@@ -605,6 +667,9 @@ func (s *Storage) SetTranscriptDataFile(recordingID, filename string) error {
 // SetTranscriptFile 记录转写 Markdown 文件。
 func (s *Storage) SetTranscriptFile(recordingID, filename string) error {
 	return s.updateEntry(recordingID, func(entry *Entry) {
+		if entry.WriteRevision != nil {
+			return
+		}
 		next := transcriptsDirName + "/" + filename
 		if entry.TranscriptFile != "" && entry.TranscriptFile != next {
 			s.removeRelativeLocked(entry.TranscriptFile)
@@ -616,6 +681,9 @@ func (s *Storage) SetTranscriptFile(recordingID, filename string) error {
 // SetSummaryFile 记录摘要文件。
 func (s *Storage) SetSummaryFile(recordingID, filename string) error {
 	return s.updateEntry(recordingID, func(entry *Entry) {
+		if entry.WriteRevision != nil {
+			return
+		}
 		next := summariesDirName + "/" + filename
 		if entry.SummaryFile != "" && entry.SummaryFile != next {
 			s.removeRelativeLocked(entry.SummaryFile)


### PR DESCRIPTION
## 变更内容

- 支持 App 通过 recordings.result.write 先写入仅含音频的录音，再使用更高 writeRevision 补齐转写和总结
- 按 recordingId 串行仲裁写入，处理 stale revision、同 revision 幂等重试、文件 staging/提交与失败清理
- 补齐 OSS 音频下载、状态推进及相关事件处理
- recordings.list 支持 limit: 0，并在所有成功响应中返回 protocol: { orderedWrite: 1, audioOnlyWrite: true }
- 增加 ordered write、并发/幂等、audio-only 与列表能力探测测试

## 兼容性约束

protocol 是 App 判断是否允许发送 audio-only 写入的能力契约。从本版本开始，后续所有版本的 recordings.list 成功响应都必须永久携带该字段，不能移除或按数据状态省略；缺失时 App 会按旧版 CLI 降级，不发送 audio-only。

同一 recordingId + writeRevision 仅允许作为相同请求的幂等重试；业务内容变化必须提升 writeRevision。recordingId 由 App 保证全局唯一且重装后不复用。

## 验证

- go test ./... 全量通过
- git diff --check 通过

注：本地实现说明 docs/recording-audio-only-sync-imp.md 按约定未提交到本 PR。