### PR TITLE
cli-0.11.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoooclaw/cli",
-  "version": "0.11.0-beta.1",
+  "version": "0.11.0-beta.2",
   "private": true,
   "description": "yoooclaw 独立 CLI（Go 实现）：本地守护进程接收手机通知、Relay 隧道、灯效规则评估，Agent-Native",
   "scripts": {


### PR DESCRIPTION
版本 bump：`0.11.0-beta.1` → `0.11.0-beta.2`（仅 package.json 1 行 diff）。

tag `cli-v0.11.0-beta.2` 已推送，发布 workflow 已触发；本 PR 仅为把版本号同步回 `release/0.11.0`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)