### PR TITLE
fix(recording): 修复 WorkBuddy 录音音频同步状态无法结束

### DIFF
--- a/internal/daemon/server_ingest.go
+++ b/internal/daemon/server_ingest.go
@@ -320,6 +320,7 @@ func recordingDetail(entry recording.Entry) map[string]any {
 		"oss_srt_url":        nilIfEmptyStr(entry.Metadata.OssSrtURL),
 		"markers":            entry.Metadata.Markers,
 		"transfer_status":    entry.Status,
+		"audio_status":       entry.AudioStatus,
 		"audioFile":          nilIfEmptyStr(entry.AudioFile),
 		"srtFile":            nilIfEmptyStr(entry.SrtFile),
 		"transcriptDataFile": nilIfEmptyStr(entry.TranscriptDataFile),

--- a/internal/daemon/server_recording_status_test.go
+++ b/internal/daemon/server_recording_status_test.go
@@ -1,0 +1,86 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/YoooClaw/cli/internal/recording"
+)
+
+type recordingStatusCapture struct {
+	events chan recording.StatusEvent
+}
+
+func (c *recordingStatusCapture) PushEvent(event string, payload any) error {
+	return c.capture(event, payload)
+}
+
+func (c *recordingStatusCapture) PushEventTo(_ string, event string, payload any) error {
+	return c.capture(event, payload)
+}
+
+func (c *recordingStatusCapture) capture(event string, payload any) error {
+	status, ok := payload.(recording.StatusEvent)
+	if event == "recording.status" && ok {
+		c.events <- status
+	}
+	return nil
+}
+
+func TestRecordingStatusMatchesDownloadedEvent(t *testing.T) {
+	srv, ts := newTestServer(t, "")
+	storage := withRecordings(t, srv)
+	capture := &recordingStatusCapture{events: make(chan recording.StatusEvent, 4)}
+	srv.egress = capture
+
+	audio := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("recording-audio"))
+	}))
+	t.Cleanup(audio.Close)
+
+	const recordingID = "rec_audio_status"
+	body, err := json.Marshal(map[string]any{
+		"recordingId": recordingID,
+		"ossUrl":      audio.URL + "/recording.ogg",
+		"transcript":  map[string]any{"text": "测试转录"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeResp := asClient(t, http.MethodPost, ts.URL+"/gateway/recordings.result.write", "phone-a", string(body))
+	if ok, _ := writeResp["ok"].(bool); !ok {
+		t.Fatalf("result.write failed: %+v", writeResp)
+	}
+
+	var downloaded recording.StatusEvent
+	timer := time.NewTimer(3 * time.Second)
+	defer timer.Stop()
+	for downloaded.AudioStatus != recording.AudioStatusDownloaded {
+		select {
+		case downloaded = <-capture.events:
+		case <-timer.C:
+			t.Fatal("timed out waiting for downloaded recording.status event")
+		}
+	}
+
+	statusResp := asClient(t, http.MethodPost, ts.URL+"/gateway/recordings.status", "phone-a",
+		`{"recordingId":"`+recordingID+`"}`)
+	status := gatewayData(t, statusResp)
+	for key, want := range map[string]any{
+		"audio_status": downloaded.AudioStatus,
+		"audioFile":    downloaded.AudioFile,
+		"updatedAt":    downloaded.UpdatedAt,
+	} {
+		if got := status[key]; got != want {
+			t.Errorf("recordings.status %s = %v, want event value %v; response=%+v", key, got, want, status)
+		}
+	}
+
+	entry, ok := storage.FindByID(recordingID)
+	if !ok || entry.AudioStatus != recording.AudioStatusDownloaded {
+		t.Fatalf("recording was not persisted as downloaded: %+v", entry)
+	}
+}


### PR DESCRIPTION
## 问题背景

Android 1.15.0 通过 WorkBuddy/CLI Relay 路由同步长录音时，关闭自动转写后，音频会持续显示“音频同步中”。

运行时证据显示：

- recordings.result.write 已成功受理；
- recording.status 事件已返回 audio_status=downloaded、有效 audioFile 和 updatedAt；
- App 随即查询同一录音的 recordings.status，但响应只有 audioFile，没有 audio_status；
- 后续多次轮询结果一致，Android 读取到 audioStatus=null，无法结束同步状态。

录音实际已经下载并落盘，因此这不是 OSS 上传、音频下载或 result.write 失败。

## 根因

recordings.status 使用 recordingDetail() 生成响应。录音列表和 recording.status 推送事件均包含 audio_status，但 recordingDetail() 漏掉了该字段，造成同一份持久化状态在事件与查询接口中的映射不一致。

关闭自动转写后，Android 必须同时确认 audio_status=downloaded 和 audioFile 非空，避免把上一轮残留文件误判为本轮同步成功，因此不能仅依赖 audioFile 兜底。

## 本次修改

- recordings.status 始终返回持久化的 audio_status；
- 保持现有 audioFile、updatedAt 等字段不变；
- 仅增加响应字段，不改变原有协议行为，也不引入其他 audio-only 功能分支改动。

## 回归测试

新增完整链路测试：

1. 通过 recordings.result.write 写入录音并触发音频下载；
2. 等待 recording.status 的 downloaded 事件；
3. 立即查询同一条 recordings.status；
4. 断言 audio_status、audioFile、updatedAt 与事件完全一致。

## 验证

- go test ./...
- go test -race ./internal/daemon
- go vet ./...
- git diff --check