### PR TITLE
[codex] 修复待办缺省时间并按格式推断全天标记

### DIFF
--- a/internal/aitodo/client_test.go
+++ b/internal/aitodo/client_test.go
@@ -196,3 +196,20 @@ func TestContentFailureStopsStatus(t *testing.T) {
 		t.Fatal(err, calls)
 	}
 }
+
+func TestTitleOnlyCreateDefaultsBeforeHTTP(t *testing.T) {
+	c, close := serve(t, func(path string, body Fields) (int, any) {
+		if path != APIPath+"/create" || !rawHas(body, "dueAt") || body["dueAt"] != nil || body["isFullDay"] != false {
+			t.Fatalf("unexpected request: %s %#v", path, body)
+		}
+		return 200, Fields{"todoId": "1309", "duplicated": false}
+	})
+	defer close()
+	input := Fields{"title": "洗衣服"}
+	if _, err := c.Execute(context.Background(), "create", input, "test-key"); err != nil {
+		t.Fatal(err)
+	}
+	if len(input) != 1 {
+		t.Fatal("input mutated")
+	}
+}

--- a/internal/aitodo/time.go
+++ b/internal/aitodo/time.go
@@ -104,6 +104,15 @@ func Validate(action string, raw Fields) (Fields, error) {
 		}
 		p[k] = v
 	}
+	if action == "create" {
+		if !rawHas(p, "dueAt") {
+			p["dueAt"] = nil
+		}
+	}
+	if (action == "create" || (action == "update" && rawHas(p, "dueAt"))) && !rawHas(p, "isFullDay") {
+		date, ok := p["dueAt"].(string)
+		p["isFullDay"] = ok && isoDate.MatchString(date)
+	}
 	for _, k := range []string{"dueAt", "startTime", "endTime"} {
 		if s, ok := p[k].(string); ok {
 			ms, e := isoMillis(s, k == "dueAt" && p["isFullDay"] == true)
@@ -133,9 +142,6 @@ func Validate(action string, raw Fields) (Fields, error) {
 			return nil, invalid("title must contain 1–30 characters")
 		}
 		p["title"] = s
-	}
-	if action == "create" && (!rawHas(p, "dueAt") || !rawHas(p, "isFullDay")) {
-		return nil, invalid("dueAt and isFullDay are required")
 	}
 	if v, exists := p["isFullDay"]; exists {
 		if _, ok := v.(bool); !ok {

--- a/internal/aitodo/time_test.go
+++ b/internal/aitodo/time_test.go
@@ -40,3 +40,38 @@ func TestValidation(t *testing.T) {
 		t.Fatal(p, e)
 	}
 }
+
+func TestInferMissingAllDay(t *testing.T) {
+	for _, action := range []string{"create", "update"} {
+		for _, tc := range []struct {
+			due  any
+			full bool
+		}{{"2026-09-12", true}, {"2026-09-12T00:00:00Z", false}, {nil, false}} {
+			input := Fields{"dueAt": tc.due}
+			if action == "create" {
+				input["title"] = "洗衣服"
+			} else {
+				input["todoId"] = "1"
+			}
+			out, err := Validate(action, input)
+			if err != nil || out["isFullDay"] != tc.full {
+				t.Fatalf("%s %#v: %#v %v", action, input, out, err)
+			}
+			if tc.due != nil && !sameNumber(out["dueAt"], int64(1789171200000)) {
+				t.Fatalf("wrong timestamp: %#v", out)
+			}
+		}
+	}
+	for _, due := range []string{"2026-02-30", "bad-date"} {
+		if _, err := Validate("create", Fields{"title": "x", "dueAt": due}); err == nil {
+			t.Fatal("accepted invalid date")
+		}
+	}
+	if _, err := Validate("create", Fields{"title": "x", "dueAt": "2026-09-12", "isFullDay": false}); err == nil {
+		t.Fatal("overrode explicit false")
+	}
+	out, err := Validate("update", Fields{"todoId": "1", "title": "x"})
+	if err != nil || rawHas(out, "dueAt") || rawHas(out, "isFullDay") {
+		t.Fatal("changed omitted update time")
+	}
+}


### PR DESCRIPTION
模型创建待办时只传标题会因缺少时间字段而失败；传纯日期但漏传全天标记也会被当作具体时间解析失败。

本次在运行时增加兜底：创建缺少 dueAt 时补 null；缺少 isFullDay 时，纯日期 YYYY-MM-DD 推断为 true，具体时间或 null 推断为 false。更新仅在传入 dueAt 时推断缺省标记，不传时间的更新保留原值。显式标记不被覆盖，无效日期继续由时间校验拒绝。

CLI 在公共参数处理层补齐字段，flags 与 JSON 创建入口共享该逻辑；不修改服务端接口。

## 验证

go test ./internal/aitodo ./internal/cli 通过，含模拟 HTTP 验证只传标题的创建请求。
测试使用模拟响应，未创建或删除真实待办。
