### PR TITLE
复用已下载的录音音频，避免重复 OSS 下载

### DIFF
--- a/internal/recording/result_writer_test.go
+++ b/internal/recording/result_writer_test.go
@@ -512,7 +512,7 @@ func TestRecoverMissingResultAudio(t *testing.T) {
 	}
 }
 
-func TestResultWriteFailedReplacementKeepsPreviousAudio(t *testing.T) {
+func TestResultWriteReusesPreviousAudioForNewURL(t *testing.T) {
 	t.Parallel()
 	oss := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/good.ogg" {
@@ -541,7 +541,7 @@ func TestResultWriteFailedReplacementKeepsPreviousAudio(t *testing.T) {
 	before, _ := storage.FindByID("rec_replace")
 	beforePath := filepath.Join(storage.dir, before.AudioFile)
 
-	_, err = HandleRecordingResultWrite(ResultWriteParams{
+	result, err := HandleRecordingResultWrite(ResultWriteParams{
 		RecordingID: "rec_replace",
 		OssURL:      oss.URL + "/missing.ogg",
 		Transcript:  &ResultTranscript{Title: "标题", Text: "更新正文"},
@@ -551,13 +551,12 @@ func TestResultWriteFailedReplacementKeepsPreviousAudio(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	waitFor(t, 2*time.Second, func() bool {
-		entry, ok := storage.FindByID("rec_replace")
-		return ok && entry.AudioStatus == AudioStatusFailed
-	})
+	if result.AudioStatus != AudioStatusDownloaded {
+		t.Fatalf("existing audio should be reused immediately: %+v", result)
+	}
 	after, _ := storage.FindByID("rec_replace")
-	if after.AudioFile != before.AudioFile || after.AudioSourceURL != oss.URL+"/good.ogg" {
-		t.Fatalf("failed replacement changed known-good audio reference: before=%+v after=%+v", before, after)
+	if after.AudioFile != before.AudioFile || after.AudioSourceURL != oss.URL+"/missing.ogg" {
+		t.Fatalf("new result did not reuse known-good audio: before=%+v after=%+v", before, after)
 	}
 	data, err := os.ReadFile(beforePath)
 	if err != nil {
@@ -566,8 +565,11 @@ func TestResultWriteFailedReplacementKeepsPreviousAudio(t *testing.T) {
 	if string(data) != "known-good-audio" {
 		t.Fatalf("known-good audio was overwritten: %q", data)
 	}
-	if missing := storage.ListMissingAudio(); len(missing) != 1 || missing[0].ID != "rec_replace" {
-		t.Fatalf("failed replacement was not queued for recovery: %+v", missing)
+	if after.AudioStatus != AudioStatusDownloaded || after.LastError != "" {
+		t.Fatalf("reused audio should remain downloaded: %+v", after)
+	}
+	if missing := storage.ListMissingAudio(); len(missing) != 0 {
+		t.Fatalf("reused audio must not be queued for recovery: %+v", missing)
 	}
 }
 

--- a/internal/recording/store.go
+++ b/internal/recording/store.go
@@ -441,14 +441,15 @@ func (s *Storage) SetAudioFile(recordingID, filename string) error {
 	})
 }
 
-// SetResultAudioPending 持久化 result.write 携带的最新 OSS URL，并把本地音频
-// 标记为待下载。即使 daemon 在后台下载前退出，下一次启动也能从索引恢复任务。
+// SetResultAudioPending 持久化 result.write 携带的最新 OSS URL；已有本地音频
+// 时直接复用，否则标记为待下载。
 func (s *Storage) SetResultAudioPending(recordingID, ossURL string) error {
 	return s.updateEntry(recordingID, func(entry *Entry) {
 		nextURL := strings.TrimSpace(ossURL)
 		entry.Metadata.OssAudioURL = nextURL
-		if strings.TrimSpace(entry.AudioSourceURL) == nextURL && entry.AudioFile != "" {
-			if info, err := os.Stat(filepath.Join(s.dir, entry.AudioFile)); err == nil && !info.IsDir() {
+		if entry.AudioFile != "" {
+			if info, err := os.Stat(filepath.Join(s.dir, entry.AudioFile)); err == nil && !info.IsDir() && info.Size() > 0 {
+				entry.AudioSourceURL = nextURL
 				entry.AudioStatus = AudioStatusDownloaded
 				entry.Metadata.FileSizeDisplay = FormatShortFileSize(info.Size())
 				entry.LastError = ""


### PR DESCRIPTION
## 变更内容

- 同一 recordingId 已有非空本地音频时直接复用，不因 OSS 签名 URL 变化重复下载
- 复用时同步更新最新 OSS URL 来源，并保持 downloaded 状态
- 本地音频缺失或为空时继续走原有下载和恢复流程

## 验证

- go test ./... 全量通过
- git diff --check 通过

注：本地 docs/recording-audio-only-sync-imp.md 未提交。