### PR TITLE
cli-0.10.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,10 @@ yoooclaw config init --no-autostart  # start now without enabling autostart
 Autostart always follows the active profile. `profile use` transfers a running
 daemon to the new profile while preserving a manually stopped state. On Linux,
 autostart begins with the user service manager; enabling pre-login boot via
-`loginctl enable-linger` remains an explicit system-administration choice.
+`yoooclaw daemon autostart enable --boot` explicitly enables linger for the current OS user.
+`daemon autostart status` reports `linger`, `unitEnabled`, `bootEnabled` and any
+`bootWarning`; `doctor` warns when pre-login startup is unavailable. Disabling
+autostart does not disable linger, which may be used by other user services.
 Upgrades from releases without an autostart preference register the initialized
 active profile even if its daemon was stopped during the upgrade. An explicit
 `autostart disable` preference and a live Hermes owner are always preserved.
@@ -501,3 +504,16 @@ All release artifacts are generated from the Go source via `scripts/build-go.sh`
 ## License
 
 MIT — see [LICENSE](LICENSE).
+
+### Linux startup and credential reload diagnostics
+
+Run `yoooclaw daemon logs --diagnostics --lines 100` to collect daemon and supervisor
+logs, lock/process identity, autostart state, and the Linux service journal for this
+boot. Use the installed executable's absolute path if it is absent from PATH.
+`service.entry` / `daemon.ready` identify the version, PID, profile and paths;
+`status.observed` / `reload.request` explain stale locks and compare systemd state.
+`credentials.reload_applied` records credential sources, labels, short SHA-256
+fingerprints and tunnel changes without logging keys or tokens. Applying credentials
+does not confirm a connection: look for the subsequent `connected` or 401/403 logs.
+If no `service.entry` exists, inspect the collected systemd/journal records: an
+application cannot log before the OS has launched it.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -238,7 +238,9 @@ yoooclaw config init --no-autostart  # 当前启动，但不开启自启
 
 自启服务始终跟随 active profile；`profile use` 会在 profile 间转移正在运行的
 daemon，但会保留用户手动 stop 后的停止状态。Linux 默认随用户服务管理器启动；是否
-通过 `loginctl enable-linger` 扩展为登录前启动，仍由系统管理员显式决定。
+通过 `yoooclaw daemon autostart enable --boot` 显式开启当前系统用户的 linger，支持无人登录时开机启动。
+`daemon autostart status` 会显示 `linger`、`unitEnabled`、`bootEnabled` 和 `bootWarning`，
+`doctor` 会提示未具备开机自启条件。关闭本应用自启不会关闭 linger，以免影响其他用户服务。
 从尚无自启偏好的旧版本升级时，即使 daemon 当时处于停止状态，也会为已初始化的
 active profile 注册自启；用户明确执行过 `autostart disable` 或 Hermes 正在持有
 owner 时不会被覆盖。
@@ -496,3 +498,17 @@ dist-native/yoooclaw-darwin-arm64 --help
 ## License
 
 MIT —— 见 [LICENSE](LICENSE)。
+
+### Linux 自启与凭据重载诊断
+
+运行 `yoooclaw daemon logs --diagnostics --lines 100` 一次汇总 daemon 日志、
+`daemon-supervisor.log`、锁文件/进程身份、自启状态及 Linux 本次启动的服务 journal。
+CLI 不在 PATH 时使用 `/usr/local/bin/yoooclaw` 等实际安装路径。
+
+`service.entry` / `daemon.ready` 标明版本、PID、profile、配置路径及实际监听端口；
+`status.observed` / `reload.request` 对照系统服务状态，并区分锁不存在、无法读取、
+进程死亡、可执行文件不匹配和命令行不匹配；`systemd.command_begin/end` 记录服务操作及失败原因。
+`credentials.reload_applied` 记录重载前后的来源、label、脱敏 SHA-256 指纹和隧道增删重启结果。
+它只代表本地配置已应用，连接成功需随后出现 `connected`；401/403 会单独提示服务端鉴权拒绝。
+日志不输出完整 key、gateway token 或凭据文件内容。若连 `service.entry` 都没有，优先检查汇总中的
+systemd/journal；应用进程尚未运行时无法自行写启动日志。

--- a/internal/autostart/autostart.go
+++ b/internal/autostart/autostart.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/YoooClaw/cli/internal/diagnostics"
 	"github.com/YoooClaw/cli/internal/fsutil"
 )
 
@@ -30,13 +31,16 @@ type Spec struct {
 
 // Status is the normalized state returned by every platform manager.
 type Status struct {
-	Manager    string `json:"manager"`
-	Unit       string `json:"unit"`
-	Installed  bool   `json:"installed"`
-	Loaded     bool   `json:"loaded"`
-	Running    bool   `json:"running"`
-	PID        int    `json:"pid,omitempty"`
-	Executable string `json:"executable,omitempty"`
+	Manager     string `json:"manager"`
+	Unit        string `json:"unit"`
+	Installed   bool   `json:"installed"`
+	Loaded      bool   `json:"loaded"`
+	Running     bool   `json:"running"`
+	PID         int    `json:"pid,omitempty"`
+	Linger      *bool  `json:"linger,omitempty"`
+	UnitEnabled *bool  `json:"unitEnabled,omitempty"`
+	BootWarning string `json:"bootWarning,omitempty"`
+	Executable  string `json:"executable,omitempty"`
 }
 
 // State records user intent independently of transient OS service state.
@@ -77,7 +81,15 @@ func writeState(root string, state State) error {
 }
 
 // Enable installs the service, persists intent, and optionally starts it now.
-func Enable(m Manager, spec Spec, start bool) (Status, error) {
+func Enable(m Manager, spec Spec, start bool) (result Status, enableErr error) {
+	began := time.Now()
+	defer func() {
+		level := "info"
+		if enableErr != nil {
+			level = "error"
+		}
+		diagnostics.Write(spec.RootDir, level, "autostart.enable_result", map[string]any{"startRequested": start, "status": result, "error": diagnostics.SafeError(enableErr), "elapsedMs": time.Since(began).Milliseconds()})
+	}()
 	if err := m.Available(); err != nil {
 		return Status{}, err
 	}
@@ -103,7 +115,14 @@ func Enable(m Manager, spec Spec, start bool) (Status, error) {
 }
 
 // Disable removes the service, then persists the explicit opt-out.
-func Disable(m Manager, root string) (Status, error) {
+func Disable(m Manager, root string) (result Status, disableErr error) {
+	defer func() {
+		level := "info"
+		if disableErr != nil {
+			level = "error"
+		}
+		diagnostics.Write(root, level, "autostart.disable_result", map[string]any{"status": result, "error": diagnostics.SafeError(disableErr)})
+	}()
 	if err := m.Available(); err != nil {
 		status, _ := m.Status()
 		if status.Installed || status.Loaded {
@@ -220,4 +239,15 @@ func waitForServiceStateWithin(status func() (Status, error), done func(Status) 
 		}
 		time.Sleep(serviceStatePollInterval)
 	}
+}
+
+// EnableBoot explicitly opts the current OS user into pre-login startup.
+// Linger belongs to the user, so disabling this application's service must not
+// undo it and disrupt other user services.
+func EnableBoot(m Manager) error {
+	boot, ok := m.(interface{ EnableBoot() error })
+	if !ok {
+		return errors.New("--boot 仅支持 Linux systemd 用户服务")
+	}
+	return boot.EnableBoot()
 }

--- a/internal/autostart/manager_linux.go
+++ b/internal/autostart/manager_linux.go
@@ -10,7 +10,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/YoooClaw/cli/internal/diagnostics"
 	"github.com/YoooClaw/cli/internal/fsutil"
+	"time"
 )
 
 type platformManager struct{ root, id, unit, path string }
@@ -24,6 +26,50 @@ func newPlatformManager(root string) Manager {
 	}
 	unit := id + ".service"
 	return &platformManager{root: root, id: id, unit: unit, path: filepath.Join(configHome, "systemd", "user", unit)}
+}
+
+var loginctl = func(args ...string) ([]byte, error) {
+	return exec.Command("loginctl", append([]string{"--no-ask-password"}, args...)...).CombinedOutput()
+}
+
+func readLinger() (*bool, error) {
+	out, err := loginctl("show-user", strconv.Itoa(os.Getuid()), "--property=Linger", "--value")
+	if err != nil {
+		return nil, fmt.Errorf("无法查询 linger: %s (%v)", strings.TrimSpace(string(out)), err)
+	}
+	value := strings.TrimSpace(string(out))
+	if value != "yes" && value != "no" {
+		return nil, fmt.Errorf("无法识别 linger 状态: %q", value)
+	}
+	enabled := value == "yes"
+	return &enabled, nil
+}
+
+func (m *platformManager) EnableBoot() (bootErr error) {
+	defer func() {
+		linger, err := readLinger()
+		fields := map[string]any{"uid": os.Getuid(), "unit": m.unit, "linger": linger, "error": diagnostics.SafeError(bootErr), "queryError": diagnostics.SafeError(err)}
+		level := "info"
+		if bootErr != nil {
+			level = "error"
+		}
+		diagnostics.Write(m.root, level, "autostart.boot", fields)
+	}()
+	if linger, err := readLinger(); err == nil && *linger {
+		return nil
+	}
+	uid := strconv.Itoa(os.Getuid())
+	if out, err := loginctl("enable-linger", uid); err != nil {
+		return fmt.Errorf("无法启用开机自启: %s (%v)；请管理员执行 loginctl enable-linger %s", strings.TrimSpace(string(out)), err, uid)
+	}
+	linger, err := readLinger()
+	if err != nil {
+		return err
+	}
+	if !*linger {
+		return fmt.Errorf("enable-linger 后仍未启用开机自启")
+	}
+	return nil
 }
 
 var systemctl = func(args ...string) ([]byte, error) {
@@ -43,6 +89,22 @@ func (m *platformManager) Status() (Status, error) {
 	status := Status{Manager: "systemd", Unit: m.unit}
 	if _, err := os.Stat(m.path); err == nil {
 		status.Installed = true
+	}
+	if status.Installed {
+		enabledOut, _ := systemctl("is-enabled", m.unit)
+		enabled := strings.TrimSpace(string(enabledOut)) == "enabled"
+		status.UnitEnabled = &enabled
+		linger, err := readLinger()
+		status.Linger = linger
+		switch {
+		case err != nil:
+			status.BootWarning = err.Error()
+		case !*linger:
+			status.BootWarning = "未启用 linger，仅配置用户登录自启；无人登录开机启动请运行 yoooclaw daemon autostart enable --boot"
+		}
+		if !enabled {
+			status.BootWarning = "系统服务未 enable；请运行 yoooclaw daemon autostart enable"
+		}
 	}
 	out, commandErr := systemctl("show", m.unit, "--property=LoadState,ActiveState,MainPID")
 	loadState := ""
@@ -101,30 +163,51 @@ Environment=` + systemdQuote("YOOOCLAW_HOME="+spec.RootDir) + `
 ExecStart=` + strings.Join(args, " ") + `
 Restart=on-failure
 RestartSec=5
-StandardOutput=` + systemdQuote("append:"+spec.SupervisorLog) + `
-StandardError=` + systemdQuote("append:"+spec.SupervisorLog) + `
+StandardOutput=append:` + strings.ReplaceAll(spec.SupervisorLog, "%", "%%") + `
+StandardError=append:` + strings.ReplaceAll(spec.SupervisorLog, "%", "%%") + `
 
 [Install]
 WantedBy=default.target
 `
 }
+func (m *platformManager) command(args ...string) ([]byte, error) {
+	began := time.Now()
+	diagnostics.Write(m.root, "info", "systemd.command_begin", map[string]any{"args": args, "uid": os.Getuid(), "unit": m.unit})
+	out, err := systemctl(args...)
+	fields := map[string]any{"args": args, "uid": os.Getuid(), "unit": m.unit, "elapsedMs": time.Since(began).Milliseconds(), "success": err == nil}
+	level := "info"
+	if err != nil {
+		level = "error"
+		fields["error"] = diagnostics.SafeError(err)
+		fields["output"] = diagnostics.SafeError(fmt.Errorf("%s", out))
+	}
+	diagnostics.Write(m.root, level, "systemd.command_end", fields)
+	return out, err
+}
+
 func (m *platformManager) Install(spec Spec) error {
+	diagnostics.Write(m.root, "info", "autostart.install", map[string]any{"unit": m.unit, "unitPath": m.path, "executable": spec.Executable, "root": spec.RootDir, "supervisorLog": spec.SupervisorLog})
+	// Output paths are raw scalar values, not ExecStart word lists. Reject
+	// line breaks instead of quoting them (quotes break the append: parser).
+	if !filepath.IsAbs(spec.SupervisorLog) || strings.ContainsAny(spec.SupervisorLog, "\r\n\x00") || strings.TrimSpace(spec.SupervisorLog) != spec.SupervisorLog || strings.HasSuffix(spec.SupervisorLog, "\\") {
+		return fmt.Errorf("无效的 supervisor 日志路径")
+	}
 	if err := fsutil.EnsureDir(filepath.Dir(spec.SupervisorLog), fsutil.DirMode); err != nil {
 		return err
 	}
 	if err := fsutil.WriteAtomic(m.path, []byte(unitText(spec)), fsutil.ConfigFileMode); err != nil {
 		return err
 	}
-	if out, err := systemctl("daemon-reload"); err != nil {
+	if out, err := m.command("daemon-reload"); err != nil {
 		return fmt.Errorf("systemctl daemon-reload 失败: %s", strings.TrimSpace(string(out)))
 	}
-	if out, err := systemctl("enable", m.unit); err != nil {
+	if out, err := m.command("enable", m.unit); err != nil {
 		return fmt.Errorf("systemctl enable 失败: %s", strings.TrimSpace(string(out)))
 	}
 	return nil
 }
 func (m *platformManager) Start() error {
-	out, err := systemctl("start", m.unit)
+	out, err := m.command("start", m.unit)
 	if err != nil {
 		return fmt.Errorf("systemctl start 失败: %s", strings.TrimSpace(string(out)))
 	}
@@ -138,7 +221,7 @@ func (m *platformManager) Stop() error {
 	if !status.Running {
 		return nil
 	}
-	out, stopErr := systemctl("stop", m.unit)
+	out, stopErr := m.command("stop", m.unit)
 	after, statusErr := waitForServiceState(m.Status, func(status Status) bool { return !status.Running })
 	if statusErr == nil && !after.Running {
 		return nil
@@ -152,7 +235,7 @@ func (m *platformManager) Stop() error {
 	return fmt.Errorf("systemctl stop 后服务仍在运行: %s", m.unit)
 }
 func (m *platformManager) Restart() error {
-	out, err := systemctl("restart", m.unit)
+	out, err := m.command("restart", m.unit)
 	if err != nil {
 		return fmt.Errorf("systemctl restart 失败: %s", strings.TrimSpace(string(out)))
 	}
@@ -169,13 +252,13 @@ func (m *platformManager) Uninstall() error {
 	if !status.Installed && !status.Loaded {
 		return nil
 	}
-	if out, err := systemctl("disable", m.unit); err != nil {
+	if out, err := m.command("disable", m.unit); err != nil {
 		return fmt.Errorf("systemctl disable 失败: %s", strings.TrimSpace(string(out)))
 	}
 	if err := os.Remove(m.path); err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	if out, err := systemctl("daemon-reload"); err != nil {
+	if out, err := m.command("daemon-reload"); err != nil {
 		return fmt.Errorf("systemctl daemon-reload 失败: %s", strings.TrimSpace(string(out)))
 	}
 	after, err := m.Status()

--- a/internal/autostart/manager_linux_test.go
+++ b/internal/autostart/manager_linux_test.go
@@ -5,7 +5,10 @@ package autostart
 import (
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -21,6 +24,9 @@ type fakeSystemd struct {
 func stubSystemctl(t *testing.T, m *platformManager, fake *fakeSystemd) {
 	t.Helper()
 	original := systemctl
+	originalLogin := loginctl
+	loginctl = func(args ...string) ([]byte, error) { return []byte("yes"), nil }
+	t.Cleanup(func() { loginctl = originalLogin })
 	systemctl = func(args ...string) ([]byte, error) {
 		switch args[0] {
 		case "show":
@@ -106,5 +112,120 @@ func TestLinuxUninstallStopsAndRemovesService(t *testing.T) {
 	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Fatalf("unit still exists or stat failed unexpectedly: %v", err)
+	}
+}
+
+func TestLinuxBootLinger(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		initial    bool
+		denied     bool
+		unchanged  bool
+		wantErr    bool
+		wantEnable int
+	}{
+		{name: "already enabled", initial: true},
+		{name: "enable", wantEnable: 1},
+		{name: "permission denied", denied: true, wantErr: true, wantEnable: 1},
+		{name: "verify failed", unchanged: true, wantErr: true, wantEnable: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			old := loginctl
+			defer func() { loginctl = old }()
+			linger := tc.initial
+			calls := 0
+			loginctl = func(args ...string) ([]byte, error) {
+				if args[1] != strconv.Itoa(os.Getuid()) {
+					t.Fatalf("wrong user: %v", args)
+				}
+				switch args[0] {
+				case "show-user":
+					if linger {
+						return []byte("yes\n"), nil
+					}
+					return []byte("no\n"), nil
+				case "enable-linger":
+					calls++
+					if tc.denied {
+						return []byte("Access denied"), errors.New("denied")
+					}
+					if !tc.unchanged {
+						linger = true
+					}
+					return nil, nil
+				}
+				t.Fatalf("unexpected loginctl: %v", args)
+				return nil, nil
+			}
+			err := (&platformManager{}).EnableBoot()
+			if (err != nil) != tc.wantErr || calls != tc.wantEnable {
+				t.Fatalf("err=%v calls=%d", err, calls)
+			}
+		})
+	}
+}
+
+func TestLinuxStatusBootReadiness(t *testing.T) {
+	for _, tc := range []struct {
+		name, linger, enabled string
+		warning               bool
+	}{
+		{"boot ready", "yes", "enabled", false},
+		{"login only", "no", "enabled", true},
+		{"disabled unit", "yes", "disabled", true},
+		{"unknown linger", "", "enabled", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			oldCtl, oldLogin := systemctl, loginctl
+			defer func() { systemctl = oldCtl; loginctl = oldLogin }()
+			path := filepath.Join(t.TempDir(), "daemon.service")
+			if err := os.WriteFile(path, []byte("unit"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			systemctl = func(args ...string) ([]byte, error) {
+				if args[0] == "is-enabled" {
+					return []byte(tc.enabled), nil
+				}
+				return []byte("LoadState=loaded\nActiveState=active\nMainPID=9284"), nil
+			}
+			loginctl = func(args ...string) ([]byte, error) { return []byte(tc.linger), nil }
+			status, err := (&platformManager{unit: "daemon.service", path: path}).Status()
+			if err != nil || !status.Running || status.UnitEnabled == nil || *status.UnitEnabled != (tc.enabled == "enabled") || (status.BootWarning != "") != tc.warning {
+				t.Fatalf("%+v err=%v", status, err)
+			}
+			if tc.linger == "" && status.Linger != nil {
+				t.Fatal("unknown linger reported as known")
+			}
+		})
+	}
+}
+
+func TestLinuxUnitOutputPaths(t *testing.T) {
+	log := `/tmp/space dir/100%/daemon "supervisor".log`
+	unit := unitText(Spec{Executable: "/bin/true", SupervisorLog: log})
+	for _, key := range []string{"StandardOutput=", "StandardError="} {
+		if !strings.Contains(unit, key+`append:/tmp/space dir/100%%/daemon "supervisor".log`+"\n") {
+			t.Fatalf("incorrect scalar output path: %s", unit)
+		}
+	}
+	// When available, use systemd's actual parser, which returns success even
+	// for ignored output directives: inspect diagnostic output as well.
+	if tool, err := exec.LookPath("systemd-analyze"); err == nil {
+		path := filepath.Join(t.TempDir(), "yoooclaw-test.service")
+		if err := os.WriteFile(path, []byte(unit), 0600); err != nil {
+			t.Fatal(err)
+		}
+		out, err := exec.Command(tool, "verify", path).CombinedOutput()
+		if err != nil || strings.Contains(string(out), "Failed to parse") || strings.Contains(string(out), "ignoring") {
+			t.Fatalf("systemd verify: %v\n%s", err, out)
+		}
+	}
+}
+
+func TestLinuxInstallRejectsUnsafeLogPath(t *testing.T) {
+	for _, path := range []string{"relative.log", "/tmp/log\nExecStart=/bin/false", "/tmp/log\r", "/tmp/log\\"} {
+		if err := (&platformManager{}).Install(Spec{SupervisorLog: path}); err == nil {
+			t.Fatalf("accepted %q", path)
+		}
 	}
 }

--- a/internal/cli/cli_local_test.go
+++ b/internal/cli/cli_local_test.go
@@ -354,3 +354,24 @@ func TestRecordingCommandsRenderTableFromResultEnvelope(t *testing.T) {
 		}
 	}
 }
+
+func TestDaemonDiagnosticLogBundle(t *testing.T) {
+	sandbox(t)
+	out, code := execCLI(t, "daemon", "reload")
+	if code != 0 {
+		t.Fatalf("reload: %s", out)
+	}
+	out, code = execCLI(t, "daemon", "logs", "--diagnostics")
+	if code != 0 {
+		t.Fatalf("logs: %s", out)
+	}
+	result := decode(t, out)
+	for _, key := range []string{"process", "autostart", "supervisor", "configPath", "root", "profile"} {
+		if _, ok := result[key]; !ok {
+			t.Fatalf("missing %s: %s", key, out)
+		}
+	}
+	if !strings.Contains(out, "reload.request") || !strings.Contains(out, "lock_missing") {
+		t.Fatalf("missing reason in bundle: %s", out)
+	}
+}

--- a/internal/cli/cmd_daemon.go
+++ b/internal/cli/cmd_daemon.go
@@ -1,10 +1,16 @@
 package cli
 
 import (
+	"context"
+	"fmt"
+	"github.com/YoooClaw/cli/internal/diagnostics"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/YoooClaw/cli/internal/clictx"
 	"github.com/YoooClaw/cli/internal/config"
@@ -44,6 +50,7 @@ func newDaemonCmd() *cobra.Command {
 	logs.Flags().String("lines", "100", "初始展示行数")
 	logs.Flags().String("level", "", "过滤日志级别")
 	logs.Flags().Bool("supervisor", false, "查看系统用户服务启动日志")
+	logs.Flags().Bool("diagnostics", false, "汇总 daemon/自启日志、进程状态和 Linux 本次启动的系统服务记录")
 
 	runFg := &cobra.Command{Use: "run-foreground", Short: "（内部）前台运行 daemon 主循环", Args: cobra.NoArgs, RunE: run(daemonRunForeground)}
 	runFg.Flags().String("bind", "", "监听地址")
@@ -190,23 +197,50 @@ func daemonRestart(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, er
 	return map[string]any{"ok": true, "pid": newLock.PID, "bind": newLock.Bind, "port": newLock.Port, "detached": true}, nil
 }
 
+func logDaemonObservation(ctx *clictx.Context, event string, state daemon.RunningState) {
+	fields := map[string]any{"profile": ctx.Profile, "root": paths.RootDir(), "lockPath": ctx.Paths.DaemonLock, "running": state.Running, "stale": state.Stale, "reason": state.Reason, "lockReadError": state.ReadError, "actualExecutable": state.ActualExecutable}
+	if state.Lock != nil {
+		fields["lockPID"] = state.Lock.PID
+		fields["expectedExecutable"] = state.Lock.Executable
+		fields["lockProfile"] = state.Lock.Profile
+		fields["lockVersion"] = state.Lock.Version
+		fields["port"] = state.Lock.Port
+	}
+	status, err := autostartManager().Status()
+	fields["service"] = status
+	if err != nil {
+		fields["serviceError"] = diagnostics.SafeError(err)
+	}
+	level := "info"
+	if !state.Running {
+		level = "warn"
+	}
+	diagnostics.Write(paths.RootDir(), level, event, fields)
+}
+
 func daemonReload(ctx *clictx.Context, _ *cobra.Command, _ []string) (any, error) {
 	state := daemon.State(ctx.Paths)
+	logDaemonObservation(ctx, "reload.request", state)
 	if !state.Running {
-		return map[string]any{"ok": true, "running": false, "reloaded": false}, nil
+		return map[string]any{"ok": true, "running": false, "reloaded": false, "stale": state.Stale,
+			"reason": "未发现可识别的 daemon 进程，未执行配置重载",
+			"hint":   "运行 yoooclaw daemon start；若系统服务显示运行中，请检查 daemon.lock 与进程身份是否一致"}, nil
 	}
 	_, body, err := daemon.NewClient(ctx.Paths).Request("POST", "/daemon/reload", nil)
 	if err != nil {
+		diagnostics.Write(paths.RootDir(), "error", "reload.request_failed", map[string]any{"profile": ctx.Profile, "error": diagnostics.SafeError(err)})
 		return nil, err
 	}
+	diagnostics.Write(paths.RootDir(), "info", "reload.response_received", map[string]any{"profile": ctx.Profile})
 	return body, nil
 }
 
 func daemonStatus(ctx *clictx.Context, _ *cobra.Command, _ []string) (any, error) {
 	state := daemon.State(ctx.Paths)
+	logDaemonObservation(ctx, "status.observed", state)
 	if !state.Running {
 		return nil, errs.New(errs.CodeDaemonNotRunning, "daemon 未运行",
-			map[string]any{"stale": state.Stale, "hint": "yoooclaw daemon start"})
+			map[string]any{"stale": state.Stale, "reason": state.Reason, "hint": "yoooclaw daemon start"})
 	}
 	_, body, err := daemon.NewClient(ctx.Paths).Request("GET", "/daemon/status", nil)
 	if err != nil {
@@ -222,6 +256,9 @@ func daemonStatus(ctx *clictx.Context, _ *cobra.Command, _ []string) (any, error
 
 func daemonLogs(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error) {
 	n := atoiDefault(flagStr(cmd, "lines"), 100)
+	if n < 1 || n > 1000 {
+		return nil, errs.New(errs.CodeInvalidArgument, "--lines 必须在 1 到 1000 之间")
+	}
 	file := ctx.Paths.DaemonLog
 	if flagBool(cmd, "supervisor") {
 		file = filepath.Join(paths.RootDir(), "logs", "daemon-supervisor.log")
@@ -238,7 +275,44 @@ func daemonLogs(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error
 		lines = filtered
 	}
 	// --follow 的实时 tail 暂不实现（Phase 2 标准输出即可）；返回当前快照。
-	return map[string]any{"ok": true, "file": file, "total": len(lines), "lines": lines}, nil
+	result := map[string]any{"ok": true, "file": file, "total": len(lines), "lines": lines}
+	if flagBool(cmd, "diagnostics") {
+		supervisorFile := filepath.Join(paths.RootDir(), "logs", "daemon-supervisor.log")
+		result["supervisor"] = map[string]any{"file": supervisorFile, "lines": tailLines(supervisorFile, n)}
+		result["process"] = daemon.State(ctx.Paths)
+		result["root"] = paths.RootDir()
+		result["profile"] = ctx.Profile
+		result["configPath"] = ctx.Paths.Config
+		status, err := autostartSnapshot()
+		result["autostart"] = status
+		if err != nil {
+			result["autostartError"] = diagnostics.SafeError(err)
+		}
+		native, _ := autostartManager().Status()
+		if runtime.GOOS == "linux" && native.Manager == "systemd" && native.Unit != "" {
+			result["systemd"] = readServiceDiagnostic("systemctl", "--user", "show", native.Unit, "--property=ActiveState,SubState,Result,ExecMainCode,ExecMainStatus,ExecMainStartTimestamp,UnitFileState,InvocationID")
+			result["userManager"] = readServiceDiagnostic("systemctl", "show", fmt.Sprintf("user@%d.service", os.Getuid()), "--property=ActiveState,SubState,Result,ExecMainStartTimestamp")
+			result["userManagerJournal"] = readServiceDiagnostic("journalctl", "-b", "-u", fmt.Sprintf("user@%d.service", os.Getuid()), "--no-pager", "-n", strconv.Itoa(n))
+			result["journal"] = readServiceDiagnostic("journalctl", "--user", "-b", "-u", native.Unit, "--no-pager", "-n", strconv.Itoa(n))
+		}
+	}
+	return result, nil
+}
+
+// Bound external diagnostics so an unavailable user bus cannot hang logs.
+func readServiceDiagnostic(command string, args ...string) map[string]any {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, command, args...).CombinedOutput()
+	lines := strings.Split(string(out), "\n")
+	for i, line := range lines {
+		lines[i] = diagnostics.SafeError(fmt.Errorf("%s", line))
+	}
+	result := map[string]any{"output": strings.Join(lines, "\n"), "ok": err == nil}
+	if err != nil {
+		result["error"] = diagnostics.SafeError(err)
+	}
+	return result
 }
 
 func tailLines(file string, n int) []string {

--- a/internal/cli/cmd_daemon_autostart.go
+++ b/internal/cli/cmd_daemon_autostart.go
@@ -11,9 +11,11 @@ import (
 	"github.com/YoooClaw/cli/internal/clictx"
 	"github.com/YoooClaw/cli/internal/config"
 	"github.com/YoooClaw/cli/internal/daemon"
+	"github.com/YoooClaw/cli/internal/diagnostics"
 	"github.com/YoooClaw/cli/internal/errs"
 	"github.com/YoooClaw/cli/internal/fsutil"
 	"github.com/YoooClaw/cli/internal/paths"
+	"github.com/YoooClaw/cli/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -22,6 +24,7 @@ const managedDaemonReadyTimeout = 15 * time.Second
 func newDaemonAutostartCmd() *cobra.Command {
 	c := &cobra.Command{Use: "autostart", Short: "管理用户登录时自动启动"}
 	enable := &cobra.Command{Use: "enable", Short: "启用自启并立即启动 daemon", Args: cobra.NoArgs, RunE: run(daemonAutostartEnable)}
+	enable.Flags().Bool("boot", false, "Linux：开启当前用户 linger，支持无人登录时开机启动")
 	enable.Flags().Bool("no-start", false, "只启用自启，当前不启动")
 	disable := &cobra.Command{Use: "disable", Short: "停止 daemon 并关闭自启", Args: cobra.NoArgs, RunE: run(daemonAutostartDisable)}
 	status := &cobra.Command{Use: "status", Short: "显示自启期望与系统服务状态", Args: cobra.NoArgs, RunE: run(daemonAutostartStatus)}
@@ -67,6 +70,21 @@ func autostartSnapshot() (map[string]any, error) {
 		"installed": status.Installed, "loaded": status.Loaded,
 		"running": status.Running, "drift": drift,
 		"profile": persistentActiveProfile(),
+	}
+	if status.Linger != nil {
+		result["linger"] = *status.Linger
+	}
+	if status.UnitEnabled != nil {
+		result["unitEnabled"] = *status.UnitEnabled
+		if desired == autostart.DesiredEnabled && !*status.UnitEnabled {
+			result["drift"] = true
+		}
+	}
+	if status.Linger != nil && status.UnitEnabled != nil {
+		result["bootEnabled"] = *status.Linger && *status.UnitEnabled
+	}
+	if status.BootWarning != "" {
+		result["bootWarning"] = status.BootWarning
 	}
 	if desired == "" {
 		result["desired"] = "unknown"
@@ -185,6 +203,12 @@ func daemonAutostartEnable(ctx *clictx.Context, cmd *cobra.Command, _ []string) 
 	if err != nil {
 		return nil, recoverDaemonAfterAutostartFailure(ctx, start, err)
 	}
+	// Do this before stopping a healthy service: policy may reject linger.
+	if flagBool(cmd, "boot") {
+		if err := autostart.EnableBoot(manager); err != nil {
+			return nil, autostartError(err)
+		}
+	}
 	if status.Running {
 		if err := manager.Stop(); err != nil {
 			return nil, recoverDaemonAfterAutostartFailure(ctx, start, err)
@@ -212,6 +236,8 @@ func daemonAutostartEnable(ctx *clictx.Context, cmd *cobra.Command, _ []string) 
 }
 
 func recoverDaemonAfterAutostartFailure(ctx *clictx.Context, start bool, cause error) error {
+	diagnostics.Write(paths.RootDir(), "warn", "autostart.recovery_requested", map[string]any{"profile": ctx.Profile, "startRequested": start, "error": diagnostics.SafeError(cause)})
+	defer func() { logDaemonObservation(ctx, "autostart.recovery_result", daemon.State(ctx.Paths)) }()
 	if !start || daemon.State(ctx.Paths).Running {
 		return autostartError(cause)
 	}
@@ -291,6 +317,7 @@ func waitForManagedDaemon(ctx *clictx.Context) error {
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
+	logDaemonObservation(ctx, "service.ready_timeout", daemon.State(ctx.Paths))
 	return errs.New(errs.CodeDaemonNotRunning, "系统服务已启动，但 daemon 未在 "+managedDaemonReadyTimeout.String()+" 内就绪").
 		WithHint("查看 `yoooclaw daemon logs` 和 `yoooclaw daemon logs --supervisor`")
 }
@@ -370,12 +397,26 @@ func daemonRunServiceWithRoot(ctx *clictx.Context, cmd *cobra.Command) (*clictx.
 	}, nil
 }
 
-func daemonRunService(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error) {
-	ctx, err := daemonRunServiceWithRoot(ctx, cmd)
+func daemonRunService(ctx *clictx.Context, cmd *cobra.Command, _ []string) (result any, runErr error) {
+	began := time.Now()
+	defer func() {
+		fields := map[string]any{"profile": ctx.Profile, "elapsedMs": time.Since(began).Milliseconds()}
+		level := "info"
+		if runErr != nil {
+			level = "error"
+			fields["error"] = diagnostics.SafeError(runErr)
+		}
+		diagnostics.Write(paths.RootDir(), level, "service.run_returned", fields)
+	}()
+	serviceCtx, err := daemonRunServiceWithRoot(ctx, cmd)
 	if err != nil {
 		return nil, err
 	}
+	ctx = serviceCtx
+	exe, _ := os.Executable()
+	diagnostics.Write(paths.RootDir(), "info", "service.entry", map[string]any{"root": paths.RootDir(), "profile": ctx.Profile, "configPath": ctx.Paths.Config, "lockPath": ctx.Paths.DaemonLock, "daemonLog": ctx.Paths.DaemonLog, "executable": exe, "version": version.Version, "parentPID": os.Getppid(), "uid": os.Getuid(), "invocationID": os.Getenv("INVOCATION_ID"), "runtimeDir": os.Getenv("XDG_RUNTIME_DIR"), "sessionBusPresent": os.Getenv("DBUS_SESSION_BUS_ADDRESS") != ""})
 	if !config.Exists(ctx.Paths) {
+		diagnostics.Write(paths.RootDir(), "warn", "service.skipped", map[string]any{"reason": "config_missing", "configPath": ctx.Paths.Config})
 		return map[string]any{"ok": true, "running": false, "skipped": "active profile 尚未初始化", "profile": ctx.Profile}, nil
 	}
 	err = daemon.RunForeground(ctx, daemon.StartOpts{})
@@ -384,10 +425,10 @@ func daemonRunService(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any,
 	}
 	var structured *errs.Error
 	if errors.As(err, &structured) && (structured.Code == errs.CodeDaemonDisabledByPlugin || structured.Code == errs.CodeDaemonAlreadyRunning) {
-		appendSupervisorLog("INFO", structured.Message)
+		diagnostics.Write(paths.RootDir(), "warn", "service.skipped", map[string]any{"reasonCode": structured.Code, "reason": diagnostics.SafeError(structured)})
 		return map[string]any{"ok": true, "running": false, "skipped": structured.Message, "profile": ctx.Profile}, nil
 	}
-	appendSupervisorLog("ERROR", err.Error())
+	appendSupervisorLog("ERROR", diagnostics.SafeError(err))
 	return nil, err
 }
 

--- a/internal/cli/cmd_doctor.go
+++ b/internal/cli/cmd_doctor.go
@@ -104,7 +104,7 @@ func doctor(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error) {
 	case state.Running:
 		checks = append(checks, check{"daemon", "ok", "运行中（pid " + strconv.Itoa(state.Lock.PID) + "）"})
 	case state.Stale:
-		checks = append(checks, check{"daemon", "warn", "锁文件存在但进程已死（陈旧锁）"})
+		checks = append(checks, check{"daemon", "warn", "锁文件存在但进程不存在或身份校验不匹配"})
 	default:
 		checks = append(checks, check{"daemon", "skip", "未运行"})
 	}
@@ -115,7 +115,7 @@ func doctor(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error) {
 	storedState, storedExists, _ := autostart.ReadState(paths.RootDir())
 	currentSpec, specErr := autostartSpec()
 	executableDrift := storedExists && specErr == nil && storedState.Executable != "" && storedState.Executable != currentSpec.Executable
-	needsEnableRepair := desired == autostart.DesiredEnabled && (!serviceStatus.Installed || executableDrift)
+	needsEnableRepair := desired == autostart.DesiredEnabled && (!serviceStatus.Installed || executableDrift || (serviceStatus.UnitEnabled != nil && !*serviceStatus.UnitEnabled))
 	switch {
 	case desiredErr != nil:
 		checks = append(checks, check{"daemon-autostart", "fail", desiredErr.Error()})
@@ -131,11 +131,13 @@ func doctor(ctx *clictx.Context, cmd *cobra.Command, _ []string) (any, error) {
 			checks = append(checks, check{"daemon-autostart", "ok", "已重新注册用户级自启服务"})
 		}
 	case needsEnableRepair:
-		detail := "期望启用但系统服务缺失（doctor --fix 可修复）"
+		detail := "期望启用但系统服务缺失或未 enable（doctor --fix 可修复）"
 		if executableDrift {
 			detail = "系统服务仍指向旧版本二进制（doctor --fix 可修复）"
 		}
 		checks = append(checks, check{"daemon-autostart", "warn", detail})
+	case desired == autostart.DesiredEnabled && serviceStatus.BootWarning != "":
+		checks = append(checks, check{"daemon-autostart", "warn", serviceStatus.BootWarning})
 	case desired == autostart.DesiredEnabled && serviceStatus.Installed:
 		checks = append(checks, check{"daemon-autostart", "ok", serviceStatus.Manager + " 已启用"})
 	case desired == autostart.DesiredDisabled && serviceStatus.Installed && fix:

--- a/internal/daemon/diagnostics_test.go
+++ b/internal/daemon/diagnostics_test.go
@@ -1,0 +1,65 @@
+package daemon
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/YoooClaw/cli/internal/creds"
+)
+
+func TestCredentialSummaryRotationAndRedaction(t *testing.T) {
+	set := creds.CredentialSet{Mode: "file-multi", Location: "/tmp/credentials.json", Entries: []creds.ApiKeyEntry{{Label: "phone", Key: "private-old-key", Source: "file", Default: true}}}
+	before, _ := json.Marshal(credentialSummary(set))
+	set.Entries[0].Key = "private-new-key"
+	after, _ := json.Marshal(credentialSummary(set))
+	if string(before) == string(after) {
+		t.Fatal("key rotation not visible")
+	}
+	for _, raw := range [][]byte{before, after} {
+		if strings.Contains(string(raw), "private-") {
+			t.Fatalf("key leaked: %s", raw)
+		}
+		if !strings.Contains(string(raw), "sha256:") || !strings.Contains(string(raw), "phone") {
+			t.Fatalf("missing metadata: %s", raw)
+		}
+	}
+}
+
+func TestStateDiagnosticReasons(t *testing.T) {
+	p := sandboxPaths(t)
+	if state := State(p); state.Reason != "lock_missing" {
+		t.Fatalf("missing: %+v", state)
+	}
+	if err := os.WriteFile(p.DaemonLock, []byte("invalid json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if state := State(p); state.Reason != "lock_unreadable" {
+		t.Fatalf("unreadable: %+v", state)
+	}
+	if err := WriteLock(p, Lock{PID: 2147483600}); err != nil {
+		t.Fatal(err)
+	}
+	if state := State(p); state.Reason != "process_not_alive" || !state.Stale {
+		t.Fatalf("dead: %+v", state)
+	}
+}
+
+func TestReloadLogsAppliedCredentialsWithoutSecrets(t *testing.T) {
+	srv, _ := newTestServer(t, "")
+	srv.credentialSet = creds.CredentialSet{Entries: []creds.ApiKeyEntry{{Label: "old", Key: "old-private-key"}}}
+	srv.reloadCredentials()
+	raw, err := os.ReadFile(srv.logger.logFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, event := range []string{"credentials.reload_begin", "credentials.reload_applied", "connectionConfirmed", "old"} {
+		if !strings.Contains(string(raw), event) {
+			t.Fatalf("missing %s: %s", event, raw)
+		}
+	}
+	if strings.Contains(string(raw), "old-private-key") {
+		t.Fatalf("credential leaked: %s", raw)
+	}
+}

--- a/internal/daemon/lock.go
+++ b/internal/daemon/lock.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 
+	"github.com/YoooClaw/cli/internal/diagnostics"
 	"github.com/YoooClaw/cli/internal/fsutil"
 	"github.com/YoooClaw/cli/internal/paths"
 )
@@ -37,8 +38,11 @@ type Lock struct {
 type RunningState struct {
 	Running bool
 	Lock    *Lock
-	// Stale 锁存在但进程已死。
-	Stale bool
+	// Stale means the recorded process is dead or its identity no longer matches.
+	Stale            bool
+	ReadError        string `json:"readError,omitempty"`
+	Reason           string `json:"reason"`
+	ActualExecutable string `json:"actualExecutable,omitempty"`
 }
 
 // ReadLock 读取锁文件；不存在返回 nil。
@@ -53,16 +57,24 @@ func ReadLock(p paths.Paths) *Lock {
 
 // State 返回 daemon 运行态（signal 0 + Linux/WSL /proc 身份校验；陈旧锁视为未运行）。
 func State(p paths.Paths) RunningState {
-	lock := ReadLock(p)
-	if lock == nil {
-		return RunningState{}
+	var record Lock
+	exists, err := fsutil.ReadJSON(p.DaemonLock, &record)
+	if err != nil {
+		return RunningState{Reason: "lock_unreadable", ReadError: diagnostics.SafeError(err)}
 	}
+	if !exists {
+		return RunningState{Reason: "lock_missing"}
+	}
+	lock := &record
 	// signal 0 alone is not enough on Linux/WSL: it also succeeds for zombies,
 	// and a persisted lock can point at an unrelated process after PID reuse.
 	// When /proc metadata is available, verify that the PID still belongs to the
 	// daemon executable and command line recorded by the lock.
-	alive := isProcessAlive(lock.PID) && isExpectedDaemonProcess(lock)
-	return RunningState{Running: alive, Lock: lock, Stale: !alive}
+	if !isProcessAlive(lock.PID) {
+		return RunningState{Lock: lock, Stale: true, Reason: "process_not_alive"}
+	}
+	reason, actual := daemonProcessIdentity(lock)
+	return RunningState{Running: reason == "", Lock: lock, Stale: reason != "", Reason: reason, ActualExecutable: actual}
 }
 
 // WriteLock 写锁文件。

--- a/internal/daemon/process_identity.go
+++ b/internal/daemon/process_identity.go
@@ -22,7 +22,7 @@ func isDaemonCommandLine(cmdline []byte) bool {
 		if string(arg) == "--yclib-daemon-bootstrap" {
 			return true
 		}
-		if string(arg) == "daemon" && i+1 < len(args) && string(args[i+1]) == "run-foreground" {
+		if string(arg) == "daemon" && i+1 < len(args) && (string(args[i+1]) == "run-foreground" || string(args[i+1]) == "run-service") {
 			return true
 		}
 	}

--- a/internal/daemon/process_identity_linux.go
+++ b/internal/daemon/process_identity_linux.go
@@ -11,28 +11,33 @@ import (
 // isExpectedDaemonProcess rejects stale daemon locks that happen to reference
 // a live PID. This matters especially in WSL, where the lock survives a distro
 // restart while the Linux PID namespace starts over and quickly reuses PIDs.
-func isExpectedDaemonProcess(lock *Lock) bool {
+func daemonProcessIdentity(lock *Lock) (string, string) {
 	procRoot := fmt.Sprintf("/proc/%d", lock.PID)
 	stat, err := os.ReadFile(filepath.Join(procRoot, "stat"))
 	if err != nil {
 		// /proc can be hidden by container policy. Preserve the historical
 		// signal-0 behavior when identity metadata is unavailable.
-		return true
+		return "", ""
 	}
 	if linuxProcessState(stat) == 'Z' || linuxProcessState(stat) == 'X' {
-		return false
+		return "process_zombie_or_dead", ""
 	}
 	if lock.Executable == "" {
-		return true // legacy locks did not record enough identity to verify.
+		return "", "" // legacy locks did not record enough identity to verify.
 	}
 
 	actualExecutable, err := os.Readlink(filepath.Join(procRoot, "exe"))
 	if err == nil && !sameExecutable(lock.Executable, actualExecutable) {
-		return false
+		return "executable_mismatch", actualExecutable
 	}
 	cmdline, err := os.ReadFile(filepath.Join(procRoot, "cmdline"))
 	if err == nil && len(cmdline) > 0 && !isDaemonCommandLine(cmdline) {
-		return false
+		return "command_not_daemon", actualExecutable
 	}
-	return true
+	return "", ""
+}
+
+func isExpectedDaemonProcess(lock *Lock) bool {
+	reason, _ := daemonProcessIdentity(lock)
+	return reason == ""
 }

--- a/internal/daemon/process_identity_linux_test.go
+++ b/internal/daemon/process_identity_linux_test.go
@@ -3,8 +3,12 @@
 package daemon
 
 import (
+	"bufio"
+	"fmt"
 	"os"
+	"os/exec"
 	"testing"
+	"time"
 )
 
 func TestStateRejectsReusedLinuxPID(t *testing.T) {
@@ -15,5 +19,49 @@ func TestStateRejectsReusedLinuxPID(t *testing.T) {
 	st := State(p)
 	if st.Running || !st.Stale {
 		t.Fatalf("reused PID should be stale: %+v", st)
+	}
+}
+
+func TestManagedProcessIdentityHelper(t *testing.T) {
+	if os.Getenv("YOOOCLAW_IDENTITY_HELPER") != "1" {
+		return
+	}
+	fmt.Println("ready")
+	time.Sleep(30 * time.Second)
+	os.Exit(0)
+}
+
+func TestStateRecognizesManagedLinuxDaemon(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, command := range []string{"run-service", "run-foreground", "status"} {
+		t.Run(command, func(t *testing.T) {
+			child := exec.Command(exe, "-test.run=^TestManagedProcessIdentityHelper$", "--", "daemon", command, "--root", t.TempDir())
+			child.Env = append(os.Environ(), "YOOOCLAW_IDENTITY_HELPER=1")
+			stdout, err := child.StdoutPipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := child.Start(); err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = child.Process.Kill(); _ = child.Wait() }()
+			if line, err := bufio.NewReader(stdout).ReadString('\n'); err != nil || line != "ready\n" {
+				t.Fatalf("helper: %q %v", line, err)
+			}
+			p := sandboxPaths(t)
+			if err := WriteLock(p, Lock{PID: child.Process.Pid, Executable: exe}); err != nil {
+				t.Fatal(err)
+			}
+			state := State(p)
+			want := command != "status"
+			if state.Running != want || state.Stale == want {
+				actualExe, _ := os.Readlink(fmt.Sprintf("/proc/%d/exe", child.Process.Pid))
+				cmdline, _ := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", child.Process.Pid))
+				t.Fatalf("%s state: %+v; expected executable=%q actual=%q cmdline=%q", command, state, exe, actualExe, cmdline)
+			}
+		})
 	}
 }

--- a/internal/daemon/process_identity_other.go
+++ b/internal/daemon/process_identity_other.go
@@ -6,3 +6,5 @@ package daemon
 // reuse. Their existing platform-specific process liveness check remains the
 // best available signal.
 func isExpectedDaemonProcess(_ *Lock) bool { return true }
+
+func daemonProcessIdentity(_ *Lock) (string, string) { return "", "" }

--- a/internal/daemon/process_identity_test.go
+++ b/internal/daemon/process_identity_test.go
@@ -9,6 +9,9 @@ func TestLinuxProcessIdentityParsing(t *testing.T) {
 	if !isDaemonCommandLine([]byte("/usr/bin/yc\x00daemon\x00run-foreground\x00--profile\x00default\x00")) {
 		t.Fatal("daemon run-foreground command line was not recognized")
 	}
+	if !isDaemonCommandLine([]byte("/usr/local/bin/yoooclaw\x00daemon\x00run-service\x00--root\x00/root/.yoooclaw\x00")) {
+		t.Fatal("systemd managed daemon command line was not recognized")
+	}
 	if !isDaemonCommandLine([]byte("/tmp/host\x00--yclib-daemon-bootstrap\x00")) {
 		t.Fatal("yclib bootstrap command line was not recognized")
 	}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -2,10 +2,12 @@ package daemon
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/YoooClaw/cli/internal/diagnostics"
 	"io"
 	"net"
 	"net/http"
@@ -60,7 +62,14 @@ type runtimeState struct {
 }
 
 // RunForeground 前台运行 daemon 主循环（detach 子进程入口）。永不正常返回。
-func RunForeground(ctx *clictx.Context, opts StartOpts) error {
+func RunForeground(ctx *clictx.Context, opts StartOpts) (runErr error) {
+	root := filepath.Dir(filepath.Dir(ctx.Paths.Dir))
+	diagnostics.Write(root, "info", "daemon.start_requested", map[string]any{"profile": ctx.Profile, "configPath": ctx.Paths.Config, "lockPath": ctx.Paths.DaemonLock})
+	defer func() {
+		if runErr != nil {
+			diagnostics.Write(root, "error", "daemon.start_or_run_failed", map[string]any{"profile": ctx.Profile, "error": diagnostics.SafeError(runErr)})
+		}
+	}()
 	if State(ctx.Paths).Running {
 		return errs.New(errs.CodeDaemonAlreadyRunning, "daemon 已在运行")
 	}
@@ -100,6 +109,10 @@ func RunForeground(ctx *clictx.Context, opts StartOpts) error {
 	}
 	ctx.Paths.MigrateLogs()
 	logger := NewLogger(ctx.Paths.DaemonLog, logLevel, false)
+	logger.Info(diagnostics.Message("daemon.start_context", map[string]any{"profile": ctx.Profile, "version": version.Version, "executable": executable, "configPath": ctx.Paths.Config, "lockPath": ctx.Paths.DaemonLock, "ingress": mode, "relayEnabled": cfg.Relay.Enabled, "credentials": credentialSummary(credentialSet), "gatewayTokenSource": tokenRef.Source, "gatewayTokenPresent": token != ""}))
+	if lockErr != nil {
+		logger.Warn(diagnostics.Message("daemon.singleton_lock_unavailable", map[string]any{"error": diagnostics.SafeError(lockErr)}))
+	}
 	st := &runtimeState{startedAt: time.Now().UTC().Format(time.RFC3339)}
 	// Validate all prerequisites before publishing daemon.lock. Previously a
 	// proxied start without an api-key wrote the lock and then exited, leaving
@@ -178,6 +191,7 @@ func RunForeground(ctx *clictx.Context, opts StartOpts) error {
 	// a lingering old daemon must never delete a newer daemon's lock.
 	selfPID := os.Getpid()
 	defer RemoveLockIfOwnedBy(ctx.Paths, selfPID)
+	diagnostics.Write(root, "info", "daemon.ready", map[string]any{"profile": ctx.Profile, "bind": bind, "port": actualPort, "lockPath": ctx.Paths.DaemonLock, "version": version.Version})
 	logger.Info(fmt.Sprintf("yoooclaw daemon 启动：%s:%d（profile=%s, pid=%d）", bind, actualPort, ctx.Profile, os.Getpid()))
 	switch mode {
 	case config.IngressProxied:
@@ -216,6 +230,7 @@ func RunForeground(ctx *clictx.Context, opts StartOpts) error {
 	srv.shutdown = func(reason string) {
 		srv.shutdownOnce.Do(func() {
 			logger.Info("daemon 退出（" + reason + "）")
+			diagnostics.Write(root, "info", "daemon.shutdown", map[string]any{"profile": ctx.Profile, "reason": reason})
 			if sup := srv.supervisor(); sup != nil {
 				sup.StopAll(reason)
 			}
@@ -232,8 +247,8 @@ func RunForeground(ctx *clictx.Context, opts StartOpts) error {
 	}
 
 	go func() {
-		<-stop
-		srv.shutdown("signal")
+		sig := <-stop
+		srv.shutdown("signal:" + sig.String())
 	}()
 
 	if err := httpSrv.Serve(ln); err != nil && err != http.ErrServerClosed {
@@ -386,11 +401,38 @@ func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // reloadCredentials 重读凭据并增量刷新隧道。持 shareMu 写锁做整体替换；
 // supervisor.Apply 里的网络操作是非阻塞的（隧道在各自 goroutine 建连），
 // 不会长时间占住写锁。
+// credentialSummary deliberately selects metadata rather than serializing the
+// credential set. Short SHA-256 fingerprints correlate rotations without key text.
+func credentialSummary(set creds.CredentialSet) map[string]any {
+	entries := make([]map[string]any, 0, len(set.Entries))
+	for _, entry := range set.Entries {
+		sum := sha256.Sum256([]byte(entry.Key))
+		entries = append(entries, map[string]any{"label": entry.Label, "source": entry.Source, "default": entry.Default, "fingerprint": fmt.Sprintf("sha256:%x", sum[:6])})
+	}
+	summary := map[string]any{"mode": set.Mode, "path": set.Location, "count": len(entries), "entries": entries, "legacyPresent": set.LegacyAPIKeyPresent, "shadowedKeychainPresent": set.ShadowedKeychainPresent, "warningCount": len(set.Warnings)}
+	if set.Location != "" {
+		raw, err := os.ReadFile(set.Location)
+		summary["fileReadable"] = err == nil
+		if err != nil {
+			summary["fileError"] = diagnostics.SafeError(err)
+		} else {
+			summary["fileValidJSON"] = json.Valid(raw)
+		}
+		if info, err := os.Stat(set.Location); err == nil {
+			summary["fileModifiedAt"] = info.ModTime().UTC().Format(time.RFC3339Nano)
+		}
+	}
+	return summary
+}
+
 func (s *server) reloadCredentials() (creds.CredentialSet, relay.ApplyResult) {
+	began := time.Now()
+	s.logger.Info(diagnostics.Message("credentials.reload_begin", map[string]any{"profile": s.ctx.Profile}))
 	set := creds.ResolveAPIKeyEntries()
 	relayResult := relay.ApplyResult{}
 	s.shareMu.Lock()
 	defer s.shareMu.Unlock()
+	before := credentialSummary(s.credentialSet)
 	s.credentialSet = set
 	if s.ingressMode == config.IngressStandalone && s.cfg.Relay.Enabled {
 		if s.tunnelSupervisor == nil && len(set.Entries) > 0 {
@@ -410,6 +452,10 @@ func (s *server) reloadCredentials() (creds.CredentialSet, relay.ApplyResult) {
 		if s.tunnelSupervisor != nil {
 			relayResult = s.tunnelSupervisor.Apply(set)
 		}
+	}
+	s.logger.Info(diagnostics.Message("credentials.reload_applied", map[string]any{"profile": s.ctx.Profile, "elapsedMs": time.Since(began).Milliseconds(), "before": before, "after": credentialSummary(set), "relayEnabled": s.cfg.Relay.Enabled, "ingress": s.ingressMode, "started": relayResult.Started, "stopped": relayResult.Stopped, "restarted": relayResult.Restarted, "unchanged": relayResult.Unchanged, "connectionConfirmed": false}))
+	if len(set.Entries) == 0 {
+		s.logger.Warn("credentials.reload: no usable API keys; Relay cannot connect")
 	}
 	return set, relayResult
 }

--- a/internal/diagnostics/events.go
+++ b/internal/diagnostics/events.go
@@ -1,0 +1,68 @@
+// Package diagnostics records low-frequency lifecycle events without dumping
+// command lines, configuration, environment values, or credential objects.
+package diagnostics
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var secret = regexp.MustCompile(`(?i)(api[_-]?key|token|authorization|password)([=:]\s*)([^\s&,;]+)`)
+var bearer = regexp.MustCompile(`(?i)Bearer\s+[^\s",;]+`)
+var apiKey = regexp.MustCompile(`ock-[a-zA-Z0-9_-]+`)
+
+// SafeError is defense in depth for errors from native service commands.
+// Callers must still never supply credentials, raw config or environment dumps.
+func SafeError(err error) string {
+	if err == nil {
+		return ""
+	}
+	s := bearer.ReplaceAllString(err.Error(), "Bearer [redacted]")
+	s = secret.ReplaceAllString(s, "${1}${2}[redacted]")
+	s = apiKey.ReplaceAllString(s, "[redacted]")
+	if len(s) > 2048 {
+		s = s[:2048] + "…"
+	}
+	return s
+}
+
+func Message(event string, fields map[string]any) string {
+	data := make(map[string]any, len(fields)+2)
+	data["event"] = event
+	data["pid"] = os.Getpid()
+	for key, value := range fields {
+		data[key] = value
+	}
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Sprintf("event=%q encoding_failed=true", event)
+	}
+	return string(raw)
+}
+
+// Write uses one append write per event. Failures go to stderr so broken log
+// permissions remain visible in the service journal; diagnostics never stop work.
+func Write(root, level, event string, fields map[string]any) {
+	if root == "" {
+		return
+	}
+	path := filepath.Join(root, "logs", "daemon-supervisor.log")
+	line := time.Now().Format("2006-01-02T15:04:05.000Z07:00") + " [" + strings.ToUpper(level) + "] " + Message(event, fields) + "\n"
+	err := os.MkdirAll(filepath.Dir(path), 0700)
+	if err == nil {
+		var file *os.File
+		file, err = os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+		if err == nil {
+			_, err = file.WriteString(line)
+			_ = file.Close()
+		}
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "diagnostic log write failed path=%q: %s\n%s", path, SafeError(err), line)
+	}
+}

--- a/internal/diagnostics/events_test.go
+++ b/internal/diagnostics/events_test.go
@@ -1,0 +1,30 @@
+package diagnostics
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSafeErrorRedactsCredentials(t *testing.T) {
+	got := SafeError(errors.New("dial wss://host/ws?apiKey=secret123&token=token456 Authorization=Bearer bearer789 ock-cli-abc123"))
+	for _, secret := range []string{"secret123", "token456", "bearer789", "ock-cli-abc123"} {
+		if strings.Contains(got, secret) {
+			t.Fatalf("secret leaked: %s", got)
+		}
+	}
+}
+func TestWriteEscapesLinesAndPreservesEvents(t *testing.T) {
+	root := t.TempDir()
+	Write(root, "info", "service.entry", map[string]any{"profile": "line1\nline2"})
+	Write(root, "error", "service.failed", map[string]any{"reason": "executable_mismatch"})
+	raw, err := os.ReadFile(filepath.Join(root, "logs", "daemon-supervisor.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(string(raw), "\n") != 2 || !strings.Contains(string(raw), "executable_mismatch") {
+		t.Fatalf("invalid event output: %s", raw)
+	}
+}

--- a/internal/relay/client.go
+++ b/internal/relay/client.go
@@ -158,6 +158,12 @@ func (c *Client) connectOnce() error {
 		status := ""
 		if result.resp != nil {
 			status = result.resp.Status
+			if result.resp.Body != nil {
+				_ = result.resp.Body.Close()
+			}
+			if result.resp.StatusCode == 401 || result.resp.StatusCode == 403 {
+				c.opts.Logger.Warn(fmt.Sprintf("Relay authentication rejected: status=%d; daemon is running; verify the credential source/fingerprint in credentials.reload_applied and server authorization", result.resp.StatusCode))
+			}
 		}
 		if status != "" {
 			return fmt.Errorf("websocket dial failed: %s (%s)", result.err.Error(), status)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {

--- a/scripts/install-wuying.sh
+++ b/scripts/install-wuying.sh
@@ -241,3 +241,8 @@ info "CLI: $CLI"
 info "profile: $PROFILE"
 info "Skill host: $SKILL_AGENT"
 info "Cloud environment: $CLOUD_ENV"
+
+case ":${PATH:-}:" in
+  *:"${CLI%/*}":*) ;;
+  *) warn "当前 PATH 不含 ${CLI%/*}；请使用完整路径 $CLI，或安装时传 --modify-path 并重新打开终端" ;;
+esac


### PR DESCRIPTION
## 0.10.2 正式版

发布已由 tag `cli-v0.10.2` 触发，本 PR 仅为把代码合回主干。

### 变更
- `daemon autostart enable --boot`：Linux 显式为当前用户开启 linger，支持无人登录时开机启动；`disable` 不撤销 linger（可能被其他用户服务使用）
- `autostart status` / `doctor` 报告 `linger`、`unitEnabled`、`bootEnabled` 与 `bootWarning`
- 新增 `internal/diagnostics`：低频生命周期事件写入 `daemon-supervisor.log`，自动脱敏 token / api key，不落盘凭据内容
- `daemon logs --diagnostics`：汇总进程身份、锁状态、自启状态与本次启动的 systemd/journal 记录；`--lines` 限制在 1..1000
- 锁状态补充 `reason` / `actualExecutable`，区分「进程已死」与「进程身份校验不匹配」
- systemd unit 的 `StandardOutput`/`StandardError` 按标量路径转义（`%%` 而非引号）
- README / README.zh-CN 补充 Linux 开机自启与诊断说明

### 验证
`gofmt`（本次改动文件）、`go build ./...`、`go vet ./...`、`go test ./...` 全部通过（macOS 本地）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)