### PR TITLE
feat(todo): 增加统一待办 CLI 命令与 Agent 使用规则

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,3 +517,20 @@ fingerprints and tunnel changes without logging keys or tokens. Applying credent
 does not confirm a connection: look for the subsequent `connected` or 401/403 logs.
 If no `service.entry` exists, inspect the collected systemd/journal records: an
 application cannot log before the OS has launched it.
+
+## AI TODO (0.11.0)
+
+`yc todo list|get|create|update|delete` manages cloud todos directly without a daemon. Use `--format json`.
+
+```sh
+yc --format json todo list --is-done false
+yc --format json todo get 841
+yc --format json todo create --title "Meeting" --due-at "2026-09-11T15:00:00+08:00" --is-full-day false
+yc --format json todo update 841 --is-done true
+yc --format json todo update 841 --is-done false
+yc --format json todo delete 841 --confirmed
+```
+
+Times are START times: ISO with explicit offsets, all-day dates, or JSON null for undated items. All commands accept `--json-file FILE` (`-` for stdin); field flags cannot be mixed with JSON. CLI list defaults to unfinished across all time; agents supply local day boundaries for natural-language today queries. Creation returns a `requestKey`; replay only the same request with `--request-key KEY` after an unknown outcome. Partial success remains `ok:false` with per-stage outcomes and a nonzero exit code. The `yoooclaw-todo` skill documents user-facing routing and confirmations.
+
+Endpoints share `/api/message/todo/agent/`; API Key and environment use existing configuration. The latest recorded backend rejected undated creation with `910001`; no silent time substitution is performed. See [implementation plan](docs/ai-todo-implementation-plan.md) for the contract and verification.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -512,3 +512,22 @@ CLI 不在 PATH 时使用 `/usr/local/bin/yoooclaw` 等实际安装路径。
 它只代表本地配置已应用，连接成功需随后出现 `connected`；401/403 会单独提示服务端鉴权拒绝。
 日志不输出完整 key、gateway token 或凭据文件内容。若连 `service.entry` 都没有，优先检查汇总中的
 systemd/journal；应用进程尚未运行时无法自行写启动日志。
+
+## AI TODO（0.11.0）
+
+`yc todo list|get|create|update|delete` 直接管理云端待办，无需 daemon，使用 `--format json` 获取结构化结果。
+
+```sh
+yc --format json todo list --is-done false
+yc --format json todo get 841
+yc --format json todo create --title '会议' --due-at '2026-09-11T15:00:00+08:00' --is-full-day false
+yc --format json todo update 841 --is-done true
+yc --format json todo update 841 --is-done false
+yc --format json todo delete 841 --confirmed
+```
+
+时间指开始时间：定时使用带偏移的 ISO，全天使用日期，无时间传 JSON null。命令支持 `--json-file FILE`（`-` 为 stdin），不能与字段参数混用。CLI 默认查询不限时间的未完成事项；Agent 查询“今天”时应显式传当地日界。
+
+创建返回 `requestKey`；结果未知时只用 `--request-key KEY` 和相同参数重放。部分成功通过 `ok:false`、分阶段结果及非零退出码呈现。`yoooclaw-todo` Skill 说明自然语言路由、创建后的查看入口及删除确认。
+
+所有接口统一位于 `/api/message/todo/agent/`，凭据及环境沿用已有配置。当前联调中无时间创建仍返回业务码 `910001`，不会自动补时间绕过。详见[实施与验证记录](docs/ai-todo-implementation-plan.md)。

--- a/docs/ai-todo-implementation-plan.md
+++ b/docs/ai-todo-implementation-plan.md
@@ -1,0 +1,102 @@
+# CLI 0.11.0 AI TODO 实施方案
+
+状态：已实现并完成单元测试、构建及测试区工具链联调；尚未提交或发布。版本号由发布流程处理。
+日期：2026-09-10。
+
+## 1. 分支与基线
+
+本仓库实际主分支是 master（不存在 main）。已 fetch origin，将本地 master 快进至 e53fec4，再依次创建 release/0.11.0、feat/0.11.0-ai-todo。实现先进入功能分支，再合入发布分支；本轮不发布、不推送。
+
+Hermes 对应分支为 feat/0.10.0-ai-todo，消费本项目产物。OpenClaw 参考实现为 openclaw-plugin 的 feat/ai-todo-tools，提交 7587628。共享的是接口和行为规范，Go 不依赖 TS 运行时。
+
+## 2. 范围及架构
+
+新增 yc/yoooclaw todo list、get、create、update、delete 五个命令。完成和恢复统一使用 update.isDone，不增设独立完成、恢复命令。CLI 直接调用云端，复用 profile、凭据及环境解析；不要求 daemon 在线，不在本地保存另一套待办，也不创建本地提醒任务。
+
+Go Client 负责鉴权、ISO 时间转换、校验、幂等、响应解析和部分成功。命令层负责参数解析及既有 JSON 输出规范。Hermes 只包装命令，不重复实现 HTTP 业务逻辑。
+
+本轮不扩展 yclib SDK 或 daemon RPC；现有 yclib 灯效走 daemon，不应为待办 CLI 强加此依赖。其他 Agent 通过统一命令及待办 Skill 复用。
+
+## 3. 对外接口（以实际联调修正为准）
+
+基础地址：https://<当前环境 host>/api/message/todo/agent。全部 POST，携带 Content-Type、Accept-Language、X-Api-Key-Id（裸 API Key）。不传 App JWT，不向模型暴露凭据，不允许请求跟随重定向泄露鉴权头。
+
+| 命令 | 路径 | 请求及结果 |
+| --- | --- | --- |
+| list | /query | isDone、startTime、endTime、keyword、pageNo、pageSize；items、pageNo、isLastPage |
+| get | /detail | todoId；item |
+| create | /create | requestId、title、dueAt、isFullDay；todoId、duplicated |
+| update（内容） | /update | todoId 及修改字段；item |
+| update（状态） | /status | todoIds、isDone；processedTodoIds |
+| delete | /deleteBatch | todoIds、deleteReason=manual_delete；processedTodoIds |
+
+成功同时要求 HTTP 成功、业务 code=000000 和响应结构合法。HTTP 200 可能包含业务错误。保留业务码及可读原因；纯文本错误（如 Jwt is missing）也需保留并脱敏。ID 全程字符串，避免大整数精度丢失。
+
+2026-09-10 联调：有时间创建、查询、详情、修改、状态、删除均已实际成功；专用测试待办 842 已清理。无时间创建仍观察到 910001：dueAt 不能为空，与 PRD/契约允许 null 不一致，需后端修复及复验，不能宣称已支持，不得自动补时间绕过。
+
+## 4. 命令契约
+
+目标参数语义与 OpenClaw ntf todo 一致，根命令沿用 yc/yoooclaw。
+
+```sh
+yc --format json todo list --is-done false --start-time '2026-09-11T00:00:00+08:00' --end-time '2026-09-12T00:00:00+08:00'
+yc --format json todo list --is-done null
+yc --format json todo get 841
+yc --format json todo create --title '会议' --due-at '2026-09-11T15:00:00+08:00' --is-full-day false
+yc --format json todo update 841 --title '审批会议'
+yc --format json todo update 841 --is-done true
+yc --format json todo update 841 --is-done false
+yc --format json todo delete 841 --confirmed
+```
+
+这些仅为接口设计示例，当前尚未实现。
+
+- list 默认未完成、不限时间、pageNo=1、pageSize=20；今天未完成的自然语言默认值由 Agent 解析成显式边界。isDone=null 表示全部状态，范围为左闭右开。
+- create 接收 --request-key，缺省生成并返回可复用键。未知结果使用原键及原参数核对/重试；不同请求使用新键。
+- update 只传指定字段。必须区分未传（保留）、null（清空）、false（布尔值）；拒绝冲突参数和空修改。
+- 支持结构化 JSON 文件及 stdin 输入；Hermes 推荐 stdin，避免标题和正文进入进程参数。结构化输入和字段参数冲突时拒绝，不暗中覆盖。
+- delete 支持多个 ID；要求显式确认参数，Hermes 仅在用户确认具体目标后传入。
+- 输出沿用现有 CLI envelope 和退出码；错误与部分成功退出非零但保留完整 JSON，不丢弃已成功部分。
+
+## 5. 时间、幂等和修改流程
+
+时间指开始时间。接收用户当前时区的 ISO（含偏移/Z），Go 转为 UTC 毫秒；不接收没有偏移的日期时间。全天使用 YYYY-MM-DD，并编码为业务日期的 UTC 零点；无时间用 JSON null，isFullDay=false。验证非法日期、时刻和时间区间。兼容数字毫秒输入时仅留给明确 CLI 调用，不要求模型计算时间戳。
+
+requestId 用 agent_todo_ 加 SHA-256 base64url，合计 54 字符，不超过服务端 64。由稳定调用键派生，重放一致；空键随机生成。创建传输失败至多自动重试一次，沿用相同 ID；业务错误不自动重试。旧格式长度 75 的问题不得带入 Go 实现。
+
+只修改状态时直接调用 status。修改内容时先 detail 校验目标及新手事项限制、合并后的时间，再 update。内容和状态同时修改：先内容后状态；内容失败停止，状态失败返回 contentUpdated=true、statusUpdated=false 和错误，只重试失败阶段。processedTodoIds 必须检查未处理 ID，不能把 HTTP 成功等同整批成功。
+
+## 6. 文件改造计划
+
+| 位置 | 计划 |
+| --- | --- |
+| internal/aitodo/client.go、time.go、types.go（新增） | 云端协议、参数与时间模型、幂等及错误处理 |
+| internal/cli/cmd_todo.go（新增）、root.go | Cobra 命令、stdin/文件输入、确认、统一输出 |
+| internal/creds、config、envhost（复用） | 当前 profile、测试/生产环境、凭据读取 |
+| skills/yoooclaw-todo/SKILL.md（后续新增） | 自然语言默认范围、创建引导、删除确认；不在本轮创建 |
+| internal/skills、assets.go 及相关测试 | 核对 Skill 打包、安装、升级发现链路 |
+| README.md、README.zh-CN.md | 命令示例、错误及重试说明 |
+
+## 7. 实施顺序与验收
+
+1. 固定命令输入输出及跨项目样例，先实现 Go Client 与时间转换。
+2. 接入命令，验证不开 daemon 也可执行；补充 Skill 与文档。
+3. 单测覆盖六个完整 URL、环境/凭据、ISO/全天/null、64 字符与重放、布尔三态、分页、响应结构、纯文本 401、业务错误、部分成功、重试上限。
+4. Go test/vet 及项目要求的构建检查；跨平台核对 stdin 和 JSON 输出。
+5. 测试区仅创建标记明确的测试事项，完成查询→详情→改标题/时间→完成→恢复→删除；记录响应并确认清理，不修改用户已有待办。无时间用例单列后端依赖。
+6. CLI 发布可供 Hermes 打包的 0.11.0 产物；Hermes 完成安装与真实模型验收后再进入对应发布流程。
+
+单次 HTTP 预算建议 30 秒，创建重试及复合修改的总时长须受整体截止时间约束。与 Hermes 约定待办命令整体不超过 100 秒、宿主包装超时 120 秒；取消后结果未知需如实反馈，不能换新键重建。
+
+## 8. 实施记录（2026-09-10）
+
+已落地 internal/aitodo（client、time）、internal/cli/cmd_todo、命令注册、yoooclaw-todo Skill、两种 README 和回归测试。结构化输入统一使用 --json-file FILE / -；CLI 默认无时间创建可表达，但后端当前仍拒绝。
+
+验证结果：
+- 待办客户端、参数、CLI 与 Skill 测试通过；Go vet 通过。
+- Go 全量首次仅新增 Skill 清单预期和录音测试临时目录清理失败；更新 Skill 预期后，Skill 与录音包均复跑通过。录音业务代码未修改。
+- Hermes 真实 handler → 编译 CLI → 测试区：定时创建、查询、详情、标题修改、完成、恢复、删除均成功（测试 ID 883 已删除）。
+- 全天创建及详情成功（测试 ID 884 已删除）；无时间创建仍返回 910001 / dueAt 不能为空，未擅自补时间。
+- 本轮测试未替换现有 CLI、OpenClaw 或 Hermes 安装；编译产物存于临时目录。
+
+正式发布仍需先发布含本功能的 CLI 0.11.0，再打包 Hermes。后续宿主真实聊天入口的模型路由和删除确认体验需安装后验收；本轮的真实接口联调不等同于完成该项模型验收。

--- a/internal/aitodo/client.go
+++ b/internal/aitodo/client.go
@@ -1,0 +1,320 @@
+// Package aitodo implements the cloud AI TODO contract shared by CLI consumers.
+package aitodo
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/YoooClaw/cli/internal/envhost"
+)
+
+const APIPath = "/api/message/todo/agent"
+
+type Fields = map[string]any
+type Error struct {
+	Code    string
+	Message string
+}
+
+func (e *Error) Error() string     { return e.Message }
+func invalid(message string) error { return &Error{"INVALID_PARAMS", message} }
+func Payload(err error) Fields {
+	code := "INTERNAL_ERROR"
+	message := "AI TODO operation failed"
+	if e, ok := err.(*Error); ok {
+		code = e.Code
+		message = e.Message
+	}
+	return Fields{"ok": false, "error": Fields{"code": code, "message": message}}
+}
+func NewRequestKey() (string, error) {
+	b := make([]byte, 24)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+func RequestID(key string) string {
+	digest := sha256.Sum256([]byte(key))
+	return "agent_todo_" + base64.RawURLEncoding.EncodeToString(digest[:])
+}
+
+type Client struct {
+	APIKey, Host, BaseURL, Language string
+	HTTPClient                      *http.Client
+}
+
+func (c *Client) request(ctx context.Context, path string, body Fields) (Fields, error) {
+	base := c.BaseURL
+	if base == "" {
+		host := envhost.Normalize(c.Host)
+		if host == "" {
+			host = envhost.Host()
+		}
+		base = "https://" + host + APIPath
+	}
+	key := strings.TrimSpace(c.APIKey)
+	if len(key) >= 7 && strings.EqualFold(key[:7], "Bearer ") {
+		key = strings.TrimSpace(key[7:])
+	}
+	if key == "" {
+		return nil, &Error{"AUTH_REQUIRED", "Configure the plugin API Key before using AI TODO"}
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, invalid("Request is not valid JSON")
+	}
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(base, "/")+"/"+path, bytes.NewReader(raw))
+	if err != nil {
+		return nil, invalid("Invalid API URL")
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Api-Key-Id", key)
+	lang := c.Language
+	if lang == "" {
+		lang = "zh-CN"
+	}
+	req.Header.Set("Accept-Language", lang)
+	client := http.Client{}
+	if c.HTTPClient != nil {
+		client = *c.HTTPClient
+	}
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, &Error{"REQUEST_FAILED", "AI TODO request failed or timed out; write outcome may be unknown"}
+	}
+	defer res.Body.Close()
+	raw, err = io.ReadAll(io.LimitReader(res.Body, 4*1024*1024+1))
+	if err != nil {
+		return nil, &Error{"REQUEST_FAILED", "AI TODO response interrupted; write outcome may be unknown"}
+	}
+	if len(raw) > 4*1024*1024 {
+		return nil, badResponse()
+	}
+	var bean Fields
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	parseErr := dec.Decode(&bean)
+	if parseErr == nil {
+		var trailing any
+		if dec.Decode(&trailing) != io.EOF {
+			return nil, badResponse()
+		}
+	}
+	code, _ := bean["code"].(string)
+	if res.StatusCode < 200 || res.StatusCode >= 300 || (code != "" && code != "000000") {
+		if code == "" || code == "000000" {
+			code = fmt.Sprintf("HTTP_%d", res.StatusCode)
+		}
+		msg, _ := bean["msg"].(string)
+		if msg == "" && parseErr != nil {
+			msg = strings.TrimSpace(string(raw))
+		}
+		if msg == "" {
+			msg = "AI TODO request failed"
+		}
+		msg = strings.ReplaceAll(msg, key, "[REDACTED]")
+		if len(msg) > 1000 {
+			msg = msg[:1000]
+		}
+		return nil, &Error{code, msg}
+	}
+	data, ok := bean["data"].(map[string]any)
+	if parseErr != nil || code != "000000" || !ok || data == nil {
+		return nil, badResponse()
+	}
+	return data, nil
+}
+func badResponse() error {
+	return &Error{"INVALID_RESPONSE", "AI TODO returned an invalid response; write outcome may be unknown"}
+}
+func validID(v any) bool { s, ok := v.(string); return ok && strings.TrimSpace(s) != "" }
+func checkItem(v any) (Fields, error) {
+	item, ok := v.(map[string]any)
+	if !ok {
+		return nil, badResponse()
+	}
+	_, titleOK := item["title"].(string)
+	_, fullOK := item["isFullDay"].(bool)
+	_, doneOK := item["isDone"].(bool)
+	_, timePresent := item["dueAt"]
+	kind := item["todoType"]
+	if !validID(item["todoId"]) || !titleOK || !fullOK || !doneOK || !timePresent || !validMillis(item["dueAt"]) || (kind != "normal" && kind != "onboarding_guide" && kind != "onboarding_rule") {
+		return nil, badResponse()
+	}
+	return item, nil
+}
+func (c *Client) Execute(ctx context.Context, action string, raw Fields, requestKey string) (Fields, error) {
+	ctx, cancel := context.WithTimeout(ctx, 100*time.Second)
+	defer cancel()
+	p, err := Validate(action, raw)
+	if err != nil {
+		return nil, err
+	}
+	request := func(path string, body Fields) (Fields, error) { return c.request(ctx, path, body) }
+	switch action {
+	case "create":
+		if requestKey == "" {
+			requestKey, err = NewRequestKey()
+			if err != nil {
+				return nil, err
+			}
+		}
+		p["requestId"] = RequestID(requestKey)
+		data, e := request("create", p)
+		if ae, ok := e.(*Error); ok && ae.Code == "REQUEST_FAILED" && ctx.Err() == nil {
+			data, e = request("create", p)
+		}
+		if e != nil {
+			return nil, e
+		}
+		_, ok := data["duplicated"].(bool)
+		if !validID(data["todoId"]) || !ok {
+			return nil, badResponse()
+		}
+		data["ok"] = true
+		return data, nil
+	case "list":
+		data, e := request("query", p)
+		if e != nil {
+			return nil, e
+		}
+		items, ok := data["items"].([]any)
+		_, lastOK := data["isLastPage"].(bool)
+		if !ok || !lastOK || !sameNumber(data["pageNo"], p["pageNo"]) {
+			return nil, badResponse()
+		}
+		for _, item := range items {
+			if _, e = checkItem(item); e != nil {
+				return nil, e
+			}
+		}
+		data["ok"] = true
+		return data, nil
+	case "get":
+		data, e := request("detail", p)
+		if e != nil {
+			return nil, e
+		}
+		item, e := checkItem(data["item"])
+		if e != nil {
+			return nil, e
+		}
+		if item["todoId"] != p["todoId"] {
+			return nil, badResponse()
+		}
+		data["ok"] = true
+		return data, nil
+	case "delete":
+		return c.process(ctx, "deleteBatch", Fields{"todoIds": p["todoIds"], "deleteReason": "manual_delete"}, p["todoIds"].([]string))
+	}
+	patch := Fields{}
+	for k, v := range p {
+		if k != "isDone" {
+			patch[k] = v
+		}
+	}
+	hasContent := len(patch) > 1
+	var updated Fields
+	if hasContent {
+		data, e := request("detail", Fields{"todoId": p["todoId"]})
+		if e != nil {
+			return nil, e
+		}
+		current, e := checkItem(data["item"])
+		if e != nil {
+			return nil, e
+		}
+		if current["todoId"] != p["todoId"] {
+			return nil, badResponse()
+		}
+		if current["todoType"] != "normal" {
+			return nil, &Error{"NOT_EDITABLE", "Onboarding todos cannot be edited"}
+		}
+		merged := Fields{}
+		for _, k := range []string{"title", "dueAt", "isFullDay"} {
+			merged[k] = current[k]
+			if v, exists := patch[k]; exists {
+				merged[k] = v
+			}
+		}
+		if v, exists := patch["dueAt"]; exists && v == nil {
+			merged["isFullDay"] = false
+			patch["isFullDay"] = false
+		}
+		if _, e = Validate("create", merged); e != nil {
+			return nil, e
+		}
+		data, e = request("update", patch)
+		if e != nil {
+			return nil, e
+		}
+		updated, e = checkItem(data["item"])
+		if e != nil {
+			return nil, e
+		}
+		if updated["todoId"] != p["todoId"] {
+			return nil, badResponse()
+		}
+	}
+	if done, exists := p["isDone"]; exists {
+		ids := []string{p["todoId"].(string)}
+		result, e := c.process(ctx, "status", Fields{"todoIds": ids, "isDone": done}, ids)
+		if e != nil {
+			if !hasContent {
+				return nil, e
+			}
+			result = Payload(e)
+			result["statusOutcome"] = "unknown"
+		}
+		result["todoId"] = p["todoId"]
+		result["contentUpdated"] = hasContent
+		result["statusUpdated"] = result["ok"] == true
+		if result["ok"] == true {
+			result["isDone"] = done
+		}
+		return result, nil
+	}
+	return Fields{"ok": true, "contentUpdated": true, "item": updated}, nil
+}
+func (c *Client) process(ctx context.Context, path string, body Fields, ids []string) (Fields, error) {
+	data, err := c.request(ctx, path, body)
+	if err != nil {
+		return nil, err
+	}
+	raw, ok := data["processedTodoIds"].([]any)
+	if !ok {
+		return nil, badResponse()
+	}
+	allowed := map[string]bool{}
+	for _, id := range ids {
+		allowed[id] = true
+	}
+	processed := map[string]bool{}
+	for _, v := range raw {
+		id, ok := v.(string)
+		if !ok || !allowed[id] {
+			return nil, badResponse()
+		}
+		processed[id] = true
+	}
+	missing := []string{}
+	for _, id := range ids {
+		if !processed[id] {
+			missing = append(missing, id)
+		}
+	}
+	return Fields{"ok": len(missing) == 0, "processedTodoIds": raw, "unprocessedTodoIds": missing}, nil
+}

--- a/internal/aitodo/client_test.go
+++ b/internal/aitodo/client_test.go
@@ -1,0 +1,198 @@
+package aitodo
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func item() Fields {
+	return Fields{"todoId": "9007199254740993", "todoType": "normal", "title": "会议", "dueAt": nil, "isFullDay": false, "isDone": false}
+}
+func serve(t *testing.T, fn func(string, Fields) (int, any)) (*Client, func()) {
+	t.Helper()
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" || r.Header.Get("X-Api-Key-Id") != "test" || r.Header.Get("Accept-Language") == "" {
+			t.Error("invalid method/auth/language")
+		}
+		var b Fields
+		d := json.NewDecoder(r.Body)
+		d.UseNumber()
+		if e := d.Decode(&b); e != nil {
+			t.Error(e)
+		}
+		status, data := fn(r.URL.Path, b)
+		w.WriteHeader(status)
+		if raw, ok := data.(string); ok {
+			fmt.Fprint(w, raw)
+		} else {
+			json.NewEncoder(w).Encode(Fields{"code": "000000", "data": data})
+		}
+	}))
+	return &Client{APIKey: "Bearer test", BaseURL: s.URL + APIPath}, s.Close
+}
+func TestAllEndpointsAndPartialStatus(t *testing.T) {
+	var paths []string
+	c, close := serve(t, func(path string, b Fields) (int, any) {
+		paths = append(paths, path)
+		switch path {
+		case APIPath + "/create":
+			if len(b["requestId"].(string)) > 64 {
+				t.Error("long requestId")
+			}
+			return 200, Fields{"todoId": item()["todoId"], "duplicated": false}
+		case APIPath + "/query":
+			if b["isDone"] != nil {
+				t.Error("all statuses lost")
+			}
+			return 200, Fields{"items": []any{item()}, "pageNo": b["pageNo"], "isLastPage": true}
+		case APIPath + "/detail":
+			return 200, Fields{"item": item()}
+		case APIPath + "/update":
+			v := item()
+			v["title"] = b["title"]
+			return 200, Fields{"item": v}
+		case APIPath + "/status":
+			return 401, "Jwt is missing"
+		case APIPath + "/deleteBatch":
+			if b["deleteReason"] != "manual_delete" {
+				t.Error("wrong deletion reason")
+			}
+			return 200, Fields{"processedTodoIds": []string{item()["todoId"].(string)}}
+		}
+		t.Fatal(path)
+		return 500, nil
+	})
+	defer close()
+	ctx := context.Background()
+	id := item()["todoId"]
+	for _, tc := range []struct {
+		a string
+		p Fields
+	}{{"create", Fields{"title": "会议", "dueAt": nil, "isFullDay": false}}, {"list", Fields{"isDone": nil}}, {"get", Fields{"todoId": id}}} {
+		if _, e := c.Execute(ctx, tc.a, tc.p, "call"); e != nil {
+			t.Fatal(e)
+		}
+	}
+	out, e := c.Execute(ctx, "update", Fields{"todoId": id, "title": "审批会议", "isDone": true}, "")
+	if e != nil {
+		t.Fatal(e)
+	}
+	if out["ok"] != false || out["contentUpdated"] != true || out["statusUpdated"] != false {
+		t.Fatalf("partial state lost: %#v", out)
+	}
+	if _, e = c.Execute(ctx, "delete", Fields{"todoIds": []string{id.(string)}, "confirmed": true}, ""); e != nil {
+		t.Fatal(e)
+	}
+	want := []string{"create", "query", "detail", "detail", "update", "status", "deleteBatch"}
+	for i, p := range want {
+		if paths[i] != APIPath+"/"+p {
+			t.Fatal(paths)
+		}
+	}
+}
+func TestCreateRetryUsesSameRequestID(t *testing.T) {
+	var ids []any
+	c, close := serve(t, func(_ string, b Fields) (int, any) {
+		ids = append(ids, b["requestId"])
+		return 200, Fields{"todoId": "1", "duplicated": false}
+	})
+	defer close()
+	p := Fields{"title": "x", "dueAt": nil, "isFullDay": false}
+	for _, key := range []string{strings.Repeat("a", 1000), strings.Repeat("a", 1000), "other"} {
+		if _, e := c.Execute(context.Background(), "create", p, key); e != nil {
+			t.Fatal(e)
+		}
+	}
+	if ids[0] != ids[1] || ids[0] == ids[2] || len(ids[0].(string)) != 54 {
+		t.Fatal(ids)
+	}
+	// Drop first response after receiving the request to model an unknown write outcome.
+	var attempts int
+	var first string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var b Fields
+		json.NewDecoder(r.Body).Decode(&b)
+		id := b["requestId"].(string)
+		attempts++
+		if attempts == 1 {
+			first = id
+			conn, _, _ := w.(http.Hijacker).Hijack()
+			conn.Close()
+			return
+		}
+		if id != first {
+			t.Error("retry changed ID")
+		}
+		json.NewEncoder(w).Encode(Fields{"code": "000000", "data": Fields{"todoId": "1", "duplicated": true}})
+	}))
+	defer server.Close()
+	c.BaseURL = server.URL
+	out, e := c.Execute(context.Background(), "create", p, "retry")
+	if e != nil || out["duplicated"] != true || attempts != 2 {
+		t.Fatalf("%v %v %d", out, e, attempts)
+	}
+}
+func TestBusinessAndHTTPFailures(t *testing.T) {
+	for _, tc := range []struct {
+		status    int
+		raw, code string
+	}{{401, "Jwt is missing", "HTTP_401"}, {200, `{"code":"910001","msg":"dueAt 不能为空","data":null}`, "910001"}, {200, `{"code":"000000","data":null}`, "INVALID_RESPONSE"}, {200, `{"code":"000000","data":{"todoId":1,"duplicated":false}}`, "INVALID_RESPONSE"}} {
+		t.Run(tc.code+fmt.Sprint(tc.status), func(t *testing.T) {
+			n := 0
+			c, close := serve(t, func(_ string, _ Fields) (int, any) { n++; return tc.status, tc.raw })
+			defer close()
+			_, e := c.Execute(context.Background(), "create", Fields{"title": "x", "dueAt": nil, "isFullDay": false}, "k")
+			if e == nil || e.(*Error).Code != tc.code || n != 1 {
+				t.Fatalf("error %v attempts %d", e, n)
+			}
+		})
+	}
+}
+func TestStatusOnlyAndMissingIDs(t *testing.T) {
+	var paths []string
+	c, close := serve(t, func(p string, b Fields) (int, any) {
+		paths = append(paths, p)
+		return 200, Fields{"processedTodoIds": []string{}}
+	})
+	defer close()
+	for _, done := range []bool{true, false} {
+		v, e := c.Execute(context.Background(), "update", Fields{"todoId": "1", "isDone": done}, "")
+		if e != nil || v["ok"] != false || v["contentUpdated"] != false {
+			t.Fatal(v, e)
+		}
+	}
+	if !reflect.DeepEqual(paths, []string{APIPath + "/status", APIPath + "/status"}) {
+		t.Fatal(paths)
+	}
+}
+func TestRejectRedirectAndForeignID(t *testing.T) {
+	leaked := false
+	dest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { leaked = true }))
+	defer dest.Close()
+	src := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { http.Redirect(w, r, dest.URL, 307) }))
+	defer src.Close()
+	c := Client{APIKey: "test", BaseURL: src.URL}
+	_, err := c.Execute(context.Background(), "get", Fields{"todoId": "1"}, "")
+	if err == nil || leaked {
+		t.Fatal("redirect followed", err)
+	}
+	c2, close := serve(t, func(string, Fields) (int, any) { return 200, Fields{"processedTodoIds": []string{"foreign"}} })
+	defer close()
+	if _, e := c2.Execute(context.Background(), "delete", Fields{"todoIds": []string{"1"}, "confirmed": true}, ""); e == nil {
+		t.Fatal("accepted foreign processed ID")
+	}
+}
+func TestContentFailureStopsStatus(t *testing.T) {
+	calls := 0
+	c, close := serve(t, func(p string, b Fields) (int, any) { calls++; return 401, "Jwt is missing" })
+	defer close()
+	if _, err := c.Execute(context.Background(), "update", Fields{"todoId": "1", "title": "x", "isDone": true}, ""); err == nil || calls != 1 {
+		t.Fatal(err, calls)
+	}
+}

--- a/internal/aitodo/time.go
+++ b/internal/aitodo/time.go
@@ -1,0 +1,230 @@
+package aitodo
+
+import (
+	"encoding/json"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+var isoDate = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
+var isoInstant = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(\.\d{1,3})?)?(Z|[+-]\d{2}:\d{2})$`)
+
+func integer(v any) (int64, bool) {
+	switch n := v.(type) {
+	case json.Number:
+		i, e := n.Int64()
+		return i, e == nil
+	case int:
+		return int64(n), true
+	case int64:
+		return n, true
+	case float64:
+		if !math.IsNaN(n) && !math.IsInf(n, 0) && n == math.Trunc(n) && math.Abs(n) <= 8640000000000000 {
+			return int64(n), true
+		}
+	}
+	return 0, false
+}
+func sameNumber(a, b any) bool { x, ok := integer(a); y, ok2 := integer(b); return ok && ok2 && x == y }
+func validMillis(v any) bool {
+	if v == nil {
+		return true
+	}
+	n, ok := integer(v)
+	return ok && n >= -8640000000000000 && n <= 8640000000000000
+}
+func isoMillis(s string, allDay bool) (int64, error) {
+	if allDay && isoDate.MatchString(s) {
+		d, e := time.Parse("2006-01-02", s)
+		if e != nil {
+			return 0, invalid("Invalid calendar date")
+		}
+		return d.UnixMilli(), nil
+	}
+	if !isoInstant.MatchString(s) || strings.HasSuffix(s, "-00:00") {
+		return 0, invalid("Use ISO START time with an explicit timezone offset; all-day items use YYYY-MM-DD; unset time uses JSON null")
+	}
+	// Go accepts out-of-range zone components; validate before parsing.
+	if !strings.HasSuffix(s, "Z") {
+		zone := s[len(s)-6:]
+		h, _ := strconv.Atoi(zone[1:3])
+		m, _ := strconv.Atoi(zone[4:])
+		if h > 23 || m > 59 {
+			return 0, invalid("Invalid timezone offset")
+		}
+	}
+	// RFC3339 requires seconds; the tool contract also accepts minute precision.
+	zoneStart := len(s) - 1
+	if !strings.HasSuffix(s, "Z") {
+		zoneStart = len(s) - 6
+	}
+	if zoneStart == 16 {
+		s = s[:16] + ":00" + s[16:]
+	}
+	t, e := time.Parse(time.RFC3339Nano, s)
+	if e != nil {
+		return 0, invalid("Invalid ISO start time")
+	}
+	if allDay {
+		t, e = time.Parse("2006-01-02", s[:10])
+		if e != nil {
+			return 0, invalid("Invalid calendar date")
+		}
+	}
+	return t.UnixMilli(), nil
+}
+
+var fields = map[string][]string{
+	"list": {"isDone", "startTime", "endTime", "keyword", "pageNo", "pageSize"}, "get": {"todoId"},
+	"create": {"title", "dueAt", "isFullDay"}, "update": {"todoId", "title", "dueAt", "isFullDay", "isDone"}, "delete": {"todoIds", "confirmed"},
+}
+
+func Validate(action string, raw Fields) (Fields, error) {
+	allowed, ok := fields[action]
+	if !ok {
+		return nil, invalid("Unknown todo action")
+	}
+	if raw == nil {
+		return nil, invalid("Expected a JSON object")
+	}
+	p := Fields{}
+	for k, v := range raw {
+		found := false
+		for _, a := range allowed {
+			if k == a {
+				found = true
+			}
+		}
+		if !found {
+			return nil, invalid("Unsupported field: " + k)
+		}
+		p[k] = v
+	}
+	for _, k := range []string{"dueAt", "startTime", "endTime"} {
+		if s, ok := p[k].(string); ok {
+			ms, e := isoMillis(s, k == "dueAt" && p["isFullDay"] == true)
+			if e != nil {
+				return nil, e
+			}
+			p[k] = ms
+			if k == "dueAt" && action == "update" {
+				if _, exists := p["isFullDay"]; !exists {
+					p["isFullDay"] = false
+				}
+			}
+		}
+		if v, exists := p[k]; exists && !validMillis(v) {
+			return nil, invalid(k + " must be ISO time, Unix milliseconds or null")
+		}
+	}
+	if action == "get" || action == "update" {
+		if !validID(p["todoId"]) {
+			return nil, invalid("todoId must be a nonempty string returned by the service")
+		}
+	}
+	if action == "create" || rawHas(p, "title") {
+		s, ok := p["title"].(string)
+		s = strings.TrimSpace(s)
+		if !ok || s == "" || utf8.RuneCountInString(s) > 30 {
+			return nil, invalid("title must contain 1–30 characters")
+		}
+		p["title"] = s
+	}
+	if action == "create" && (!rawHas(p, "dueAt") || !rawHas(p, "isFullDay")) {
+		return nil, invalid("dueAt and isFullDay are required")
+	}
+	if v, exists := p["isFullDay"]; exists {
+		if _, ok := v.(bool); !ok {
+			return nil, invalid("isFullDay must be boolean")
+		}
+	}
+	if v, exists := p["isDone"]; exists {
+		if _, ok := v.(bool); !ok && !(action == "list" && v == nil) {
+			return nil, invalid("isDone must be boolean (or null for all statuses in list)")
+		}
+	}
+	if p["isFullDay"] == true {
+		ms, ok := integer(p["dueAt"])
+		if !ok || ms%86400000 != 0 {
+			return nil, invalid("All-day dueAt must encode its business date at UTC midnight")
+		}
+	}
+	if action == "update" {
+		if len(p) <= 1 {
+			return nil, invalid("At least one update field is required")
+		}
+		if rawHas(p, "isFullDay") && !rawHas(p, "dueAt") {
+			return nil, invalid("Send dueAt together with isFullDay")
+		}
+	}
+	if action == "list" {
+		if p["startTime"] != nil && p["endTime"] != nil {
+			start, _ := integer(p["startTime"])
+			end, _ := integer(p["endTime"])
+			if end <= start {
+				return nil, invalid("endTime must be after startTime")
+			}
+		}
+		if v := p["keyword"]; v != nil {
+			s, ok := v.(string)
+			if !ok {
+				return nil, invalid("keyword must be string or null")
+			}
+			p["keyword"] = strings.TrimSpace(s)
+		}
+		if !rawHas(p, "isDone") {
+			p["isDone"] = false
+		}
+		if !rawHas(p, "pageNo") {
+			p["pageNo"] = 1
+		}
+		if p["pageSize"] == nil {
+			p["pageSize"] = 20
+		}
+		for _, k := range []string{"pageNo", "pageSize"} {
+			n, ok := integer(p[k])
+			if !ok || n < 1 || n > 9007199254740991 {
+				return nil, invalid(k + " must be a positive safe integer")
+			}
+			p[k] = n
+		}
+	}
+	if action == "delete" {
+		if p["confirmed"] != true {
+			return nil, invalid("Confirm the specific deletion before invoking delete")
+		}
+		var ids []string
+		switch v := p["todoIds"].(type) {
+		case []string:
+			ids = v
+		case []any:
+			for _, id := range v {
+				if !validID(id) {
+					return nil, invalid("todoIds must contain nonempty string IDs")
+				}
+				ids = append(ids, id.(string))
+			}
+		}
+		if len(ids) == 0 {
+			return nil, invalid("todoIds must not be empty")
+		}
+		seen := map[string]bool{}
+		out := []string{}
+		for _, id := range ids {
+			if !validID(id) {
+				return nil, invalid("Invalid todoId")
+			}
+			if !seen[id] {
+				out = append(out, id)
+				seen[id] = true
+			}
+		}
+		p["todoIds"] = out
+	}
+	return p, nil
+}
+func rawHas(p Fields, k string) bool { _, ok := p[k]; return ok }

--- a/internal/aitodo/time_test.go
+++ b/internal/aitodo/time_test.go
@@ -1,0 +1,42 @@
+package aitodo
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestTimeConversion(t *testing.T) {
+	for _, tc := range []struct {
+		s    string
+		day  bool
+		want int64
+	}{{"2026-09-11T15:00:00+08:00", false, 1789110000000}, {"2026-09-11T15:00+08:00", false, 1789110000000}, {"2026-09-11T07:00:00Z", false, 1789110000000}, {"2026-09-14", true, 1789344000000}, {"2026-09-14T15:00:00-07:00", true, 1789344000000}} {
+		n, e := isoMillis(tc.s, tc.day)
+		if e != nil || n != tc.want {
+			t.Errorf("%s: %d %v", tc.s, n, e)
+		}
+	}
+	for _, s := range []string{"", "2026-09-11", "2026-09-11T15:00:00", "2026-02-30T15:00:00+08:00", "2026-09-11T24:00:00Z", "2026-09-11T15:00:00+24:00", "2026-09-11T15:00:00+08:60", "2026-09-11T15:00:00-00:00"} {
+		if _, e := isoMillis(s, false); e == nil {
+			t.Error("accepted", s)
+		}
+	}
+}
+func TestValidation(t *testing.T) {
+	for _, tc := range []struct {
+		a string
+		p Fields
+	}{{"update", Fields{"todoId": "1"}}, {"update", Fields{"todoId": "1", "isDone": "false"}}, {"update", Fields{"todoId": "1", "isFullDay": false}}, {"create", Fields{"title": "x", "dueAt": nil, "isFullDay": true}}, {"get", Fields{"todoId": json.Number("9007199254740993")}}, {"list", Fields{"pageNo": nil}}, {"delete", Fields{"todoIds": []string{"1"}, "confirmed": false}}, {"delete", Fields{"todoIds": []string{}, "confirmed": true}}, {"list", Fields{"startTime": 3, "endTime": 2}}, {"list", Fields{"unknown": true}}} {
+		if _, e := Validate(tc.a, tc.p); e == nil {
+			t.Errorf("accepted %s %#v", tc.a, tc.p)
+		}
+	}
+	p, e := Validate("update", Fields{"todoId": "1", "dueAt": nil, "isDone": false})
+	if e != nil || p["dueAt"] != nil || p["isDone"] != false || rawHas(p, "title") {
+		t.Fatal(p, e)
+	}
+	p, e = Validate("list", Fields{"isDone": nil, "pageSize": nil})
+	if e != nil || p["isDone"] != nil || !sameNumber(p["pageSize"], 20) {
+		t.Fatal(p, e)
+	}
+}

--- a/internal/cli/cmd_todo.go
+++ b/internal/cli/cmd_todo.go
@@ -1,0 +1,188 @@
+package cli
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/YoooClaw/cli/internal/aitodo"
+	"github.com/YoooClaw/cli/internal/clictx"
+	"github.com/YoooClaw/cli/internal/creds"
+	"github.com/YoooClaw/cli/internal/errs"
+	"github.com/spf13/cobra"
+)
+
+var todoFlags = map[string]string{"title": "title", "due-at": "dueAt", "is-full-day": "isFullDay", "is-done": "isDone", "start-time": "startTime", "end-time": "endTime", "keyword": "keyword", "page-no": "pageNo", "page-size": "pageSize"}
+
+func newTodoCmd() *cobra.Command {
+	root := &cobra.Command{Use: "todo", Short: "管理云端待办（无需 daemon）"}
+	for _, action := range []string{"list", "get", "create", "update", "delete"} {
+		cmd := &cobra.Command{Use: action, Short: "AI TODO " + action, RunE: run(todoRun)}
+		if action == "get" || action == "update" {
+			cmd.Use += " [todoId]"
+			cmd.Args = cobra.MaximumNArgs(1)
+		} else if action == "delete" {
+			cmd.Use += " [todoIds...]"
+		} else {
+			cmd.Args = cobra.NoArgs
+		}
+		cmd.Flags().String("json-file", "", "Read a JSON object from file, or - for stdin; cannot combine with field flags")
+		switch action {
+		case "list":
+			for _, f := range []string{"is-done", "start-time", "end-time", "keyword", "page-no", "page-size"} {
+				cmd.Flags().String(f, "", "Filter "+f+"; time bounds accept ISO with timezone offsets or null")
+			}
+		case "create", "update":
+			cmd.Flags().String("title", "", "Todo title")
+			cmd.Flags().String("due-at", "", "START time: ISO with timezone offset, all-day YYYY-MM-DD, or null")
+			cmd.Flags().String("is-full-day", "", "true or false")
+			if action == "update" {
+				cmd.Flags().String("is-done", "", "true completes; false reopens")
+			} else {
+				cmd.Flags().String("request-key", "", "Reuse the returned key to retry the same creation after an unknown outcome")
+			}
+		case "delete":
+			cmd.Flags().Bool("confirmed", false, "Confirm deletion of these specific todos")
+		}
+		root.AddCommand(cmd)
+	}
+	return root
+}
+func todoParams(cmd *cobra.Command, args []string) (aitodo.Fields, error) {
+	bad := func(msg string) (aitodo.Fields, error) { return nil, errs.New(errs.CodeInvalidArgument, msg) }
+	p := aitodo.Fields{}
+	hasJSON := cmd.Flags().Changed("json-file")
+	if hasJSON {
+		for f := range todoFlags {
+			if cmd.Flags().Changed(f) {
+				return bad("--json-file cannot be combined with field flags")
+			}
+		}
+		if cmd.Flags().Changed("confirmed") {
+			return bad("--json-file cannot be combined with --confirmed")
+		}
+		var reader io.Reader
+		var file *os.File
+		if flagStr(cmd, "json-file") == "-" {
+			reader = cmd.InOrStdin()
+		} else {
+			var err error
+			file, err = os.Open(flagStr(cmd, "json-file"))
+			if err != nil {
+				return bad("Cannot read JSON file")
+			}
+			defer file.Close()
+			reader = file
+		}
+		dec := json.NewDecoder(io.LimitReader(reader, 1024*1024))
+		dec.UseNumber()
+		if dec.Decode(&p) != nil || p == nil {
+			return bad("Expected a JSON object")
+		}
+		var extra any
+		if dec.Decode(&extra) != io.EOF {
+			return bad("Expected exactly one JSON object")
+		}
+	} else {
+		for f, k := range todoFlags {
+			if !cmd.Flags().Changed(f) {
+				continue
+			}
+			s := flagStr(cmd, f)
+			switch k {
+			case "title", "keyword":
+				p[k] = s
+			case "isDone", "isFullDay":
+				if s == "true" {
+					p[k] = true
+				} else if s == "false" {
+					p[k] = false
+				} else if s == "null" && k == "isDone" {
+					p[k] = nil
+				} else {
+					return bad(f + " expects true or false (list is-done also accepts null)")
+				}
+			case "pageNo", "pageSize":
+				if s == "null" && k == "pageSize" {
+					p[k] = nil
+				} else {
+					n := json.Number(s)
+					if _, err := n.Int64(); err != nil {
+						return bad(f + " expects an integer")
+					}
+					p[k] = n
+				}
+			default:
+				if s == "null" {
+					p[k] = nil
+				} else {
+					n := json.Number(s)
+					if _, err := n.Int64(); err == nil {
+						p[k] = n
+					} else {
+						p[k] = s
+					}
+				}
+			}
+		}
+	}
+	action := cmd.Name()
+	if action == "get" || action == "update" {
+		if len(args) > 0 {
+			if id, exists := p["todoId"]; exists && id != args[0] {
+				return bad("Positional todoId differs from JSON todoId")
+			}
+			p["todoId"] = args[0]
+		}
+	}
+	if action == "delete" {
+		if hasJSON && len(args) > 0 {
+			return bad("Do not combine positional IDs with --json-file")
+		}
+		if !hasJSON {
+			p["todoIds"] = args
+			p["confirmed"] = flagBool(cmd, "confirmed")
+		}
+	}
+	if action == "create" && !hasJSON {
+		if _, exists := p["dueAt"]; !exists {
+			p["dueAt"] = nil
+		}
+		if _, exists := p["isFullDay"]; !exists {
+			p["isFullDay"] = false
+		}
+	}
+	return p, nil
+}
+func todoRun(ctx *clictx.Context, cmd *cobra.Command, args []string) (any, error) {
+	p, err := todoParams(cmd, args)
+	if err != nil {
+		return nil, err
+	}
+	key := ""
+	if cmd.Name() == "create" {
+		key = flagStr(cmd, "request-key")
+		if strings.TrimSpace(key) == "" {
+			if cmd.Flags().Changed("request-key") {
+				return nil, errs.New(errs.CodeInvalidArgument, "request-key must not be empty")
+			}
+			key, err = aitodo.NewRequestKey()
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	client := aitodo.Client{APIKey: creds.ResolveAPIKey().Value, Host: cloudHost(ctx)}
+	data, err := client.Execute(cmd.Context(), cmd.Name(), p, key)
+	if err != nil {
+		data = aitodo.Payload(err)
+	}
+	if key != "" {
+		data["requestKey"] = key
+	}
+	if data["ok"] == false {
+		exitCode = 1
+	}
+	return data, nil
+}

--- a/internal/cli/cmd_todo_test.go
+++ b/internal/cli/cmd_todo_test.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"github.com/YoooClaw/cli/internal/aitodo"
+	"strings"
+	"testing"
+)
+
+func TestTodoStructuredInputs(t *testing.T) {
+	for _, tc := range []struct {
+		argv  []string
+		stdin string
+		bad   bool
+	}{
+		{[]string{"update", "--json-file", "-"}, `{"todoId":"9007199254740993","dueAt":null,"isDone":false}`, false},
+		{[]string{"update", "1", "--json-file", "-"}, `{"todoId":"2","title":"x"}`, true},
+		{[]string{"create", "--json-file", "-", "--title", "x"}, `{}`, true},
+		{[]string{"create", "--json-file", "-"}, `null`, true},
+		{[]string{"create", "--json-file", "-"}, `{} {}`, true},
+		{[]string{"delete", "1", "--json-file", "-"}, `{"todoIds":["2"],"confirmed":true}`, true},
+		{[]string{"delete", "1", "--confirmed"}, ``, false},
+		{[]string{"list", "--is-done", "false", "--page-size", "20"}, ``, false},
+	} {
+		root := newTodoCmd()
+		cmd, args, e := root.Find(tc.argv)
+		if e != nil {
+			t.Fatal(e)
+		}
+		if e = cmd.ParseFlags(args); e != nil {
+			t.Fatal(e)
+		}
+		cmd.SetIn(strings.NewReader(tc.stdin))
+		p, e := todoParams(cmd, cmd.Flags().Args())
+		if (e != nil) != tc.bad {
+			t.Fatalf("%v: %v", tc.argv, e)
+		}
+		if e == nil {
+			if _, e = aitodo.Validate(cmd.Name(), p); e != nil {
+				t.Fatal(p, e)
+			}
+		}
+	}
+}
+func TestTodoCLIUndatedAndBoolean(t *testing.T) {
+	root := newTodoCmd()
+	cmd, args, _ := root.Find([]string{"create", "--title", "照片"})
+	cmd.ParseFlags(args)
+	p, e := todoParams(cmd, nil)
+	if e != nil || p["dueAt"] != nil || p["isFullDay"] != false {
+		t.Fatal(p, e)
+	}
+	root = newTodoCmd()
+	cmd, args, _ = root.Find([]string{"update", "1", "--is-done", "false"})
+	cmd.ParseFlags(args)
+	p, e = todoParams(cmd, cmd.Flags().Args())
+	if e != nil || p["isDone"] != false {
+		t.Fatal(p, e)
+	}
+	if _, exists := p["dueAt"]; exists {
+		t.Fatal("omitted time became clear")
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -41,6 +41,7 @@ func newRootCmd() *cobra.Command {
 		newMonitorCmd(),
 		newLightCmd(),
 		newLightruleCmd(),
+		newTodoCmd(),
 		newTunnelCmd(),
 		newGatewayCmd(),
 		newAPICmd(),

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -64,6 +64,7 @@ func TestList(t *testing.T) {
 		"yoooclaw-context-query",
 		"yoooclaw-light",
 		"yoooclaw-recordings-process",
+		"yoooclaw-todo",
 		"yoooclaw-tunnel-debug",
 	}
 	if !reflect.DeepEqual(names, want) {

--- a/skills/yoooclaw-todo/SKILL.md
+++ b/skills/yoooclaw-todo/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: yoooclaw-todo
+description: 使用 yoooclaw CLI 查询、创建、修改、完成、恢复和删除待办。普通待办和会议待办默认使用；用户明确指定飞书等其他平台作为操作目标时使用对应平台能力。
+---
+
+# 待办
+
+使用 `yoooclaw --format json todo`（别名 `yc`），要求包含 todo 命令的 CLI 0.11.0 或后续版本。无需 daemon。凭据和环境沿用本机配置，不把 API Key 传入参数或回复。用户指定 profile 时使用全局 `--profile`。
+
+## 选择操作
+
+- `todo list`：按下表解析独立请求；用户明确条件优先。追问沿用上文筛选，只改变用户指定的部分，不重新套用独立请求默认值。按名称定位且没有日期时不限时间。查询边界左闭右开，有时间范围不包含无时间事项；根据 isLastPage 翻页，条件改变时从第一页开始。
+- `todo get <todoId>`：详情；ID 必须来自已查询结果，始终作为字符串。
+- `todo create`：结合当前本地时间和上下文推断缺失信息，不补问、不二次确认；不要把用户明确的过去时间改到未来。
+- `todo update <todoId>`：只传修改字段，省略保留、null 清空。is-done=true 完成、false 恢复；目标或修改内容不清楚时先定位/澄清，不新建替代项。
+- `todo delete <todoIds...> --confirmed`：先核对并让用户确认具体目标，再传 confirmed；取消则停止。
+
+## 独立查询的四种默认范围
+
+| 用户表达 | 时间范围 | 完成状态 |
+| --- | --- | --- |
+| 看看待办／今天有什么要做／我有什么没完成的／我有什么要做的 | 今天 | `--is-done false` |
+| 明天有什么安排 | 明天 | `--is-done false` |
+| 查一下已完成的 | 今天 | `--is-done true` |
+| 查看全部待办 | 不限时间，不传时间边界 | `--is-done null` |
+
+今天、明天均按用户当前时区计算当天零点到次日零点，显式传 `--start-time` 和 `--end-time` 的带偏移 ISO。明确“全部未完成”时不限时间、`--is-done false`。这些是 Agent 的自然语言规则；CLI 裸命令默认值仍为不限时间的未完成，不能用空参数代替“今天”。
+
+## 时间与结构化输入
+
+时间是事项的**开始时间**。定时传带用户时区偏移的 ISO，例如 `2026-09-11T15:00:00+08:00`；全天传 `2026-09-11` 并设置 isFullDay=true；无时间传 JSON null、isFullDay=false。CLI 负责 UTC 转换。切换定时/全天时同时传 dueAt 和 isFullDay。
+
+所有命令支持 `--json-file <path>`；`--json-file -` 从 stdin 读 JSON 对象，不能和字段参数混用。通过 shell 传内容时使用带引号的 heredoc，防止用户文本被执行：
+
+```sh
+yoooclaw --format json todo create --json-file - <<'JSON'
+{"title":"会议","dueAt":"2026-09-11T15:00:00+08:00","isFullDay":false}
+JSON
+```
+
+日期仅为格式示例，执行时依据用户当前本地日期。无时间服务端若拒绝，报告实际错误，不擅自补时间。
+
+## 结果与重试
+
+同时检查退出码及 JSON 的 ok。仅成功后展示实际标题和开始时间，并提示“已添加到待办列表，可在 App 首页的待办卡片或列表中查看”。不新增跳转按钮、不重复成功提示。
+
+create 返回 requestKey。网络结果未知时先核对，必要时只用 `--request-key <原键>` 和相同参数重试；不能重新生成键创建。duplicated=true 是原请求重放。CLI 已处理一次传输重试，不无限循环。
+
+内容和完成状态可能分步成功：根据 contentUpdated、statusUpdated、unprocessedTodoIds 报告实际结果，仅处理失败部分。鉴权失败保留 code/message，不擅自归因为 App 登录失效；功能明确关闭时才提示去 App 开启。删除后不要引导查看已删除内容。


### PR DESCRIPTION
新增统一的云端待办命令，让 Agent 和其他项目通过同一套 CLI 查询、创建、修改及删除待办，复用当前环境和凭据，无需 daemon。

- 提供 `todo list/get/create/update/delete`，支持 JSON 输入；完成和恢复统一使用 `update` 的 `isDone` 字段。
- 开始时间接受当前时区的 ISO 字符串，由 CLI 转换成 UTC 时间戳；区分全天、无时间和省略字段。
- 创建支持幂等重试；内容与状态分步更新时返回实际成功部分；删除要求显式确认参数。
- 增加待办 Skill 和中英文说明，明确四种独立查询默认范围、追问继承条件及创建后的 App 查看入口。

验证：`go test ./internal/aitodo ./internal/cli ./internal/skills`、`go vet ./internal/aitodo ./internal/cli` 及差异格式检查通过。

目标分支：`release/0.11.0`。本 PR 不包含 Hermes 插件修改或本地构建产物。
