### PR TITLE
feat(install): 增加 Windows 免 Node 原生安装器

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,112 @@ jobs:
             exit 0
           fi
           echo "::notice::Feishu 构建通知已送达"
+
+  windows-installer:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Smoke test one-command Windows installer
+        # Use inbox Windows PowerShell 5.1; PowerShell 7 is backward-compatible
+        # with the syntax exercised here.
+        shell: powershell
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $version = '0.0.0-test.1'
+          $asset = 'yoooclaw-win32-x64.exe'
+          $serverRoot = Join-Path $env:RUNNER_TEMP 'yoooclaw-installer-server'
+          $versionRoot = Join-Path $serverRoot "v$version"
+          $env:LOCALAPPDATA = Join-Path $env:RUNNER_TEMP 'yoooclaw-local-app-data'
+          $env:YOOOCLAW_HOME = Join-Path $env:RUNNER_TEMP 'yoooclaw-runtime-home'
+          New-Item -ItemType Directory -Path $versionRoot -Force | Out-Null
+
+          # Simulate an older global npm installation and verify that the native
+          # installer migrates it only after the new executable is usable.
+          $mockNpmBin = Join-Path $env:RUNNER_TEMP 'mock-npm-bin'
+          $env:MOCK_NPM_ROOT = Join-Path $env:RUNNER_TEMP 'mock-npm-root'
+          $env:MOCK_NPM_LOG = Join-Path $env:RUNNER_TEMP 'mock-npm.log'
+          New-Item -ItemType Directory -Path $mockNpmBin -Force | Out-Null
+          New-Item -ItemType Directory -Path (Join-Path $env:MOCK_NPM_ROOT '@yoooclaw\cli') -Force | Out-Null
+          '{}' | Set-Content -Encoding ascii (Join-Path $env:MOCK_NPM_ROOT '@yoooclaw\cli\package.json')
+          $mockNpmSource = @'
+          @echo off
+          if "%1"=="root" (
+            echo %MOCK_NPM_ROOT%
+            exit /b 0
+          )
+          if "%1"=="uninstall" (
+            echo %*>>"%MOCK_NPM_LOG%"
+            exit /b 0
+          )
+          exit /b 2
+          '@
+          $mockNpmSource | Set-Content -Encoding ascii (Join-Path $mockNpmBin 'npm.cmd')
+          $env:Path = "$mockNpmBin;$($env:Path)"
+
+          go build -trimpath -ldflags "-s -w -X github.com/YoooClaw/cli/internal/version.Version=$version" -o (Join-Path $versionRoot $asset) ./cmd/yc
+          $hash = (Get-FileHash -Algorithm SHA256 (Join-Path $versionRoot $asset)).Hash.ToLowerInvariant()
+          "$hash  $asset" | Set-Content -Encoding ascii (Join-Path $versionRoot 'checksums.txt')
+          $version | Set-Content -Encoding ascii (Join-Path $serverRoot 'latest')
+
+          $baseUrl = 'http://127.0.0.1:18765'
+          $installer = Get-Content -Raw scripts/install.ps1
+          $installer = $installer.Replace('__YOOOCLAW_CLI_OSS_BASE_URL__', $baseUrl)
+          $installer = $installer.Replace('__YOOOCLAW_CLI_TEMPLATE_RENDERED__', '1')
+          $installer | Set-Content -Encoding utf8 (Join-Path $serverRoot 'install.ps1')
+
+          # Python does not know the .ps1 MIME type by default. Match the OSS
+          # text/plain response so Invoke-RestMethod returns script text.
+          $serverSource = @'
+          import http.server
+          import os
+          import sys
+
+          class Handler(http.server.SimpleHTTPRequestHandler):
+              extensions_map = dict(http.server.SimpleHTTPRequestHandler.extensions_map, **{".ps1": "text/plain; charset=utf-8"})
+
+              def guess_type(self, path):
+                  if path.endswith("/latest") or path.endswith("/beta"):
+                      return "text/plain; charset=utf-8"
+                  return super().guess_type(path)
+
+          os.chdir(sys.argv[1])
+          http.server.ThreadingHTTPServer(("127.0.0.1", 18765), Handler).serve_forever()
+          '@
+          $serverScript = Join-Path $env:RUNNER_TEMP 'serve-yoooclaw-installer.py'
+          $serverSource | Set-Content -Encoding utf8 $serverScript
+          $server = Start-Process python -ArgumentList $serverScript, $serverRoot -PassThru
+          try {
+            $deadline = (Get-Date).AddSeconds(15)
+            do {
+              try {
+                Invoke-WebRequest -UseBasicParsing "$baseUrl/latest" | Out-Null
+                $ready = $true
+              }
+              catch {
+                Start-Sleep -Milliseconds 250
+              }
+            } until ($ready -or (Get-Date) -ge $deadline)
+            if (-not $ready) { throw 'local installer server did not start' }
+
+            Invoke-RestMethod "$baseUrl/install.ps1" | Invoke-Expression
+
+            $installDir = Join-Path $env:LOCALAPPDATA 'YoooClaw\bin'
+            $yoooclawVersion = & (Join-Path $installDir 'yoooclaw.exe') --version
+            $ycVersion = & (Join-Path $installDir 'yc.exe') --version
+            if ($yoooclawVersion -ne $version -or $ycVersion -ne $version) {
+              throw "installed command versions do not match: yoooclaw=$yoooclawVersion yc=$ycVersion"
+            }
+            $npmLog = Get-Content -Raw $env:MOCK_NPM_LOG
+            if ($npmLog -notmatch 'uninstall --global @yoooclaw/cli') {
+              throw "old npm package was not removed: $npmLog"
+            }
+          }
+          finally {
+            Stop-Process -Id $server.Id -Force -ErrorAction SilentlyContinue
+          }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,12 @@ jobs:
           $installer = Get-Content -Raw scripts/install.ps1
           $installer = $installer.Replace('__YOOOCLAW_CLI_OSS_BASE_URL__', $baseUrl)
           $installer = $installer.Replace('__YOOOCLAW_CLI_TEMPLATE_RENDERED__', '1')
-          $installer | Set-Content -Encoding utf8 (Join-Path $serverRoot 'install.ps1')
+          # Windows PowerShell 5.1's `Set-Content -Encoding utf8` adds a BOM.
+          # OSS publishes the repository bytes without one, so mirror that
+          # behavior: a BOM at the start of text piped to Invoke-Expression is
+          # interpreted as part of the first token.
+          $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+          [System.IO.File]::WriteAllText((Join-Path $serverRoot 'install.ps1'), $installer, $utf8NoBom)
 
           # Python does not know the .ps1 MIME type by default. Match the OSS
           # text/plain response so Invoke-RestMethod returns script text.

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -493,10 +493,18 @@ jobs:
           INSTALL_FLAGS=""
           [ "$PRERELEASE" = "1" ] && INSTALL_FLAGS=" -s -- --beta"
 
+          WINDOWS_INSTALL_COMMAND="irm ${OSS_PUBLIC_URL}/${OSS_PREFIX}/install.ps1 | iex"
+          if [ "$PRERELEASE" = "1" ]; then
+            WINDOWS_INSTALL_COMMAND="& ([scriptblock]::Create((irm '${OSS_PUBLIC_URL}/${OSS_PREFIX}/install.ps1'))) -Beta"
+          fi
+
           TEXT="🚀 @yoooclaw/cli ${CURRENT_TAG}（${CHANNEL}）已发布
 
-          📥 安装（阿里云 OSS）：
+          📥 macOS / Linux 安装（阿里云 OSS）：
           curl -fsSL ${OSS_PUBLIC_URL}/${OSS_PREFIX}/install.sh | sh${INSTALL_FLAGS}
+
+          📥 Windows PowerShell 安装（无需 Node/npm）：
+          ${WINDOWS_INSTALL_COMMAND}
 
           📝 改动（${RANGE}）：
           ${CHANGES}

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Service-oriented command tree, a three-tier command system, Agent-Native.
 
 Two distribution channels with **identical functionality** — pick whichever fits. The npm package is now a very thin Node launcher; the actual work is done by the native Go binary installed via optionalDependencies. The direct-install channel skips Node entirely and downloads the same Go binary.
 
-**Platform support**: the npm channel supports `darwin/linux` `x64+arm64` and `win32-x64` (the launcher needs Node ≥ 18); `install.sh` / GitHub Release direct install supports `darwin/linux` `x64+arm64`. On Windows, credentials are stored in plaintext at `~/.yoooclaw/credentials.json` (no OS keychain hardening — `yoooclaw doctor` will warn about this), and the daemon shuts down gracefully over HTTP.
+**Platform support**: the npm channel supports `darwin/linux` `x64+arm64` and `win32-x64` (the launcher needs Node ≥ 18); native direct install supports `darwin/linux` `x64+arm64` and Windows x64 (Windows on ARM uses the OS x64 compatibility layer). On Windows, credentials are stored in plaintext at `~/.yoooclaw/credentials.json` (no OS keychain hardening — `yoooclaw doctor` will warn about this), and the daemon shuts down gracefully over HTTP.
 
 ### Channel A — npm (thin Node launcher + platform Go binary)
 
@@ -65,6 +65,22 @@ yc --help
 
 A single-file Go executable — lighter cold-start and resource footprint than the older TS/Bun implementation.
 
+One-command install on Windows PowerShell 5.1+, with no Node/npm or administrator rights required:
+
+```powershell
+irm https://artifact.yoooclaw.com/cli/install.ps1 | iex
+```
+
+It installs `yoooclaw.exe` / `yc.exe` under `%LOCALAPPDATA%\YoooClaw\bin` and adds that directory to the current user's PATH. To pin a version or overwrite an existing installation:
+
+```powershell
+& ([scriptblock]::Create((irm https://artifact.yoooclaw.com/cli/install.ps1))) -Version 0.9.1 -Force
+```
+
+If an older `npm i -g @yoooclaw/cli` installation is detected, the installer first verifies the new native CLI and then runs `npm uninstall -g @yoooclaw/cli`. Pass `-KeepNpm` to retain it. An npm cleanup failure never rolls back a verified native installation.
+
+macOS / Linux:
+
 ```bash
 # Auto-detect platform, download, verify sha256, install to ~/.local/bin
 curl -fsSL https://raw.githubusercontent.com/YoooClaw/cli/master/scripts/install.sh | sh
@@ -78,10 +94,10 @@ curl -fsSL https://raw.githubusercontent.com/YoooClaw/cli/master/scripts/install
   | sh -s -- --version 0.2.0-beta.2 --dir ~/bin --force
 ```
 
-The installer does not modify shell startup files by default. It only updates PATH when
-`--modify-path` is explicitly supplied; `--no-modify-path` remains accepted for compatibility.
+The Unix installer does not modify shell startup files by default; pass `--modify-path` to opt in.
+The Windows installer updates the user PATH by default; pass `-NoModifyPath` to opt out.
 
-Direct-install supported platforms: `darwin-arm64` / `darwin-x64` / `linux-x64` / `linux-arm64`. The Windows Go binary currently ships only via the npm platform subpackage. You can also download manually from [GitHub Releases](https://github.com/YoooClaw/cli/releases?q=cli-v) (verify against the `checksums.txt` in the same release).
+Direct-install supported platforms: `darwin-arm64` / `darwin-x64` / `linux-x64` / `linux-arm64` / `win32-x64`. You can also download manually from [GitHub Releases](https://github.com/YoooClaw/cli/releases?q=cli-v) (verify against the `checksums.txt` in the same release).
 
 ### Unattended WUYING cloud desktop installation
 
@@ -99,7 +115,7 @@ curl -fsSL https://artifact.yoooclaw.com/cli/install-wuying.sh \
 
 Current CLI releases accept `claude` and `codex` for `--skill`. The value is passed directly to the CLI Skill adapter, so the installer will not need a workflow change when a DeepSeek Harness adapter is added. `--env` accepts `development`, `test`, or `production`; it defaults to `PHONE_NOTIFICATIONS_ENV`, then `production`, and is persisted in the profile for systemd-launched daemons. The live script installs the CLI release that shipped it by default and also accepts `--version`, `--beta`, `--dir`, `--profile`, and `--modify-path`. It never prints the API key and writes it through stdin to the shared `0600` credentials file; reference an environment variable as above to keep the plaintext value out of shell history.
 
-> `yoooclaw update self` gives you the right upgrade command for how you installed (npm → `npm update -g`, binary → install.sh).
+> `yoooclaw update self` gives you the right upgrade command for your installation source and OS (npm → `npm update -g`, native → `install.sh` / `install.ps1`).
 
 ### Quickstart (Human Users)
 
@@ -248,10 +264,10 @@ yoooclaw owner activate cli                          # hand ownership from the H
 yoooclaw owner activate cli --hermes-profile work --no-start
 ```
 
-`install.sh` **preserves ownership as it was before the upgrade** by default —
-an upgrade never silently hands it off. Only passing `--activate` explicitly
-(or setting `YOOOCLAW_ACTIVATE_OWNER=cli`) makes it actively hand ownership to
-the standalone CLI after install.
+`install.sh` / `install.ps1` **preserve ownership as it was before the upgrade**
+by default—an upgrade never silently hands it off. Only passing `--activate` /
+`-Activate` explicitly (or setting `YOOOCLAW_ACTIVATE_OWNER=cli`) makes it
+actively hand ownership to the standalone CLI after install.
 
 ## Daemon lifecycle protocol
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,7 +47,7 @@ Service-oriented 命令树、三层命令体系、Agent-Native。
 
 两种分发渠道，二者**功能一致**，按需选择。npm 包现在是极薄 Node launcher，真正执行的是 optionalDependencies 安装的 Go 原生二进制；直接安装渠道则跳过 Node，直接下载同一套 Go binary。
 
-**平台支持**：npm 渠道支持 `darwin/linux` 的 `x64+arm64` 与 `win32-x64`（launcher 需 Node ≥ 18）；`install.sh` / GitHub Release 直装支持 `darwin/linux` 的 `x64+arm64`。Windows 上凭据以明文落 `~/.yoooclaw/credentials.json`（无系统 keychain 加固，`yoooclaw doctor` 会提示），daemon 停止经 HTTP 优雅退出。
+**平台支持**：npm 渠道支持 `darwin/linux` 的 `x64+arm64` 与 `win32-x64`（launcher 需 Node ≥ 18）；原生直装支持 `darwin/linux` 的 `x64+arm64` 与 Windows x64（Windows on ARM 通过系统 x64 兼容层运行）。Windows 上凭据以明文落 `~/.yoooclaw/credentials.json`（无系统 keychain 加固，`yoooclaw doctor` 会提示），daemon 停止经 HTTP 优雅退出。
 
 ### 渠道 A — npm（薄 Node launcher + 平台 Go 二进制）
 
@@ -65,6 +65,24 @@ yc --help
 
 单文件 Go 可执行，冷启动和资源占用都比旧 TS/Bun 形态更轻。
 
+Windows PowerShell 5.1+ 一条命令安装，无需 Node/npm、无需管理员权限：
+
+```powershell
+irm https://artifact.yoooclaw.com/cli/install.ps1 | iex
+```
+
+默认写入 `%LOCALAPPDATA%\YoooClaw\bin`，安装 `yoooclaw.exe` / `yc.exe`，并自动加入当前用户 PATH。指定版本或覆盖升级：
+
+```powershell
+& ([scriptblock]::Create((irm https://artifact.yoooclaw.com/cli/install.ps1))) -Version 0.9.1 -Force
+```
+
+如果检测到此前通过 `npm i -g @yoooclaw/cli` 安装的旧版本，安装器会先确认新的原生
+CLI 可执行，再自动运行 `npm uninstall -g @yoooclaw/cli` 清理旧包；传 `-KeepNpm`
+可选择保留。npm 清理异常不会撤销已经验证可用的新版本。
+
+macOS / Linux：
+
 ```bash
 # 自动检测平台、下载、校验 sha256、写到 ~/.local/bin
 curl -fsSL https://raw.githubusercontent.com/YoooClaw/cli/master/scripts/install.sh | sh
@@ -78,10 +96,10 @@ curl -fsSL https://raw.githubusercontent.com/YoooClaw/cli/master/scripts/install
   | sh -s -- --version 0.2.0-beta.2 --dir ~/bin --force
 ```
 
-安装器默认不会修改 shell 启动文件；只有显式传入 `--modify-path` 才会写入 PATH。
-`--no-modify-path` 仍保留，用于兼容已有调用。
+Unix 安装器默认不会修改 shell 启动文件；只有显式传入 `--modify-path` 才会写入 PATH。
+Windows 安装器默认写入用户 PATH；传 `-NoModifyPath` 可关闭。
 
-直装支持平台：`darwin-arm64` / `darwin-x64` / `linux-x64` / `linux-arm64`。Windows Go binary 目前随 npm 平台子包发布。也可从 [GitHub Releases](https://github.com/YoooClaw/cli/releases?q=cli-v) 手动下载（同 release 内 `checksums.txt` 校验）。
+直装支持平台：`darwin-arm64` / `darwin-x64` / `linux-x64` / `linux-arm64` / `win32-x64`。也可从 [GitHub Releases](https://github.com/YoooClaw/cli/releases?q=cli-v) 手动下载（同 release 内 `checksums.txt` 校验）。
 
 ### 无影云电脑无人值守安装
 
@@ -99,7 +117,7 @@ curl -fsSL https://artifact.yoooclaw.com/cli/install-wuying.sh \
 
 当前 CLI 的 `--skill` 支持 `claude`、`codex`；该参数直接传给 CLI 的 Skill adapter，未来加入 DeepSeek Harness 等宿主后安装脚本无需改变。`--env` 支持 `development`、`test`、`production`，默认读取 `PHONE_NOTIFICATIONS_ENV`，未设置时使用 `production`，并持久化到 profile 配置供 systemd 服务使用。live 脚本默认安装发布它的同版本 CLI，也可显式传 `--version`、`--beta`、`--dir`、`--profile` 与 `--modify-path`。脚本不会打印 API key，并通过 stdin 写入权限为 `0600` 的共享凭据文件；建议像示例一样引用环境变量，避免在 shell 历史中留下明文。
 
-> `yoooclaw update self` 会按当前安装来源给出对应升级命令（npm 走 `npm update -g`，二进制走 install.sh）。
+> `yoooclaw update self` 会按当前安装来源和系统给出对应升级命令（npm 走 `npm update -g`，原生安装走 `install.sh` / `install.ps1`）。
 
 ### 快速开始（人类用户）
 
@@ -242,9 +260,9 @@ yoooclaw owner activate cli                          # 把所有权从 Hermes �
 yoooclaw owner activate cli --hermes-profile work --no-start
 ```
 
-`install.sh` 升级时默认**保留升级前的所有权归属**，不会因为一次升级悄悄换手；只有
-显式传 `--activate`（或 `YOOOCLAW_ACTIVATE_OWNER=cli`）才会在装完后主动把所有权转
-交给独立 CLI。
+`install.sh` / `install.ps1` 升级时默认**保留升级前的所有权归属**，不会因为一次升级
+悄悄换手；只有显式传 `--activate` / `-Activate`（或
+`YOOOCLAW_ACTIVATE_OWNER=cli`）才会在装完后主动把所有权转交给独立 CLI。
 
 ## Daemon lifecycle protocol
 

--- a/internal/cli/cmd_update.go
+++ b/internal/cli/cmd_update.go
@@ -17,14 +17,15 @@ import (
 )
 
 const (
-	updatePackage   = "@yoooclaw/cli"
-	updateRegistry  = "https://registry.npmjs.org"
-	updateInstallSh = "https://raw.githubusercontent.com/YoooClaw/cli/master/scripts/install.sh"
+	updatePackage    = "@yoooclaw/cli"
+	updateRegistry   = "https://registry.npmjs.org"
+	updateInstallSh  = "https://raw.githubusercontent.com/YoooClaw/cli/master/scripts/install.sh"
+	updateInstallPS1 = "https://artifact.yoooclaw.com/cli/install.ps1"
 )
 
 func newUpdateCmd() *cobra.Command {
 	c := &cobra.Command{Use: "update", Short: "版本检查 🟢"}
-	self := &cobra.Command{Use: "self", Short: "检查 npm 最新版本并提示（不自动更新）", Args: cobra.NoArgs, RunE: run(updateSelf)}
+	self := &cobra.Command{Use: "self", Short: "检查最新版本并提示（不自动更新）", Args: cobra.NoArgs, RunE: run(updateSelf)}
 	self.Flags().Bool("beta", false, "检查 beta channel")
 	self.Flags().Bool("json", false, "只输出版本信息 JSON")
 	c.AddCommand(self)
@@ -32,22 +33,35 @@ func newUpdateCmd() *cobra.Command {
 }
 
 func nativeTargetName() string {
-	os, arch := runtime.GOOS, runtime.GOARCH
+	return nativeTargetNameFor(runtime.GOOS, runtime.GOARCH)
+}
+
+func nativeTargetNameFor(os, arch string) string {
 	if arch == "amd64" {
 		arch = "x64"
 	}
 	if (os == "darwin" || os == "linux") && (arch == "arm64" || arch == "x64") {
 		return "yoooclaw-" + os + "-" + arch
 	}
+	if os == "windows" && arch == "x64" {
+		return "yoooclaw-win32-x64.exe"
+	}
 	return ""
 }
 
 func upgradeCommand(channel, latest string) string {
-	if version.Dist() == "native" {
-		if nativeTargetName() == "" {
+	return upgradeCommandFor(version.Dist(), runtime.GOOS, runtime.GOARCH, channel, latest)
+}
+
+func upgradeCommandFor(dist, goos, goarch, channel, latest string) string {
+	if dist == "native" {
+		if goos == "windows" {
+			return "& ([scriptblock]::Create((irm '" + updateInstallPS1 + "'))) -Version " + latest + " -Force"
+		}
+		if nativeTargetNameFor(goos, goarch) == "" {
 			return "curl -fsSL " + updateInstallSh + " | sh"
 		}
-		return "curl -fsSL " + updateInstallSh + " | sh -s -- --version " + latest
+		return "curl -fsSL " + updateInstallSh + " | sh -s -- --version " + latest + " --force"
 	}
 	if channel == "beta" {
 		return "npm i -g " + updatePackage + "@beta"

--- a/internal/cli/cmd_update_test.go
+++ b/internal/cli/cmd_update_test.go
@@ -9,6 +9,41 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func TestNativeTargetNameForWindows(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		goos, goarch, want string
+	}{
+		{goos: "windows", goarch: "amd64", want: "yoooclaw-win32-x64.exe"},
+		{goos: "darwin", goarch: "arm64", want: "yoooclaw-darwin-arm64"},
+		{goos: "linux", goarch: "amd64", want: "yoooclaw-linux-x64"},
+		{goos: "windows", goarch: "386", want: ""},
+	} {
+		if got := nativeTargetNameFor(tc.goos, tc.goarch); got != tc.want {
+			t.Errorf("nativeTargetNameFor(%q, %q) = %q, want %q", tc.goos, tc.goarch, got, tc.want)
+		}
+	}
+}
+
+func TestUpgradeCommandForNativeInstallers(t *testing.T) {
+	t.Parallel()
+
+	windows := upgradeCommandFor("native", "windows", "amd64", "latest", "1.2.3")
+	for _, want := range []string{"install.ps1", "-Version 1.2.3", "-Force"} {
+		if !strings.Contains(windows, want) {
+			t.Errorf("Windows upgrade command %q does not contain %q", windows, want)
+		}
+	}
+
+	unix := upgradeCommandFor("native", "linux", "amd64", "latest", "1.2.3")
+	for _, want := range []string{"install.sh", "--version 1.2.3", "--force"} {
+		if !strings.Contains(unix, want) {
+			t.Errorf("Unix upgrade command %q does not contain %q", unix, want)
+		}
+	}
+}
+
 type updateRoundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f updateRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/npm/cli/README.md
+++ b/npm/cli/README.md
@@ -12,7 +12,16 @@ npm i -g @yoooclaw/cli
 yc --version
 ```
 
-也可不经 npm，直接下载原生二进制（见 GitHub Release / install.sh）。
+也可不经 npm，直接下载原生二进制（见 GitHub Release / `install.sh` / `install.ps1`）。
+
+Windows PowerShell 5.1+ 可一条命令安装原生版本，无需 Node/npm 或管理员权限：
+
+```powershell
+irm https://artifact.yoooclaw.com/cli/install.ps1 | iex
+```
+
+安装器会在新的原生 CLI 验证通过后，自动卸载检测到的旧版全局 npm 包；传
+`-KeepNpm` 可保留 npm 版本。
 
 ## 支持平台
 

--- a/scripts/build-go.sh
+++ b/scripts/build-go.sh
@@ -6,7 +6,7 @@
 #   scripts/build-go.sh --current        # 只构当前平台（本地快速验证）
 #
 # 产物:
-#   dist-native/yoooclaw-<os>-<arch>{,.exe}   原始二进制（GitHub Release / install.sh 用）
+#   dist-native/yoooclaw-<os>-<arch>{,.exe}   原始二进制（GitHub Release / install.* 用）
 #   dist-npm/cli/                             主 launcher 包 @yoooclaw/cli
 #   dist-npm/cli-<os>-<arch>/                 各平台子包 @yoooclaw/cli-<os>-<arch>
 set -euo pipefail

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -69,6 +69,12 @@ function Assert-SupportedPlatform {
 function Get-WebText([string] $Uri) {
     $headers = @{ "User-Agent" = "yoooclaw-installer" }
     $response = Invoke-WebRequest -UseBasicParsing -Headers $headers -Uri $Uri
+    # Windows PowerShell 5.1 may expose text responses as byte[] depending on
+    # the server/CDN content type. Casting byte[] directly to string produces a
+    # space-separated list of decimal byte values instead of the response text.
+    if ($response.Content -is [byte[]]) {
+        return [Text.Encoding]::UTF8.GetString($response.Content)
+    }
     return [string] $response.Content
 }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,531 @@
+# @yoooclaw/cli Windows installer
+#
+# One-command install (PowerShell 5.1+):
+#   irm https://artifact.yoooclaw.com/cli/install.ps1 | iex
+#
+# Install with options:
+#   & ([scriptblock]::Create((irm https://artifact.yoooclaw.com/cli/install.ps1))) -Version 0.9.1 -Force
+#
+# The installer downloads the native Go executable. Node.js and npm are not
+# required, and installation is per-user by default (no administrator rights).
+
+[CmdletBinding()]
+param(
+    [string] $Version = "",
+    [switch] $Beta,
+    [string] $InstallDir = "",
+    [switch] $Force,
+    [switch] $Activate,
+    [string] $HermesProfile = "",
+    [switch] $NoModifyPath,
+    [switch] $KeepNpm,
+    # Primarily useful for mirrors and installer integration tests. The layout
+    # must be <BaseUrl>/v<version>/{asset,checksums.txt} with latest/beta markers.
+    [string] $BaseUrl = ""
+)
+
+& {
+[CmdletBinding()]
+param(
+    [string] $Version,
+    [switch] $Beta,
+    [string] $InstallDir,
+    [switch] $Force,
+    [switch] $Activate,
+    [string] $HermesProfile,
+    [switch] $NoModifyPath,
+    [switch] $KeepNpm,
+    [string] $BaseUrl
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = "Stop"
+
+# These placeholders are rendered by tools/oss-upload during a release. The
+# source version falls back to GitHub Releases, while the rendered version uses
+# the OSS mirror and its latest/beta marker files.
+$OssBaseUrl = "__YOOOCLAW_CLI_OSS_BASE_URL__"
+$OssRendered = "__YOOOCLAW_CLI_TEMPLATE_RENDERED__"
+$Repository = "YoooClaw/cli"
+$Asset = "yoooclaw-win32-x64.exe"
+
+function Write-Info([string] $Message) {
+    Write-Host "==> $Message" -ForegroundColor Blue
+}
+
+function Write-WarningMessage([string] $Message) {
+    Write-Warning $Message
+}
+
+function Assert-SupportedPlatform {
+    if ($env:OS -ne "Windows_NT") {
+        throw "This installer only supports Windows. Use scripts/install.sh on macOS or Linux."
+    }
+
+    # An x64 build is currently published. Windows on ARM can run it through
+    # the OS x64 compatibility layer; 32-bit-only Windows is not supported.
+    $architecture = $env:PROCESSOR_ARCHITEW6432
+    if ([string]::IsNullOrWhiteSpace($architecture)) {
+        $architecture = $env:PROCESSOR_ARCHITECTURE
+    }
+    if ($architecture -notin @("AMD64", "ARM64")) {
+        throw "Unsupported Windows architecture: $architecture (x64 or Windows on ARM is required)."
+    }
+}
+
+function Get-WebText([string] $Uri) {
+    $headers = @{ "User-Agent" = "yoooclaw-installer" }
+    $response = Invoke-WebRequest -UseBasicParsing -Headers $headers -Uri $Uri
+    return [string] $response.Content
+}
+
+function Save-WebFile([string] $Uri, [string] $Destination) {
+    $headers = @{ "User-Agent" = "yoooclaw-installer" }
+    Invoke-WebRequest -UseBasicParsing -Headers $headers -Uri $Uri -OutFile $Destination
+}
+
+function Resolve-Version {
+    if (-not [string]::IsNullOrWhiteSpace($Version)) {
+        return $Version.Trim()
+    }
+
+    $channel = "latest"
+    if ($Beta) {
+        $channel = "beta"
+    }
+
+    $markerBaseUrl = ""
+    if (-not [string]::IsNullOrWhiteSpace($BaseUrl)) {
+        $markerBaseUrl = $BaseUrl.TrimEnd("/")
+    }
+    elseif ($OssRendered -eq "1") {
+        $markerBaseUrl = $OssBaseUrl.TrimEnd("/")
+    }
+
+    if ($markerBaseUrl) {
+        Write-Info "Resolving $channel version..."
+        return (Get-WebText "$markerBaseUrl/$channel").Trim()
+    }
+
+    Write-Info "Resolving the latest GitHub release..."
+    $headers = @{ "Accept" = "application/vnd.github+json"; "User-Agent" = "yoooclaw-installer" }
+    $releases = @(Invoke-RestMethod -Headers $headers -Uri "https://api.github.com/repos/$Repository/releases?per_page=100")
+    $tags = @($releases | ForEach-Object { [string] $_.tag_name } | Where-Object { $_ -match '^cli-v' })
+    if ($Beta) {
+        $tag = $tags | Where-Object { $_ -match '-(beta|alpha|rc)([.-]|$)' } | Select-Object -First 1
+    }
+    else {
+        $tag = $tags | Where-Object { $_ -notmatch '-(beta|alpha|rc)([.-]|$)' } | Select-Object -First 1
+    }
+    if ([string]::IsNullOrWhiteSpace($tag)) {
+        throw "Unable to resolve the $channel release. Specify -Version explicitly."
+    }
+    return $tag.Substring("cli-v".Length)
+}
+
+function Get-ArtifactBaseUrl([string] $ResolvedVersion) {
+    if (-not [string]::IsNullOrWhiteSpace($BaseUrl)) {
+        return $BaseUrl.TrimEnd("/") + "/v" + $ResolvedVersion
+    }
+    if ($OssRendered -eq "1") {
+        return $OssBaseUrl.TrimEnd("/") + "/v" + $ResolvedVersion
+    }
+    return "https://github.com/$Repository/releases/download/cli-v$ResolvedVersion"
+}
+
+function Get-DefaultInstallDir {
+    if (-not [string]::IsNullOrWhiteSpace($env:LOCALAPPDATA)) {
+        return Join-Path $env:LOCALAPPDATA "YoooClaw\bin"
+    }
+    return Join-Path $HOME ".yoooclaw\bin"
+}
+
+function Test-PathEntry([string] $PathValue, [string] $Entry) {
+    if ([string]::IsNullOrWhiteSpace($PathValue)) {
+        return $false
+    }
+    $fullEntry = [IO.Path]::GetFullPath($Entry).TrimEnd("\")
+    foreach ($item in ($PathValue -split ";")) {
+        if ([string]::IsNullOrWhiteSpace($item)) {
+            continue
+        }
+        try {
+            if ([IO.Path]::GetFullPath($item.Trim()).TrimEnd("\") -ieq $fullEntry) {
+                return $true
+            }
+        }
+        catch {
+            # Preserve malformed or environment-variable-based PATH entries; they
+            # simply do not match our absolute installation directory.
+        }
+    }
+    return $false
+}
+
+function Add-InstallDirToPath([string] $Directory) {
+    if (-not (Test-PathEntry $env:Path $Directory)) {
+        $env:Path = "$Directory;$($env:Path)"
+    }
+
+    if ($NoModifyPath) {
+        Write-WarningMessage "PATH was not persisted because -NoModifyPath was supplied."
+        return
+    }
+
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    if (Test-PathEntry $userPath $Directory) {
+        Write-Info "User PATH is already configured."
+        return
+    }
+    if ([string]::IsNullOrWhiteSpace($userPath)) {
+        $newUserPath = $Directory
+    }
+    else {
+        $newUserPath = $Directory + ";" + $userPath.TrimStart(";")
+    }
+    try {
+        [Environment]::SetEnvironmentVariable("Path", $newUserPath, "User")
+    }
+    catch {
+        Write-WarningMessage "Could not persist the user PATH. The command works in this terminal; add '$Directory' manually for future terminals."
+        return
+    }
+    try {
+        # Notify Explorer and already-running terminal hosts that the persisted
+        # environment changed. The current PowerShell process was updated above.
+        if ($null -eq ("YoooClawInstaller.NativeMethods" -as [type])) {
+            Add-Type -Namespace YoooClawInstaller -Name NativeMethods -MemberDefinition @'
+[System.Runtime.InteropServices.DllImport("user32.dll", SetLastError=true, CharSet=System.Runtime.InteropServices.CharSet.Auto)]
+public static extern System.IntPtr SendMessageTimeout(
+    System.IntPtr hWnd,
+    uint Msg,
+    System.UIntPtr wParam,
+    string lParam,
+    uint flags,
+    uint timeout,
+    out System.UIntPtr result);
+'@
+        }
+        $broadcastResult = [UIntPtr]::Zero
+        [void] [YoooClawInstaller.NativeMethods]::SendMessageTimeout(
+            [IntPtr] 0xffff,
+            [uint32] 0x001a,
+            [UIntPtr]::Zero,
+            "Environment",
+            [uint32] 0x0002,
+            [uint32] 1000,
+            [ref] $broadcastResult
+        )
+    }
+    catch {
+        Write-WarningMessage "PATH was saved, but other running apps could not be notified. Reopen the terminal if needed."
+    }
+    Write-Info "Added $Directory to the user PATH."
+}
+
+function Find-NpmCommand {
+    $command = Get-Command "npm.cmd" -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($null -ne $command) {
+        return [string] $command.Path
+    }
+    return ""
+}
+
+function Test-NpmCliInstalled([string] $Npm) {
+    if ([string]::IsNullOrWhiteSpace($Npm)) {
+        return $false
+    }
+    try {
+        $rootOutput = @(& $Npm root --global 2>$null)
+        $rootExitCode = $LASTEXITCODE
+        if ($rootExitCode -ne 0 -or $rootOutput.Count -eq 0) {
+            return $false
+        }
+        $globalRoot = ([string] ($rootOutput | Select-Object -First 1)).Trim()
+        if ([string]::IsNullOrWhiteSpace($globalRoot)) {
+            return $false
+        }
+        return Test-Path -LiteralPath (Join-Path $globalRoot "@yoooclaw\cli\package.json") -PathType Leaf
+    }
+    catch {
+        return $false
+    }
+}
+
+function Remove-NpmCli([string] $Npm) {
+    Write-Info "Removing the previous global npm installation..."
+    try {
+        & $Npm uninstall --global "@yoooclaw/cli"
+        if ($LASTEXITCODE -eq 0) {
+            Write-Info "Removed previous npm package: @yoooclaw/cli"
+            return $true
+        }
+        Write-WarningMessage "The native CLI is ready, but npm returned exit code $LASTEXITCODE while removing @yoooclaw/cli. Run 'npm uninstall -g @yoooclaw/cli' manually."
+    }
+    catch {
+        Write-WarningMessage "The native CLI is ready, but the old npm package could not be removed. Run 'npm uninstall -g @yoooclaw/cli' manually. $($_.Exception.Message)"
+    }
+    return $false
+}
+
+function Find-ExistingCli([string] $Target) {
+    if (Test-Path -LiteralPath $Target -PathType Leaf) {
+        return $Target
+    }
+    foreach ($name in @("yoooclaw.exe", "yoooclaw")) {
+        $commands = @(Get-Command $name -All -ErrorAction SilentlyContinue)
+        foreach ($command in $commands) {
+            if ($command.CommandType -notin @("Application", "ExternalScript")) {
+                continue
+            }
+            $source = [string] $command.Path
+            if ($source.EndsWith(".ps1", [StringComparison]::OrdinalIgnoreCase)) {
+                $cmdShim = [IO.Path]::ChangeExtension($source, ".cmd")
+                if (Test-Path -LiteralPath $cmdShim -PathType Leaf) {
+                    return $cmdShim
+                }
+            }
+            return $source
+        }
+    }
+    return ""
+}
+
+function Invoke-CliQuiet([string] $Cli, [string[]] $Arguments) {
+    & $Cli @Arguments *> $null
+    return ($LASTEXITCODE -eq 0)
+}
+
+function Stop-ExistingDaemons([string] $Cli) {
+    $stopped = @()
+    if ([string]::IsNullOrWhiteSpace($Cli)) {
+        return $stopped
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($env:YOOOCLAW_HOME)) {
+        $runtimeRoot = $env:YOOOCLAW_HOME
+    }
+    else {
+        $runtimeRoot = Join-Path $HOME ".yoooclaw"
+    }
+    $profilesRoot = Join-Path $runtimeRoot "profiles"
+    $profiles = @()
+    if (Test-Path -LiteralPath $profilesRoot -PathType Container) {
+        $profiles = @(Get-ChildItem -LiteralPath $profilesRoot -Directory | ForEach-Object { $_.Name })
+    }
+    if ($profiles.Count -eq 0) {
+        $profiles = @("default")
+    }
+
+    foreach ($profile in $profiles) {
+        if (Invoke-CliQuiet $Cli @("--profile", $profile, "daemon", "status")) {
+            if (-not (Invoke-CliQuiet $Cli @("--profile", $profile, "daemon", "stop"))) {
+                throw "Unable to stop the existing CLI daemon for profile '$profile'."
+            }
+            $stopped += $profile
+            Write-Info "Stopped existing CLI daemon: $profile"
+        }
+    }
+    return $stopped
+}
+
+function Restore-Daemons([string] $Cli, [string[]] $Profiles) {
+    foreach ($profile in $Profiles) {
+        if (Invoke-CliQuiet $Cli @("--profile", $profile, "daemon", "autostart", "enable")) {
+            Write-Info "Restored CLI daemon and login autostart: $profile"
+        }
+        else {
+            Write-WarningMessage "Could not configure login autostart; restoring detached daemon for '$profile'."
+            if (-not (Invoke-CliQuiet $Cli @("--profile", $profile, "daemon", "start"))) {
+                throw "The CLI was updated, but daemon profile '$profile' could not be restored."
+            }
+        }
+    }
+}
+
+Assert-SupportedPlatform
+
+# PowerShell 5.1 may otherwise negotiate TLS 1.0 on older Windows installs.
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
+$resolvedVersion = Resolve-Version
+if ($resolvedVersion -notmatch '^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z][0-9A-Za-z.+-]*)?$') {
+    throw "Invalid version: $resolvedVersion"
+}
+if ([string]::IsNullOrWhiteSpace($InstallDir)) {
+    $InstallDir = Get-DefaultInstallDir
+}
+$InstallDir = [IO.Path]::GetFullPath([Environment]::ExpandEnvironmentVariables($InstallDir))
+$target = Join-Path $InstallDir "yoooclaw.exe"
+$alias = Join-Path $InstallDir "yc.exe"
+
+if (((Test-Path -LiteralPath $target) -or (Test-Path -LiteralPath $alias)) -and -not $Force) {
+    throw "$target or $alias already exists. Re-run with -Force to update it."
+}
+
+$npmCommand = ""
+$npmCliInstalled = $false
+if (-not $KeepNpm) {
+    $npmCommand = Find-NpmCommand
+    $npmCliInstalled = Test-NpmCliInstalled $npmCommand
+    if ($npmCliInstalled) {
+        Write-Info "Detected previous global npm package: @yoooclaw/cli"
+    }
+}
+
+$artifactBaseUrl = Get-ArtifactBaseUrl $resolvedVersion
+Write-Info "Target $Asset  version $resolvedVersion"
+
+$tempRoot = Join-Path ([IO.Path]::GetTempPath()) ("yoooclaw-install-" + [guid]::NewGuid().ToString("N"))
+$downloaded = Join-Path $tempRoot $Asset
+$backupSuffix = ".installer-backup-" + [guid]::NewGuid().ToString("N")
+$targetBackup = $target + $backupSuffix
+$aliasBackup = $alias + $backupSuffix
+$targetOriginallyExisted = Test-Path -LiteralPath $target
+$aliasOriginallyExisted = Test-Path -LiteralPath $alias
+$stoppedProfiles = @()
+$handoffPending = $false
+$installationCommitted = $false
+$targetBackedUp = $false
+$aliasBackedUp = $false
+
+try {
+    New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+
+    Write-Info "Downloading $artifactBaseUrl/$Asset"
+    Save-WebFile "$artifactBaseUrl/$Asset" $downloaded
+
+    Write-Info "Downloading checksums.txt"
+    try {
+        $checksums = Get-WebText "$artifactBaseUrl/checksums.txt"
+        $match = [regex]::Match($checksums, "(?mi)^([0-9a-f]{64})\s+\*?$([regex]::Escape($Asset))\s*$")
+        if (-not $match.Success) {
+            throw "checksums.txt does not contain $Asset"
+        }
+        $expectedHash = $match.Groups[1].Value.ToLowerInvariant()
+        $actualHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $downloaded).Hash.ToLowerInvariant()
+        if ($actualHash -ne $expectedHash) {
+            throw "SHA-256 mismatch: expected $expectedHash, got $actualHash"
+        }
+        Write-Info "SHA-256 verified: $actualHash"
+    }
+    catch {
+        # Match install.sh compatibility for old releases that did not publish a
+        # checksum manifest, but never ignore a checksum mismatch once parsed.
+        if ($_.Exception.Message -match '^SHA-256 mismatch:' -or $_.Exception.Message -match '^checksums\.txt does not contain') {
+            throw
+        }
+        Write-WarningMessage "checksums.txt is unavailable; checksum verification was skipped. $($_.Exception.Message)"
+    }
+
+    # Download and verify before briefly draining existing standalone daemons.
+    $oldCli = Find-ExistingCli $target
+    $stoppedProfiles = @(Stop-ExistingDaemons $oldCli)
+    $handoffPending = ($stoppedProfiles.Count -gt 0)
+
+    if (Test-Path -LiteralPath $target) {
+        Move-Item -LiteralPath $target -Destination $targetBackup -Force
+        $targetBackedUp = $true
+    }
+    if (Test-Path -LiteralPath $alias) {
+        Move-Item -LiteralPath $alias -Destination $aliasBackup -Force
+        $aliasBackedUp = $true
+    }
+
+    Move-Item -LiteralPath $downloaded -Destination $target -Force
+    Copy-Item -LiteralPath $target -Destination $alias -Force
+
+    $installedVersionOutput = @(& $target --version 2>$null)
+    $versionExitCode = $LASTEXITCODE
+    $installedVersion = ([string] ($installedVersionOutput | Select-Object -First 1)).Trim()
+    if ($versionExitCode -ne 0 -or [string]::IsNullOrWhiteSpace($installedVersion)) {
+        throw "The executable was written, but yoooclaw --version failed."
+    }
+    if ($installedVersion -ne $resolvedVersion) {
+        throw "Installed version '$installedVersion' does not match requested version '$resolvedVersion'."
+    }
+    Add-InstallDirToPath $InstallDir
+    $installationCommitted = $true
+
+    if ($npmCliInstalled) {
+        $npmRemoved = Remove-NpmCli $npmCommand
+        if (-not $npmRemoved) {
+            Write-WarningMessage "The new native commands take precedence in PATH; the leftover npm package will not block their use."
+        }
+    }
+    Write-Info "Installed: $target"
+    Write-Info "Installed: $alias"
+    Write-Info "yoooclaw $installedVersion ready"
+
+    $activateOwner = $Activate -or ($env:YOOOCLAW_ACTIVATE_OWNER -eq "cli")
+    if ($activateOwner) {
+        Write-Info "Switching Relay owner to the standalone CLI..."
+        $ownerArgs = @("owner", "activate", "cli")
+        if (-not [string]::IsNullOrWhiteSpace($HermesProfile)) {
+            $ownerArgs += @("--hermes-profile", $HermesProfile)
+        }
+        & $target @ownerArgs
+        if ($LASTEXITCODE -ne 0) {
+            throw "The CLI was installed, but Relay owner activation failed."
+        }
+    }
+    else {
+        Restore-Daemons $target $stoppedProfiles
+        Write-Info "Current Relay owner was preserved. Use -Activate to switch it to the standalone CLI."
+    }
+
+    if (Invoke-CliQuiet $target @("daemon", "autostart", "migrate", "--format", "json")) {
+        Write-Info "Daemon login-autostart state checked."
+    }
+    else {
+        Write-WarningMessage "Could not migrate daemon login autostart; run 'yoooclaw daemon autostart enable' later."
+    }
+    $handoffPending = $false
+}
+catch {
+    if (-not $installationCommitted) {
+        if (($targetBackedUp -or -not $targetOriginallyExisted) -and (Test-Path -LiteralPath $target)) {
+            Remove-Item -LiteralPath $target -Force
+        }
+        if (($aliasBackedUp -or -not $aliasOriginallyExisted) -and (Test-Path -LiteralPath $alias)) {
+            Remove-Item -LiteralPath $alias -Force
+        }
+        if ($targetBackedUp -and (Test-Path -LiteralPath $targetBackup)) {
+            Move-Item -LiteralPath $targetBackup -Destination $target -Force
+        }
+        if ($aliasBackedUp -and (Test-Path -LiteralPath $aliasBackup)) {
+            Move-Item -LiteralPath $aliasBackup -Destination $alias -Force
+        }
+    }
+
+    if ($handoffPending -and $stoppedProfiles.Count -gt 0) {
+        Write-WarningMessage "Installation did not finish cleanly; restoring previously running CLI daemons."
+        $recoveryCli = Find-ExistingCli $target
+        if (-not [string]::IsNullOrWhiteSpace($recoveryCli)) {
+            foreach ($profile in $stoppedProfiles) {
+                if (-not (Invoke-CliQuiet $recoveryCli @("--profile", $profile, "daemon", "start"))) {
+                    Write-WarningMessage "Could not automatically restore daemon profile '$profile'."
+                }
+            }
+        }
+    }
+    throw
+}
+finally {
+    if (Test-Path -LiteralPath $tempRoot) {
+        Remove-Item -LiteralPath $tempRoot -Recurse -Force
+    }
+    if ($installationCommitted) {
+        if (Test-Path -LiteralPath $targetBackup) {
+            Remove-Item -LiteralPath $targetBackup -Force
+        }
+        if (Test-Path -LiteralPath $aliasBackup) {
+            Remove-Item -LiteralPath $aliasBackup -Force
+        }
+    }
+}
+
+Write-Host ""
+Write-Host "Installation complete. Try: yoooclaw --help" -ForegroundColor Green
+} -Version $Version -Beta:$Beta -InstallDir $InstallDir -Force:$Force -Activate:$Activate -HermesProfile $HermesProfile -NoModifyPath:$NoModifyPath -KeepNpm:$KeepNpm -BaseUrl $BaseUrl

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -9,6 +9,13 @@
 # The installer downloads the native Go executable. Node.js and npm are not
 # required, and installation is per-user by default (no administrator rights).
 
+# A script-level param block cannot be parsed by `Invoke-Expression` in Windows
+# PowerShell 5.1. Capture the automatic argument list and forward it into an
+# advanced child script block instead, which supports both `irm ... | iex` and
+# `& ([scriptblock]::Create((irm ...))) -Version ...`.
+$yoooclawInstallerArguments = @($args)
+try {
+& {
 [CmdletBinding()]
 param(
     [string] $Version = "",
@@ -22,20 +29,6 @@ param(
     # Primarily useful for mirrors and installer integration tests. The layout
     # must be <BaseUrl>/v<version>/{asset,checksums.txt} with latest/beta markers.
     [string] $BaseUrl = ""
-)
-
-& {
-[CmdletBinding()]
-param(
-    [string] $Version,
-    [switch] $Beta,
-    [string] $InstallDir,
-    [switch] $Force,
-    [switch] $Activate,
-    [string] $HermesProfile,
-    [switch] $NoModifyPath,
-    [switch] $KeepNpm,
-    [string] $BaseUrl
 )
 
 Set-StrictMode -Version 2.0
@@ -528,4 +521,8 @@ finally {
 
 Write-Host ""
 Write-Host "Installation complete. Try: yoooclaw --help" -ForegroundColor Green
-} -Version $Version -Beta:$Beta -InstallDir $InstallDir -Force:$Force -Activate:$Activate -HermesProfile $HermesProfile -NoModifyPath:$NoModifyPath -KeepNpm:$KeepNpm -BaseUrl $BaseUrl
+} @yoooclawInstallerArguments
+}
+finally {
+    Remove-Variable -Name yoooclawInstallerArguments -ErrorAction SilentlyContinue
+}

--- a/scripts/install_test.go
+++ b/scripts/install_test.go
@@ -171,6 +171,24 @@ func TestWindowsInstallScriptIsNativeAndSelfContained(t *testing.T) {
 	}
 }
 
+func TestWindowsInstallerCanRunThroughPowerShell51InvokeExpression(t *testing.T) {
+	t.Parallel()
+
+	text, err := os.ReadFile(mustAbs(t, "install.ps1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := string(text)
+	childBlockAt := strings.Index(script, "& {")
+	cmdletBindingAt := strings.Index(script, "[CmdletBinding()]")
+	if childBlockAt < 0 || cmdletBindingAt < 0 || cmdletBindingAt < childBlockAt {
+		t.Fatal("install.ps1 must keep CmdletBinding inside a child script block for Windows PowerShell 5.1 Invoke-Expression")
+	}
+	if !strings.Contains(script, "} @yoooclawInstallerArguments") {
+		t.Fatal("install.ps1 must forward script-block arguments to the child installer")
+	}
+}
+
 func TestWindowsInstallerMigratesNpmAfterNativeVerification(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/install_test.go
+++ b/scripts/install_test.go
@@ -147,6 +147,8 @@ func TestWindowsInstallScriptIsNativeAndSelfContained(t *testing.T) {
 	for _, want := range []string{
 		"yoooclaw-win32-x64.exe",
 		"Get-FileHash -Algorithm SHA256",
+		"$response.Content -is [byte[]]",
+		"[Text.Encoding]::UTF8.GetString",
 		"YoooClaw\\bin",
 		"yoooclaw.exe",
 		"yc.exe",

--- a/scripts/install_test.go
+++ b/scripts/install_test.go
@@ -136,6 +136,60 @@ func TestInstallScriptRequiresExplicitOwnerActivation(t *testing.T) {
 	}
 }
 
+func TestWindowsInstallScriptIsNativeAndSelfContained(t *testing.T) {
+	t.Parallel()
+
+	text, err := os.ReadFile(mustAbs(t, "install.ps1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := string(text)
+	for _, want := range []string{
+		"yoooclaw-win32-x64.exe",
+		"Get-FileHash -Algorithm SHA256",
+		"YoooClaw\\bin",
+		"yoooclaw.exe",
+		"yc.exe",
+		"SetEnvironmentVariable(\"Path\"",
+		"Stop-ExistingDaemons",
+		"Restore-Daemons",
+		"Find-NpmCommand",
+		"npm uninstall -g @yoooclaw/cli",
+		"KeepNpm",
+		"YOOOCLAW_ACTIVATE_OWNER",
+		"__YOOOCLAW_CLI_OSS_BASE_URL__",
+		"__YOOOCLAW_CLI_TEMPLATE_RENDERED__",
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("install.ps1 missing %q", want)
+		}
+	}
+	for _, unwanted := range []string{"npm install -g", "npm i -g", "node.exe"} {
+		if strings.Contains(strings.ToLower(script), unwanted) {
+			t.Errorf("install.ps1 unexpectedly depends on %q", unwanted)
+		}
+	}
+}
+
+func TestWindowsInstallerMigratesNpmAfterNativeVerification(t *testing.T) {
+	t.Parallel()
+
+	text, err := os.ReadFile(mustAbs(t, "install.ps1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := string(text)
+	verifiedAt := strings.Index(script, `if ($installedVersion -ne $resolvedVersion)`)
+	committedAt := strings.Index(script, `$installationCommitted = $true`)
+	removeAt := strings.Index(script, `$npmRemoved = Remove-NpmCli $npmCommand`)
+	if verifiedAt < 0 || committedAt < 0 || removeAt < 0 {
+		t.Fatalf("install.ps1 is missing npm migration ordering markers")
+	}
+	if !(verifiedAt < committedAt && committedAt < removeAt) {
+		t.Fatalf("npm cleanup must happen after native verification and commit: verify=%d commit=%d remove=%d", verifiedAt, committedAt, removeAt)
+	}
+}
+
 func TestInstallScriptUpdateRestoresRunningCLIOwner(t *testing.T) {
 	t.Parallel()
 

--- a/tools/oss-upload/main.go
+++ b/tools/oss-upload/main.go
@@ -19,11 +19,12 @@
 //
 // OSS 布局（与 hermes-plugin 一致的组织方式）：
 //
-//	<prefix>/install.sh                     渲染后的通用安装脚本（live，始终指向 OSS）
-//	<prefix>/install-wuying.sh              渲染后的无影一键安装脚本（live）
-//	<prefix>/v<ver>/yoooclaw-<os>-<arch>    原生二进制
-//	<prefix>/v<ver>/checksums.txt           sha256 清单
-//	<prefix>/v<ver>/installer/install.sh    安装脚本归档
+//	<prefix>/install.sh                         渲染后的 Unix 安装脚本（live，始终指向 OSS）
+//	<prefix>/install.ps1                        渲染后的 Windows 安装脚本（live）
+//	<prefix>/install-wuying.sh                  渲染后的无影一键安装脚本（live）
+//	<prefix>/v<ver>/yoooclaw-<os>-<arch>        原生二进制
+//	<prefix>/v<ver>/checksums.txt               sha256 清单
+//	<prefix>/v<ver>/installer/install.*         通用安装脚本归档
 //	<prefix>/v<ver>/installer/install-wuying.sh 无影安装脚本归档
 //	<prefix>/v<ver>/oss-manifest.json       本次发布清单
 //	<prefix>/latest | <prefix>/beta         渠道版本标记（纯版本号文本）
@@ -53,6 +54,7 @@ const (
 	sentinelReleaseVersion = "__YOOOCLAW_CLI_RELEASE_VERSION__"
 	rawInstallerURL        = "https://raw.githubusercontent.com/YoooClaw/cli/master/scripts/install.sh"
 	rawWuyingInstallerURL  = "https://raw.githubusercontent.com/YoooClaw/cli/master/scripts/install-wuying.sh"
+	rawInstallerPS1URL     = "https://raw.githubusercontent.com/YoooClaw/cli/master/scripts/install.ps1"
 
 	defaultBucket       = "yoooclaw-artifacts"
 	defaultPublicURL    = "https://artifact.yoooclaw.com"
@@ -181,6 +183,8 @@ func contentTypeFor(name string) string {
 		return "text/plain; charset=utf-8"
 	case strings.HasSuffix(name, ".sh"):
 		return "text/x-shellscript; charset=utf-8"
+	case strings.HasSuffix(name, ".ps1"):
+		return "text/plain; charset=utf-8"
 	case strings.HasSuffix(name, ".json"):
 		return "application/json; charset=utf-8"
 	default:
@@ -309,21 +313,22 @@ func collectArtifacts(distDir, prefix, publicURL, version string) []artifact {
 	return artifacts
 }
 
-func renderInstaller(root, installBaseURL string) []byte {
-	path := filepath.Join(root, "scripts", "install.sh")
+func renderInstaller(root, filename, installBaseURL string) []byte {
+	path := filepath.Join(root, "scripts", filename)
 	data, err := os.ReadFile(path)
 	if err != nil {
-		fatalf("读取安装脚本: %v", err)
+		fatalf("读取安装脚本 %s: %v", filename, err)
 	}
 	source := string(data)
 	for _, sentinel := range []string{sentinelBaseURL, sentinelRendered} {
 		if !strings.Contains(source, sentinel) {
-			fatalf("scripts/install.sh 缺少占位符 %s", sentinel)
+			fatalf("scripts/%s 缺少占位符 %s", filename, sentinel)
 		}
 	}
 	source = strings.ReplaceAll(source, sentinelBaseURL, installBaseURL)
 	source = strings.ReplaceAll(source, sentinelRendered, "1")
 	source = strings.ReplaceAll(source, rawInstallerURL, installBaseURL+"/install.sh")
+	source = strings.ReplaceAll(source, rawInstallerPS1URL, installBaseURL+"/install.ps1")
 	return []byte(source)
 }
 
@@ -405,11 +410,13 @@ func main() {
 	fmt.Println()
 
 	if *only == "" || *only == "install" {
-		rendered := renderInstaller(root, installBaseURL)
-		liveKey := joinKey(prefix, "install.sh")
-		archiveKey := joinKey(prefix, "v"+version, "installer", "install.sh")
-		u.put(liveKey, rendered, contentTypeFor("install.sh"), "install.sh")
-		u.put(archiveKey, rendered, contentTypeFor("install.sh"), "v"+version+"/installer/install.sh")
+		for _, filename := range []string{"install.sh", "install.ps1"} {
+			rendered := renderInstaller(root, filename, installBaseURL)
+			liveKey := joinKey(prefix, filename)
+			archiveKey := joinKey(prefix, "v"+version, "installer", filename)
+			u.put(liveKey, rendered, contentTypeFor(filename), filename)
+			u.put(archiveKey, rendered, contentTypeFor(filename), "v"+version+"/installer/"+filename)
+		}
 
 		renderedWuying := renderWuyingInstaller(root, installBaseURL, version)
 		wuyingLiveKey := joinKey(prefix, "install-wuying.sh")
@@ -435,16 +442,18 @@ func main() {
 			}
 		}
 		manifest := map[string]any{
-			"package":                   "@yoooclaw/cli",
-			"version":                   version,
-			"channel":                   channel,
-			"installScriptUrl":          urlForKey(publicURL, joinKey(prefix, "install.sh")),
-			"wuyingInstallScriptUrl":    urlForKey(publicURL, joinKey(prefix, "install-wuying.sh")),
-			"installerArchiveUrl":       urlForKey(publicURL, joinKey(prefix, "v"+version, "installer", "install.sh")),
-			"wuyingInstallerArchiveUrl": urlForKey(publicURL, joinKey(prefix, "v"+version, "installer", "install-wuying.sh")),
-			"artifactBaseUrl":           urlForKey(publicURL, joinKey(prefix, "v"+version)),
-			"checksumsUrl":              checksumsURL,
-			"artifacts":                 artifacts,
+			"package":                    "@yoooclaw/cli",
+			"version":                    version,
+			"channel":                    channel,
+			"installScriptUrl":           urlForKey(publicURL, joinKey(prefix, "install.sh")),
+			"wuyingInstallScriptUrl":     urlForKey(publicURL, joinKey(prefix, "install-wuying.sh")),
+			"installerArchiveUrl":        urlForKey(publicURL, joinKey(prefix, "v"+version, "installer", "install.sh")),
+			"wuyingInstallerArchiveUrl":  urlForKey(publicURL, joinKey(prefix, "v"+version, "installer", "install-wuying.sh")),
+			"windowsInstallScriptUrl":    urlForKey(publicURL, joinKey(prefix, "install.ps1")),
+			"windowsInstallerArchiveUrl": urlForKey(publicURL, joinKey(prefix, "v"+version, "installer", "install.ps1")),
+			"artifactBaseUrl":            urlForKey(publicURL, joinKey(prefix, "v"+version)),
+			"checksumsUrl":               checksumsURL,
+			"artifacts":                  artifacts,
 		}
 		manifestJSON, err := json.MarshalIndent(manifest, "", "  ")
 		if err != nil {
@@ -462,6 +471,7 @@ func main() {
 	fmt.Println()
 	okf("installer: %s", urlForKey(publicURL, joinKey(prefix, "install.sh")))
 	okf("wuying installer: %s", urlForKey(publicURL, joinKey(prefix, "install-wuying.sh")))
+	okf("Windows installer: %s", urlForKey(publicURL, joinKey(prefix, "install.ps1")))
 	okf("artifacts: %s/", urlForKey(publicURL, joinKey(prefix, "v"+version)))
 	okf("%s marker: %s", channel, urlForKey(publicURL, joinKey(prefix, channel)))
 	okf("OSS upload complete")

--- a/tools/oss-upload/main_test.go
+++ b/tools/oss-upload/main_test.go
@@ -41,3 +41,41 @@ func TestRenderWuyingInstallerUsesOSSBase(t *testing.T) {
 		}
 	}
 }
+
+func TestPowerShellInstallerContentType(t *testing.T) {
+	t.Parallel()
+	if got := contentTypeFor("install.ps1"); got != "text/plain; charset=utf-8" {
+		t.Fatalf("contentTypeFor(install.ps1) = %q", got)
+	}
+}
+
+func TestRenderPowerShellInstaller(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	scriptsDir := filepath.Join(root, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	source := strings.Join([]string{
+		`$Base = "` + sentinelBaseURL + `"`,
+		`$Rendered = "` + sentinelRendered + `"`,
+		`$Source = "` + rawInstallerPS1URL + `"`,
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(scriptsDir, "install.ps1"), []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	baseURL := "https://example.test/cli"
+	rendered := string(renderInstaller(root, "install.ps1", baseURL))
+	for _, want := range []string{`$Base = "` + baseURL + `"`, `$Rendered = "1"`, baseURL + "/install.ps1"} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("rendered installer missing %q:\n%s", want, rendered)
+		}
+	}
+	for _, unwanted := range []string{sentinelBaseURL, sentinelRendered, rawInstallerPS1URL} {
+		if strings.Contains(rendered, unwanted) {
+			t.Errorf("rendered installer still contains %q:\n%s", unwanted, rendered)
+		}
+	}
+}


### PR DESCRIPTION
## 背景

Windows 用户目前通过 npm 安装 CLI 时必须先安装 Node.js。CLI 实际已经是 Go 原生二进制，因此补充 PowerShell 一键安装渠道，直接分发与 npm 平台包一致的 Windows x64 可执行文件。

## 主要改动

- 新增 Windows PowerShell 5.1+ 一键安装器，无需 Node/npm 和管理员权限
- 默认安装到当前用户 LOCALAPPDATA 下的 YoooClaw/bin，并配置用户 PATH
- 同时提供 yoooclaw.exe 与 yc.exe
- 下载后校验 SHA-256，支持版本锁定、beta、覆盖升级和自定义目录
- 升级时保留 Relay owner，并安全停止、恢复已有 daemon
- 检测旧版全局 npm 安装；新原生版验证通过后再自动卸载旧包，可用 KeepNpm 保留
- update self 在 Windows 原生安装场景返回 PowerShell 升级命令
- OSS 发布流程同时上传 Unix、Windows、无影三种安装器，并写入 manifest
- 发布通知补充 Windows 安装命令
- README 中英文及 npm 包说明同步更新

## 验证

- go test ./...
- go vet ./...
- tools/oss-upload 单测与 vet
- Windows amd64 交叉编译，产物确认为 PE32+ x86-64
- install.sh 与 install-wuying.sh 语法检查
- OSS 三安装器渲染 dry-run
- GitHub Actions YAML 解析与 diff 检查
- 新增 Windows PowerShell 5.1 CI 冒烟测试：本地构建制品、校验下载、一键安装、双命令验证及旧 npm 包迁移

## 发布建议

合入 release/0.10.0 后先发布 0.10.0-beta.2，在 Windows 实机验证安装、npm 迁移和 daemon 恢复，再进入稳定版。