### PR TITLE
style: gofmt 四个测试文件

### DIFF
--- a/internal/creds/store_test.go
+++ b/internal/creds/store_test.go
@@ -66,9 +66,9 @@ func TestIsValidAPIKeyLabel(t *testing.T) {
 func TestMaskSecret(t *testing.T) {
 	t.Parallel()
 	cases := map[string]string{
-		"":                 "",
-		"short":            "***",
-		"12345678":         "***",
+		"":                  "",
+		"short":             "***",
+		"12345678":          "***",
 		"sk-1234567890abcd": "sk-1***abcd",
 	}
 	for in, want := range cases {

--- a/internal/monitor/store_test.go
+++ b/internal/monitor/store_test.go
@@ -46,10 +46,10 @@ func TestCreateGetList(t *testing.T) {
 func TestCreateValidation(t *testing.T) {
 	p := testutil.Sandbox(t)
 	bad := []CreateInput{
-		{Description: "d", MatchRules: 1, Schedule: "s"},          // 无 name
-		{Name: "n", MatchRules: 1, Schedule: "s"},                 // 无 description
-		{Name: "n", Description: "d", Schedule: "s"},              // 无 matchRules
-		{Name: "n", Description: "d", MatchRules: 1},              // 无 schedule
+		{Description: "d", MatchRules: 1, Schedule: "s"}, // 无 name
+		{Name: "n", MatchRules: 1, Schedule: "s"},        // 无 description
+		{Name: "n", Description: "d", Schedule: "s"},     // 无 matchRules
+		{Name: "n", Description: "d", MatchRules: 1},     // 无 schedule
 	}
 	for i, in := range bad {
 		if _, err := Create(p, in); err == nil {

--- a/internal/notif/feishu_test.go
+++ b/internal/notif/feishu_test.go
@@ -19,11 +19,11 @@ func TestIsFeishuApp(t *testing.T) {
 func TestExtractColonSender(t *testing.T) {
 	t.Parallel()
 	tests := map[string]string{
-		"Alice: hi":   "Alice",
-		"Bob：你好":      "Bob",
-		"no colon":    "",
-		"":            "",
-		":leading":    "",
+		"Alice: hi": "Alice",
+		"Bob：你好":    "Bob",
+		"no colon":  "",
+		"":          "",
+		":leading":  "",
 	}
 	for in, want := range tests {
 		if got := extractColonSender(in); got != want {

--- a/internal/notif/query_test.go
+++ b/internal/notif/query_test.go
@@ -42,12 +42,12 @@ func TestBuildQueryOptions(t *testing.T) {
 func TestBuildQueryOptionsErrors(t *testing.T) {
 	t.Parallel()
 	cases := []RawQueryOpts{
-		{ConversationType: "channel"},                                            // 非法 type
-		{From: "bad-date"},                                                       // 非法 from
-		{To: "bad-date"},                                                         // 非法 to
-		{From: "2026-06-30T00:00:00Z", To: "2026-06-01T00:00:00Z"},               // from > to
-		{Limit: "0"},                                                             // limit <= 0
-		{Limit: "abc"},                                                           // limit 非数字
+		{ConversationType: "channel"}, // 非法 type
+		{From: "bad-date"},            // 非法 from
+		{To: "bad-date"},              // 非法 to
+		{From: "2026-06-30T00:00:00Z", To: "2026-06-01T00:00:00Z"}, // from > to
+		{Limit: "0"},   // limit <= 0
+		{Limit: "abc"}, // limit 非数字
 	}
 	for i, c := range cases {
 		if _, err := BuildQueryOptions(c, 20); err == nil {


### PR DESCRIPTION
`gofmt -l internal cmd` 此前长期报这四个文件（map 字面量/行尾注释按显示宽度对齐，与 gofmt 的算法不一致）：

- `internal/creds/store_test.go`
- `internal/monitor/store_test.go`
- `internal/notif/feishu_test.go`
- `internal/notif/query_test.go`

本 PR 只跑了 `gofmt -w`，纯空白对齐，无逻辑改动。现在 `gofmt -l internal cmd` 为空。

`go test -count=1` 三个包全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)