### PR TITLE
cli-0.11.0-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.10.2",
+  "version": "0.11.0-beta.0",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {


### PR DESCRIPTION
将 package.json 版本更新为 0.11.0-beta.0，并在该版本发布成功后同步回 release/0.11.0。验证：本地 go test ./...、go vet ./... 及发布分支 CI 均已通过。发布流水线：https://github.com/YoooClaw/cli/actions/runs/34473162444