### PR TITLE
fix: 修复 Windows 原生版卸载后 EXE 残留

### DIFF
--- a/internal/cli/cmd_uninstall.go
+++ b/internal/cli/cmd_uninstall.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"os"
-	"path/filepath"
 
 	"github.com/YoooClaw/cli/internal/clictx"
 	"github.com/YoooClaw/cli/internal/daemon"
@@ -65,18 +64,24 @@ func uninstall(_ *clictx.Context, cmd *cobra.Command, _ []string) (any, error) {
 	}
 	removed = append(autostartRemoved, removed...)
 
-	// 3. 删二进制（npm 安装无法自删，给提示）。
-	binRemoved, hint := removeSelfBinary()
+	// 3. 删二进制（npm 安装无法自删，给提示；Windows 在当前进程退出后删除）。
+	binaryRemoval, err := removeSelfBinary()
+	if err != nil {
+		return nil, errs.New(errs.CodeStorageUnavailable, "删除 CLI 二进制失败："+err.Error())
+	}
 
 	result := map[string]any{
 		"ok":             true,
 		"daemonsStopped": stopped,
 		"removed":        removed,
-		"binaryRemoved":  binRemoved,
+		"binaryRemoved":  binaryRemoval.Removed,
 		"dataKept":       !withData,
 	}
-	if hint != "" {
-		result["hint"] = hint
+	if len(binaryRemoval.Scheduled) > 0 {
+		result["binaryRemovalScheduled"] = binaryRemoval.Scheduled
+	}
+	if binaryRemoval.Hint != "" {
+		result["hint"] = binaryRemoval.Hint
 	}
 	return result, nil
 }
@@ -125,40 +130,28 @@ func removeConfigKeepData() []string {
 	return removed
 }
 
-// removeSelfBinary 删除当前可执行文件及同目录下的 yc / yoooclaw 软链。
-// npm 安装由 node_modules 托管，不自删，返回卸载提示。
-func removeSelfBinary() (removed []string, hint string) {
-	removed = []string{}
+type binaryRemovalResult struct {
+	Removed   []string
+	Scheduled []string
+	Hint      string
+}
+
+// removeSelfBinary 删除当前可执行文件及同目录下的命令别名。
+// npm 安装由 node_modules 托管，不自删；Windows 原生安装则安排在当前
+// 进程退出后删除，避免删除正在运行的 .exe 被系统拒绝。
+func removeSelfBinary() (binaryRemovalResult, error) {
 	if version.Dist() == "npm" {
-		return removed, "npm 安装：请运行 `npm uninstall -g @yoooclaw/cli` 移除二进制"
+		return binaryRemovalResult{
+			Removed: []string{},
+			Hint:    "npm 安装：请运行 `npm uninstall -g @yoooclaw/cli` 移除二进制",
+		}, nil
 	}
 	exe, err := os.Executable()
 	if err != nil {
-		return removed, "无法定位可执行文件，请手动删除二进制"
+		return binaryRemovalResult{
+			Removed: []string{},
+			Hint:    "无法定位可执行文件，请手动删除二进制",
+		}, nil
 	}
-	real := exe
-	if r, e := filepath.EvalSymlinks(exe); e == nil {
-		real = r
-	}
-	dir := filepath.Dir(real)
-	candidates := []string{real, exe, filepath.Join(dir, "yc"), filepath.Join(dir, "yoooclaw")}
-	seen := map[string]bool{}
-	for _, c := range candidates {
-		if c == "" || seen[c] {
-			continue
-		}
-		seen[c] = true
-		// 只删我们认得的文件名（native 安装为 yoooclaw + yc 软链），
-		// 避免可执行文件被改名/嵌套时误删无关文件。
-		if base := filepath.Base(c); base != "yc" && base != "yoooclaw" {
-			continue
-		}
-		if _, e := os.Lstat(c); e != nil {
-			continue
-		}
-		if os.Remove(c) == nil {
-			removed = append(removed, c)
-		}
-	}
-	return removed, ""
+	return removeNativeSelfBinary(exe)
 }

--- a/internal/cli/self_remove_unix.go
+++ b/internal/cli/self_remove_unix.go
@@ -1,0 +1,42 @@
+//go:build !windows
+
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+func removeNativeSelfBinary(exe string) (binaryRemovalResult, error) {
+	result := binaryRemovalResult{Removed: []string{}}
+	real := exe
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		real = resolved
+	}
+	dir := filepath.Dir(real)
+	candidates := []string{real, exe, filepath.Join(dir, "yc"), filepath.Join(dir, "yoooclaw")}
+	seen := map[string]bool{}
+	for _, candidate := range candidates {
+		if candidate == "" || seen[candidate] {
+			continue
+		}
+		seen[candidate] = true
+		// 只删 native 安装器创建的文件名，避免可执行文件被改名或嵌套时
+		// 误删无关文件。
+		if base := filepath.Base(candidate); base != "yc" && base != "yoooclaw" {
+			continue
+		}
+		if _, err := os.Lstat(candidate); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return result, err
+		}
+		if err := os.Remove(candidate); err != nil {
+			return result, err
+		}
+		result.Removed = append(result.Removed, candidate)
+	}
+	return result, nil
+}

--- a/internal/cli/self_remove_windows.go
+++ b/internal/cli/self_remove_windows.go
@@ -1,0 +1,93 @@
+//go:build windows
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+const (
+	windowsCreateNewProcessGroup = 0x00000200
+	windowsDetachedProcess       = 0x00000008
+	windowsCreateBreakaway       = 0x01000000
+)
+
+func removeNativeSelfBinary(exe string) (binaryRemovalResult, error) {
+	result := binaryRemovalResult{Removed: []string{}, Scheduled: []string{}}
+	if !isWindowsNativeBinary(exe) {
+		result.Hint = "当前可执行文件不是 yoooclaw.exe 或 yc.exe，请手动删除二进制"
+		return result, nil
+	}
+
+	dir := filepath.Dir(exe)
+	candidates := []string{
+		exe,
+		filepath.Join(dir, "yoooclaw.exe"),
+		filepath.Join(dir, "yc.exe"),
+	}
+	seen := map[string]bool{}
+	for _, candidate := range candidates {
+		cleaned := filepath.Clean(candidate)
+		key := strings.ToLower(cleaned)
+		if seen[key] || !isWindowsNativeBinary(cleaned) {
+			continue
+		}
+		seen[key] = true
+		if _, err := os.Lstat(cleaned); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return result, err
+		}
+		result.Scheduled = append(result.Scheduled, cleaned)
+	}
+	if len(result.Scheduled) == 0 {
+		return result, nil
+	}
+
+	encoded := encodePowerShellCommand(windowsRemovalScript(os.Getpid(), result.Scheduled))
+	if err := startWindowsRemovalHelper(encoded, true); err != nil {
+		// 某些 Agent 会把 CLI 放进不允许 breakaway 的 Job Object；这种情况
+		// 回退到普通 detached 子进程，至少覆盖常规终端和安装器环境。
+		if fallbackErr := startWindowsRemovalHelper(encoded, false); fallbackErr != nil {
+			return result, fmt.Errorf("启动退出后删除任务失败：%v；回退重试失败：%w", err, fallbackErr)
+		}
+	}
+	result.Hint = "Windows 已安排在当前命令退出后删除 CLI 二进制"
+	return result, nil
+}
+
+func isWindowsNativeBinary(path string) bool {
+	base := strings.ToLower(filepath.Base(path))
+	return base == "yoooclaw.exe" || base == "yc.exe"
+}
+
+func startWindowsRemovalHelper(encodedCommand string, breakaway bool) error {
+	flags := uint32(windowsCreateNewProcessGroup | windowsDetachedProcess)
+	if breakaway {
+		flags |= windowsCreateBreakaway
+	}
+	cmd := exec.Command(
+		"powershell.exe",
+		"-NoLogo",
+		"-NoProfile",
+		"-NonInteractive",
+		"-WindowStyle", "Hidden",
+		"-EncodedCommand", encodedCommand,
+	)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow:    true,
+		CreationFlags: flags,
+	}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	_ = cmd.Process.Release()
+	return nil
+}

--- a/internal/cli/self_remove_windows_command.go
+++ b/internal/cli/self_remove_windows_command.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"strconv"
+	"strings"
+	"unicode/utf16"
+)
+
+// windowsRemovalScript 等待当前 CLI 退出，再重试删除 yoooclaw.exe 和
+// yc.exe。使用 LiteralPath 和单引号转义，避免安装路径中的 PowerShell
+// 特殊字符被解释。
+func windowsRemovalScript(parentPID int, paths []string) string {
+	quoted := make([]string, 0, len(paths))
+	for _, path := range paths {
+		quoted = append(quoted, "'"+strings.ReplaceAll(path, "'", "''")+"'")
+	}
+	return strings.Join([]string{
+		"$ErrorActionPreference = 'SilentlyContinue'",
+		"$paths = @(" + strings.Join(quoted, ", ") + ")",
+		"try { Wait-Process -Id " + strconv.Itoa(parentPID) + " -ErrorAction SilentlyContinue } catch {}",
+		"$deadline = [DateTime]::UtcNow.AddSeconds(30)",
+		"do {",
+		"  $remaining = $false",
+		"  foreach ($path in $paths) {",
+		"    if (Test-Path -LiteralPath $path) {",
+		"      Remove-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue",
+		"      if (Test-Path -LiteralPath $path) { $remaining = $true }",
+		"    }",
+		"  }",
+		"  if ($remaining) { Start-Sleep -Milliseconds 200 }",
+		"} while ($remaining -and [DateTime]::UtcNow -lt $deadline)",
+	}, "\r\n")
+}
+
+// encodePowerShellCommand 按 powershell.exe -EncodedCommand 要求编码为
+// UTF-16LE 后再做 Base64。
+func encodePowerShellCommand(script string) string {
+	encoded := utf16.Encode([]rune(script))
+	bytes := make([]byte, len(encoded)*2)
+	for i, value := range encoded {
+		binary.LittleEndian.PutUint16(bytes[i*2:], value)
+	}
+	return base64.StdEncoding.EncodeToString(bytes)
+}

--- a/internal/cli/self_remove_windows_command_test.go
+++ b/internal/cli/self_remove_windows_command_test.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"strings"
+	"testing"
+	"unicode/utf16"
+)
+
+func TestWindowsRemovalScriptWaitsAndRemovesBothBinaries(t *testing.T) {
+	t.Parallel()
+
+	script := windowsRemovalScript(1234, []string{
+		`C:\Users\O'Brien\YoooClaw\bin\yoooclaw.exe`,
+		`C:\Users\O'Brien\YoooClaw\bin\yc.exe`,
+	})
+	for _, want := range []string{
+		"Wait-Process -Id 1234",
+		`'C:\Users\O''Brien\YoooClaw\bin\yoooclaw.exe'`,
+		`'C:\Users\O''Brien\YoooClaw\bin\yc.exe'`,
+		"Remove-Item -LiteralPath $path -Force",
+		"AddSeconds(30)",
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("windowsRemovalScript() missing %q\n%s", want, script)
+		}
+	}
+}
+
+func TestEncodePowerShellCommandUsesUTF16LE(t *testing.T) {
+	t.Parallel()
+
+	want := "路径 with spaces"
+	raw, err := base64.StdEncoding.DecodeString(encodePowerShellCommand(want))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(raw)%2 != 0 {
+		t.Fatalf("encoded command has odd UTF-16 byte count: %d", len(raw))
+	}
+	units := make([]uint16, len(raw)/2)
+	for i := range units {
+		units[i] = binary.LittleEndian.Uint16(raw[i*2:])
+	}
+	if got := string(utf16.Decode(units)); got != want {
+		t.Fatalf("decoded command = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## 背景

客户在 Windows 使用原生安装的 CLI 执行 `yoooclaw uninstall --yes` 后，发现已安装的 EXE 仍然存在，卸载没有真正完成。

根因有两点：

1. 原卸载逻辑只识别 `yoooclaw` 和 `yc`，未识别 Windows 安装器生成的 `yoooclaw.exe` 与 `yc.exe`。
2. 即使识别到文件，Windows 也不允许当前正在运行的进程同步删除自身；原逻辑还会忽略删除失败，最终返回 `ok=true`，造成卸载成功的假象。

## 本次修改

- 按平台拆分原生二进制删除逻辑，保持 Unix 原有同步删除行为。
- Windows 下识别并处理同目录中的 `yoooclaw.exe` 和 `yc.exe`。
- 启动隐藏、脱离当前 CLI 的 PowerShell helper：
  - 等待当前卸载命令退出；
  - 在 30 秒内重试删除两个 EXE；
  - 优先脱离调用方 Job Object，失败时回退为普通 detached 子进程，兼容 Agent 和普通终端环境。
- 卸载结果通过 `binaryRemovalScheduled` 明确表示文件已安排在进程退出后删除，避免误报为已同步删除。
- helper 无法启动时返回 `YOOOCLAW_STORAGE_UNAVAILABLE`，不再静默成功。
- npm 安装方式的卸载提示保持不变。

## 兼容性说明

本次修改只改变 Windows 原生版的自删除方式，不影响现有 `yoooclaw update self` 和 `install.ps1 -Version <version> -Force` 升级链路。

## 验证

- `go test ./...`
- `GOOS=windows GOARCH=amd64 go test -c ./internal/cli`
- `GOOS=windows GOARCH=amd64 go build ./cmd/yc`
- 新增 PowerShell 路径转义、父进程等待、双 EXE 删除及 UTF-16LE `EncodedCommand` 编码测试。