### PR TITLE
fix(windows): 隐藏自启动计划任务操作的临时黑框

### DIFF
--- a/internal/autostart/manager_windows.go
+++ b/internal/autostart/manager_windows.go
@@ -47,6 +47,12 @@ var taskSchedulerCOM = func(action string, args ...string) ([]byte, error) {
 	}
 	script = `$utf8=New-Object Text.UTF8Encoding $false; [Console]::OutputEncoding=$utf8; $OutputEncoding=$utf8; ` + script
 	cmd := exec.Command("powershell.exe", "-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script)
+	// Agent hosts may have no console. Prevent Windows from creating one for
+	// each short-lived helper, while preserving CombinedOutput's output pipes.
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow:    true,
+		CreationFlags: windowsCreateNoWindow,
+	}
 	cmd.Env = append(os.Environ(), "YOOOCLAW_TASK_SCHEDULER_ARGS="+string(payload))
 	return cmd.CombinedOutput()
 }
@@ -64,7 +70,10 @@ var taskSchedulerScripts = map[string]string{
 	"delete":  `$ErrorActionPreference='Stop'; $a=ConvertFrom-Json $env:YOOOCLAW_TASK_SCHEDULER_ARGS; $s=New-Object -ComObject 'Schedule.Service'; $s.Connect(); $s.GetFolder($a[0]).DeleteTask($a[1],0); 'ok'`,
 }
 
-const windowsTaskStateRunning = 4
+const (
+	windowsTaskStateRunning = 4
+	windowsCreateNoWindow   = 0x08000000 // CREATE_NO_WINDOW
+)
 
 func (m *platformManager) folderAndName() (string, string) {
 	trimmed := strings.Trim(m.task, `\`)


### PR DESCRIPTION
## 问题

Windows 用户执行 `yoooclaw daemon autostart enable --format json` 时反馈会出现临时黑框，约 10 秒内自动关闭。daemon 已通过隐藏启动器运行，但计划任务的查询、注册、启动等操作仍会创建未显式隐藏的 PowerShell 辅助进程，从无控制台的 Agent 宿主执行时可能弹出窗口。

## 修改

在 Windows 计划任务 COM 操作的统一入口，为 PowerShell 辅助进程设置 `HideWindow=true` 和 `CREATE_NO_WINDOW`，从进程创建阶段避免辅助控制台弹窗。覆盖自启动检查、注册、查询、启动、停止和删除操作。

仅修改 Windows 辅助进程的窗口属性。计划任务与 daemon 生命周期逻辑保持原样，标准输出、错误输出和退出码继续由 `CombinedOutput` 收集；不影响 macOS/Linux。

## 验证

- `go test ./internal/autostart` 通过。
- Windows amd64 目标的 `internal/autostart` 测试编译通过。
- Windows amd64 目标的 `go vet ./internal/autostart` 和 CLI 编译通过。
- `git diff --check` 通过。

当前验证环境为 macOS，尚未执行 Windows 实机测试。实机验收需确认：从 Agent 执行自启动命令后不再出现临时黑框，命令仍正常返回，daemon 与隧道状态正常。
