### PR TITLE
cli-0.11.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.11.0-beta.0",
+  "version": "0.11.0-beta.1",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {


### PR DESCRIPTION
发布 `@yoooclaw/cli@0.11.0-beta.1`（tag `cli-v0.11.0-beta.1`，npm `beta` tag），将版本 bump 合回 `release/0.11.0`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)